### PR TITLE
Parameter store for secrets

### DIFF
--- a/_sub/compute/eks-heptio/configmap.tf
+++ b/_sub/compute/eks-heptio/configmap.tf
@@ -49,3 +49,10 @@ data:
         - system:nodes
 CONFIGMAPAWSAUTH
 }
+
+resource "aws_ssm_parameter" "kubeconfig" {
+  name        = "/eks/${var.cluster_name}/admin"
+  description = "The initial config file for eks ${var.cluster_name}"
+  type        = "SecureString"
+  value       = "${local.kubeconfig}"
+}

--- a/_sub/compute/k8s-service-account/get-token.sh
+++ b/_sub/compute/k8s-service-account/get-token.sh
@@ -4,17 +4,17 @@ set -e
 eval "$(jq -r '@sh "CLUSTER_NAME=\(.cluster_name) DEFAULT_SECRET_NAME=\(.default_secret_name)"')"
 
 # get token for sa
-token=$(kubectl -n kube-system get secret $DEFAULT_SECRET_NAME -o json | jq '.data.token' | tr -d '"' | base64 --decode)
+token=$(kubectl --kubeconfig ~/.kube/config_$CLUSTER_NAME -n kube-system get secret $DEFAULT_SECRET_NAME -o json | jq '.data.token' | tr -d '"' | base64 --decode)
 
 # get current context
-context=`kubectl config current-context`
+context=`kubectl --kubeconfig ~/.kube/config_$CLUSTER_NAME config current-context`
 
 # get cluster name of context
-name=`kubectl config get-contexts $context | awk '{print $3}' | tail -n 1`
+name=`kubectl --kubeconfig ~/.kube/config_$CLUSTER_NAME config get-contexts $context | awk '{print $3}' | tail -n 1`
 
 # get endpoint of current context 
-endpoint=`kubectl config view -o jsonpath="{.clusters[?(@.name == \"$name\")].cluster.server}"`
-certificate=`kubectl config view --raw -o jsonpath="{.clusters[?(@.name == \"$name\")].cluster.certificate-authority-data}"`
+endpoint=`kubectl --kubeconfig ~/.kube/config_$CLUSTER_NAME config view -o jsonpath="{.clusters[?(@.name == \"$name\")].cluster.server}"`
+certificate=`kubectl --kubeconfig ~/.kube/config_$CLUSTER_NAME config view --raw -o jsonpath="{.clusters[?(@.name == \"$name\")].cluster.certificate-authority-data}"`
 
 # generate kubeconfig
 kubeconfig=$(cat <<KUBECONFIG

--- a/_sub/compute/k8s-service-account/get-token.sh
+++ b/_sub/compute/k8s-service-account/get-token.sh
@@ -1,0 +1,43 @@
+# Exit if any of the intermediate steps fail
+set -e
+
+eval "$(jq -r '@sh "CLUSTER_NAME=\(.cluster_name) DEFAULT_SECRET_NAME=\(.default_secret_name)"')"
+
+# get token for sa
+token=$(kubectl -n kube-system get secret $DEFAULT_SECRET_NAME -o json | jq '.data.token' | tr -d '"' | base64 --decode)
+
+# get current context
+context=`kubectl config current-context`
+
+# get cluster name of context
+name=`kubectl config get-contexts $context | awk '{print $3}' | tail -n 1`
+
+# get endpoint of current context 
+endpoint=`kubectl config view -o jsonpath="{.clusters[?(@.name == \"$name\")].cluster.server}"`
+certificate=`kubectl config view --raw -o jsonpath="{.clusters[?(@.name == \"$name\")].cluster.certificate-authority-data}"`
+
+# generate kubeconfig
+kubeconfig=$(cat <<KUBECONFIG
+apiVersion: v1
+clusters:
+- cluster:
+    server: $endpoint
+    certificate-authority-data: $certificate
+  name: $CLUSTER_NAME
+contexts:
+- context:
+    cluster: $CLUSTER_NAME
+    user: deploy-user
+  name: aws
+current-context: aws
+kind: Config
+preferences: {}
+users:
+- name: deploy-user
+  user:
+    token: $token
+KUBECONFIG
+)
+
+# return kubeconfig in json format
+jq -n --arg kubeconfig_json "$kubeconfig" '{"kubeconfig_json": $kubeconfig_json}'

--- a/_sub/compute/k8s-service-account/vars.tf
+++ b/_sub/compute/k8s-service-account/vars.tf
@@ -1,0 +1,1 @@
+variable "cluster_name" {}

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -1,3 +1,14 @@
+provider "aws" {
+
+  region = "${var.aws_region}"
+
+  version = "~> 1.40"
+
+  assume_role {
+    role_arn = "${var.assume_role_arn}"
+  }
+}
+
 provider "kubernetes" {
   config_path = "${pathexpand("~/.kube/config_${var.cluster_name}")}"
 }
@@ -15,6 +26,7 @@ module "k8s_traefik" {
 
 module "k8s_service_account" {
   source       = "../../_sub/compute/k8s-service-account"
+  cluster_name         = "${var.cluster_name}" 
 }
 
 module "k8s_flux" {

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -48,3 +48,7 @@ variable "docker_registry_password" {
 variable "docker_registry_email" {
   description = "Email address for the user that enables Flux to read the docker registry information."
 }
+
+variable "assume_role_arn" {
+  type = "string"
+}


### PR DESCRIPTION
Added the possibility to store kubeconfig files directly in aws parameter store. If this is merged prime needs to be updated to include an assume_role_arn for the service tfvars file to get permissions for parameter store.