### PR TITLE
Revert "Removed obsolete ecr-repo, because it is unused"

### DIFF
--- a/compute/ecr-repo/main.tf
+++ b/compute/ecr-repo/main.tf
@@ -1,0 +1,45 @@
+# --------------------------------------------------
+# Init
+# --------------------------------------------------
+
+terraform {
+  backend          "s3"             {}
+  required_version = "~> 0.11.7"
+}
+
+provider "aws" {
+  region  = "${var.aws_region}"
+  version = "~> 2.21.0"
+}
+
+# --------------------------------------------------
+# ECR repo and policy
+# --------------------------------------------------
+
+resource "aws_ecr_repository" "repo" {
+  name  = "${var.name}"
+}
+
+resource "aws_ecr_repository_policy" "pol" {
+  repository = "${aws_ecr_repository.repo.name}"
+
+  policy = <<EOF
+{
+    "Version": "2008-10-17",
+    "Statement": [
+        {
+            "Sid": "Allow pull from AWS IAM principals",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": ${jsonencode(var.pull_principals)}
+            },
+            "Action": [
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage",
+                "ecr:BatchCheckLayerAvailability"
+            ]
+        }
+    ]
+}
+EOF
+}

--- a/compute/ecr-repo/outputs.tf
+++ b/compute/ecr-repo/outputs.tf
@@ -1,0 +1,3 @@
+output "registry_id" {
+  value = "${aws_ecr_repository.repo.registry_id}"
+}

--- a/compute/ecr-repo/vars.tf
+++ b/compute/ecr-repo/vars.tf
@@ -1,0 +1,14 @@
+variable "aws_region" {
+  type = "string"
+}
+
+variable "name" {
+  description = "The name of the ECR repo to create"
+  type        = "string"
+}
+
+variable "pull_principals" {
+  description = "A list of AWS IAM principals that should be allowed to pull images from this repo"
+  type    = "list"
+  default = []
+}


### PR DESCRIPTION
Reverts dfds/infrastructure-modules#79

Used for team self-service ECR and https://github.com/dfds/harald/blob/master/build/ecr-harald-repo/terraform.tfvars