### PR TITLE
Added describe for dynamo to eudeny rule

### DIFF
--- a/security/org-capability-root/dependencies.tf
+++ b/security/org-capability-root/dependencies.tf
@@ -22,7 +22,8 @@ locals {
                 "route53:*",
                 "support:*",
                 "waf:*",
-				"s3:List*"
+		"s3:List*",
+		"dynamoDB:DescribeTable"
             ],
             "Resource": "*",
             "Condition": {


### PR DESCRIPTION
Some users are trying to use dynamodb via kiam but failing at describe. It seems to be a global command which is currently blocked by our EU policy