### PR TITLE
update prometheus annotations

### DIFF
--- a/_sub/compute/k8s-traefik/main.tf
+++ b/_sub/compute/k8s-traefik/main.tf
@@ -79,8 +79,8 @@ resource "kubernetes_service" "traefik" {
     name      = "${var.deploy_name}-ingress-service"
     namespace = "kube-system"
     annotations {
-      "prometheus.io/port" = "'8080'"
-      "prometheus.io/scrape" = "'true'"
+      "prometheus.io/port" = "8080"
+      "prometheus.io/scrape" = "true"
     }
   }
 


### PR DESCRIPTION
The current annotations on the traefik service yield the following after being applied:

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    prometheus.io/port: '''8080'''
    prometheus.io/scrape: '''true'''
   ...
```

Prometheus is not able to scrape the triple apostrophes (`'''`) for `promtheus.io/port` and `prometheus.io/scrape`.

