### PR TITLE
Unsubscribe all accounts from AWS spam

### DIFF
--- a/_sub/security/org-account/main.tf
+++ b/_sub/security/org-account/main.tf
@@ -12,6 +12,8 @@ resource "aws_organizations_account" "org_account" {
 
 resource "null_resource" "ubsubscribe_spam" {
 
+  depends_on = ["aws_organizations_account.org_account"]
+
   provisioner "local-exec" {
     command = "curl -v 'https://pages.awscloud.com/index.php/leadCapture/save2' --data 'Email=${replace(var.email, "@", "%40")}&preferenceCenterCategory=no&preferenceCenterGettingStarted=no&preferenceCenterOnlineInPersonEvents=no&preferenceCenterMonthlyAWSNewsletter=no&preferenceCenterTrainingandBestPracticeContent=no&preferenceCenterProductandServiceAnnoucements=no&preferenceCenterSurveys=no&PreferenceCenter_AWS_Partner_Events_Co__c=no&preferenceCenterOtherAWSCommunications=no&formVid=19260'"
   }

--- a/_sub/security/org-account/main.tf
+++ b/_sub/security/org-account/main.tf
@@ -9,3 +9,10 @@ resource "aws_organizations_account" "org_account" {
     command = "sleep ${var.sleep_after}"
   }
 }
+
+resource "null_resource" "ubsubscribe_spam" {
+
+  provisioner "local-exec" {
+    command = "curl -v 'https://pages.awscloud.com/index.php/leadCapture/save2' --data 'Email=${replace(var.email, "@", "%40")}&preferenceCenterCategory=no&preferenceCenterGettingStarted=no&preferenceCenterOnlineInPersonEvents=no&preferenceCenterMonthlyAWSNewsletter=no&preferenceCenterTrainingandBestPracticeContent=no&preferenceCenterProductandServiceAnnoucements=no&preferenceCenterSurveys=no&PreferenceCenter_AWS_Partner_Events_Co__c=no&preferenceCenterOtherAWSCommunications=no&formVid=19260'"
+  }
+}


### PR DESCRIPTION
I'm tired of AWS spam in our shared mailbox.

This should be the `curl` command to opt-out of all and will be run after each account has been setup.

In this setup, it will run the command every time the module is used with a Terraform `apply` action. However, the endpoint uses to unsubscribe may not be as resilient as the AWS API we normally use, so this could theoretical make the module more fragile.

Once we're reasonably certain that we have unsubscribed from all accounts, we might consider moving the command to the "local-exec" block within the "aws_organizations_account" resource - this will cause it to only fire when creating accounts.

After merge, we should publish a new release and update `pre-prime`, `prime` and `aws-account-manifests` to use it.