### PR TITLE
Added assume_role option for applying blaster configmap

### DIFF
--- a/_sub/compute/k8s-blaster-configmap/apply_blaster_configmap.sh
+++ b/_sub/compute/k8s-blaster-configmap/apply_blaster_configmap.sh
@@ -8,14 +8,48 @@ KUBE_CONFIG_PATH=$1
 CONFIGMAP_PATH_S3=$2
 
 
+# Generate AWS CLI config files, if 
+if [ -n "$3" ]; then
+    AWS_ASSUME_ARN=$3
+    AWS_ASSUMED_CREDS=( $(aws sts assume-role \
+        --role-arn "$AWS_ASSUME_ARN" \
+        --role-session-name "ApplyBlasterConfigmap" \
+        --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
+        --output text
+    ) )
+    AWS_ASSUMED_ACCESS_KEY_ID=${AWS_ASSUMED_CREDS[0]}
+    AWS_ASSUMED_SECRET_ACCESS_KEY=${AWS_ASSUMED_CREDS[1]}
+    AWS_ASSUMED_SESSION_TOKEN=${AWS_ASSUMED_CREDS[2]}    
+fi
+
+
 # Determine if key file exists in S3
-aws s3 ls $CONFIGMAP_PATH_S3 >/dev/null && APPLY_CONFIGMAP=1
+if [ -n "$AWS_ASSUME_ARN" ]; then
+    AWS_ACCESS_KEY_ID=${AWS_ASSUMED_ACCESS_KEY_ID} \
+    AWS_SECRET_ACCESS_KEY=${AWS_ASSUMED_SECRET_ACCESS_KEY} \
+    AWS_SESSION_TOKEN=${AWS_ASSUMED_SESSION_TOKEN} \
+    aws s3 ls $CONFIGMAP_PATH_S3 >/dev/null && APPLY_CONFIGMAP=1
+else
+    aws s3 ls $CONFIGMAP_PATH_S3 >/dev/null && APPLY_CONFIGMAP=1
+fi
 
 
 # Create new key
 if [ $APPLY_CONFIGMAP -eq 1 ]; then
+
     echo "Applying configmap from $CONFIGMAP_PATH_S3"
-    aws s3 cp $CONFIGMAP_PATH_S3 - | kubectl -f -
+
+    if [ -n "$AWS_ASSUME_ARN" ]; then
+        AWS_ACCESS_KEY_ID=${AWS_ASSUMED_ACCESS_KEY_ID} \
+        AWS_SECRET_ACCESS_KEY=${AWS_ASSUMED_SECRET_ACCESS_KEY} \
+        AWS_SESSION_TOKEN=${AWS_ASSUMED_SESSION_TOKEN} \
+        aws s3 cp $CONFIGMAP_PATH_S3 - | kubectl -f -
+    else
+        aws s3 cp $CONFIGMAP_PATH_S3 - | kubectl -f -
+    fi
+
 else
-    echo "No configmap found at $CONFIGMAP_PATH_S3"
+
+    echo "No configmap found at $CONFIGMAP_PATH_S3 or permission denied"
+
 fi

--- a/_sub/compute/k8s-blaster-configmap/main.tf
+++ b/_sub/compute/k8s-blaster-configmap/main.tf
@@ -6,7 +6,7 @@ resource "null_resource" "apply_blaster_configmap" {
     }
 
     provisioner "local-exec" {
-         command = "${path.module}/apply_blaster_configmap.sh ${pathexpand("~/.kube/config_${var.cluster_name}")} s3://${var.s3_bucket}/configmap_${var.cluster_name}_blaster.yml"
+         command = "${path.module}/apply_blaster_configmap.sh ${pathexpand("~/.kube/config_${var.cluster_name}")} s3://${var.s3_bucket}/configmap_${var.cluster_name}_blaster.yml ${var.assume_role_arn}"
     }
 
 }

--- a/_sub/compute/k8s-blaster-configmap/vars.tf
+++ b/_sub/compute/k8s-blaster-configmap/vars.tf
@@ -4,3 +4,7 @@ variable "cluster_name" {
 
 variable "s3_bucket" {
 }
+
+variable "assume_role_arn" {
+    default = ""
+}

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -46,9 +46,10 @@ module "eks_heptio" {
 }
 
 module "apply_blaster_configmap" {
-  source       = "../../_sub/compute/k8s-blaster-configmap"
-  cluster_name = "${module.eks_heptio.cluster_name}"
-  s3_bucket    = "${var.blaster_configmap_bucket}"
+  source          = "../../_sub/compute/k8s-blaster-configmap"
+  cluster_name    = "${module.eks_heptio.cluster_name}"
+  s3_bucket       = "${var.blaster_configmap_bucket}"
+  assume_role_arn = "${var.assume_role_arn}"
 }
 
 module "eks_alb" {
@@ -112,7 +113,7 @@ module "eks_kiam" {
   source              = "../../_sub/compute/eks-kiam"
   cluster_name        = "${var.cluster_name}"
   workload_account_id = "${var.workload_account_id}"
-  worker_role_id     = "${module.eks_workers.worker_role_id}"
+  worker_role_id      = "${module.eks_workers.worker_role_id}"
 }
 
 module "eks_servicebroker" {


### PR DESCRIPTION
Problem with applying configmap from Blaster, seems to be due to AWS CLI runnning with AWS credentials supplied in the pipeline, not the role on the workload account it needs to assume.

Added option to shell script to assume role, and passing the role ARN to the TF module.