### PR TITLE
Ended heredoc of EOF correctly on new line

### DIFF
--- a/_sub/misc/kafka-message/main.tf
+++ b/_sub/misc/kafka-message/main.tf
@@ -1,6 +1,7 @@
 locals {
   message = <<EOF
-{"version":"${var.message_version}","eventName":"${var.event_name}","x-correlationId":"${var.correlation_id}","x-sender":"${var.sender}","payload":${var.payload}}EOF
+{"version":"${var.message_version}","eventName":"${var.event_name}","x-correlationId":"${var.correlation_id}","x-sender":"${var.sender}","payload":${var.payload}}
+EOF
 }
 
 resource "null_resource" "message" {

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -131,7 +131,8 @@ provider "aws" {
 
   locals {
     account_created_payload = <<EOF
-  {"contextId":"${var.context_id}","accountId":"${module.org_account.id}","roleArn":"${module.iam_role_capability.arn}","roleEmail":"${module.org_account.email}","capabilityRootId":"${var.capability_root_id}","capabilityName":"${var.capability_name}","contextName":"${var.context_name}","capabilityId":"${var.capability_id}"}EOF
+  {"contextId":"${var.context_id}","accountId":"${module.org_account.id}","roleArn":"${module.iam_role_capability.arn}","roleEmail":"${module.org_account.email}","capabilityRootId":"${var.capability_root_id}","capabilityName":"${var.capability_name}","contextName":"${var.context_name}","capabilityId":"${var.capability_id}"}
+  EOF
   }
 
   module "kafka_produce_account_created" {


### PR DESCRIPTION
I believe the heredoc had a wrongful ending by being on the same line as the context text.

If it was intended that way, please decline this.