### PR TITLE
EKS: More specific VPC CNI reference, to avoid buggy AWS CNI

### DIFF
--- a/_sub/compute/eks-addons/dependencies.tf
+++ b/_sub/compute/eks-addons/dependencies.tf
@@ -15,10 +15,10 @@ locals {
         "1.14", "1.3.1"
     )}"
     vpccni_version_map = "${map(
-        "1.11", "1.5",
-        "1.12", "1.5",
-        "1.13", "1.5",
-        "1.14", "1.5"
+        "1.11", "1.5.3",
+        "1.12", "1.5.3",
+        "1.13", "1.5.3",
+        "1.14", "1.5.3"
     )}"
 }
 
@@ -28,4 +28,6 @@ locals {
     kubeproxy_version = "${local.kubeproxy_version_map[var.cluster_version]}"
     coredns_version = "${local.coredns_version_map[var.cluster_version]}"
     vpccni_version = "${local.vpccni_version_map[var.cluster_version]}"
+    vpccni_minorversion = "${join(".", slice(split(".", local.vpccni_version), 0, 2))}"
+
 }

--- a/_sub/compute/eks-addons/main.tf
+++ b/_sub/compute/eks-addons/main.tf
@@ -22,7 +22,7 @@ resource "null_resource" "coredns" {
 
 resource "null_resource" "vpccni" {
   provisioner "local-exec" {
-    command = "kubectl --kubeconfig ${var.kubeconfig_path} apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-${local.vpccni_version}/config/v${local.vpccni_version}/aws-k8s-cni.yaml"
+    command = "kubectl --kubeconfig ${var.kubeconfig_path} apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-${local.vpccni_version}/config/v${local.vpccni_minorversion}/aws-k8s-cni.yaml"
   }
 
   triggers {


### PR DESCRIPTION
Previous implementation did not allow for specifying patch version of CNI, which presented a problem: https://github.com/aws/amazon-vpc-cni-k8s/issues/641.

Now:
- Able to specify x.y.z version
- Recommended VPC CNI version changed to 1.5.3