### PR TITLE
EKS: Two node groups, node taints and labels [ch1238] (#77)

### DIFF
--- a/_sub/compute/eks-nodegroup-unmanaged/outputs.tf
+++ b/_sub/compute/eks-nodegroup-unmanaged/outputs.tf
@@ -1,4 +1,4 @@
 output "autoscaling_group_id" {
-  value = aws_autoscaling_group.eks.id
+  value = element(concat(aws_autoscaling_group.eks.*.id, [""]), 0)
 }
 

--- a/_sub/compute/eks-nodegroup-unmanaged/vars.tf
+++ b/_sub/compute/eks-nodegroup-unmanaged/vars.tf
@@ -23,9 +23,11 @@ variable "security_groups" {
 }
 
 variable "scaling_config_min_size" {
+  default = 0
 }
 
 variable "scaling_config_max_size" {
+  default = 0
 }
 
 variable "subnet_ids" {
@@ -36,7 +38,8 @@ variable "disk_size" {
 }
 
 variable "instance_types" {
-  type = list(string)
+  type    = list(string)
+  default = []
 }
 
 variable "ec2_ssh_key" {
@@ -65,3 +68,7 @@ variable "cloudwatch_agent_enabled" {
 variable "worker_inotify_max_user_watches" {
 }
 
+variable "kubelet_extra_args" {
+  type    = string
+  default = ""
+}

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -93,12 +93,25 @@ module "eks_workers_route_table_assoc" {
   route_table_id = module.eks_route_table.id
 }
 
+# Misleading - is actually for all node groups. Might even not need both this, and eks_workers_route_table_assoc?
+module "eks_nodegroup1_route_table_assoc" {
+  source = "../../_sub/network/route-table-assoc"
+
+  # count          = "${length(var.eks_worker_subnets)}"       # need to pass count explicitly, otherwise: value of 'count' cannot be computed
+  subnet_ids     = module.eks_workers_subnet.subnet_ids
+  route_table_id = module.eks_route_table.id
+}
+
 /*
 TO DO:
 Move worker/node IAM role (currently in workers) to separate sub
 Feature toggle nodegroups
  - Test 0, 1, more-subnets-than-AZs
 */
+
+# --------------------------------------------------
+# NODE GROUP 1
+# --------------------------------------------------
 
 module "eks_nodegroup1_workers" {
   source = "../../_sub/compute/eks-nodegroup-unmanaged"
@@ -118,6 +131,8 @@ module "eks_nodegroup1_workers" {
   instance_types          = var.eks_nodegroup1_instance_types
   ec2_ssh_key             = module.eks_workers_keypair.key_name
 
+  kubelet_extra_args = var.eks_nodegroup1_kubelet_extra_args
+
   cloudwatch_agent_config_bucket  = var.eks_worker_cloudwatch_agent_config_deploy ? module.cloudwatch_agent_config_bucket.bucket_name : "none"
   cloudwatch_agent_config_file    = var.eks_worker_cloudwatch_agent_config_file
   cloudwatch_agent_enabled        = var.eks_worker_cloudwatch_agent_config_deploy
@@ -127,13 +142,44 @@ module "eks_nodegroup1_workers" {
   autoscale_security_group        = module.eks_cluster.autoscale_security_group
 }
 
-module "eks_nodegroup1_route_table_assoc" {
-  source = "../../_sub/network/route-table-assoc"
 
-  # count          = "${length(var.eks_worker_subnets)}"       # need to pass count explicitly, otherwise: value of 'count' cannot be computed
-  subnet_ids     = module.eks_workers_subnet.subnet_ids
-  route_table_id = module.eks_route_table.id
+# --------------------------------------------------
+# NODE GROUP 2
+# --------------------------------------------------
+
+module "eks_nodegroup2_workers" {
+  source = "../../_sub/compute/eks-nodegroup-unmanaged"
+
+  # deploy                          = "${signum(length(var.eks_nodegroup1_subnets))}"
+  cluster_name    = var.eks_cluster_name
+  cluster_version = var.eks_cluster_version
+  nodegroup_name  = "ng2"
+
+  # node_role_arn           = "${module.eks_workers_iam_role.arn}"
+  iam_instance_profile    = module.eks_workers.iam_instance_profile_name
+  security_groups         = [module.eks_workers_security_group.id]
+  scaling_config_min_size = var.eks_nodegroup2_instance_min_count
+  scaling_config_max_size = var.eks_nodegroup2_instance_max_count
+  subnet_ids              = module.eks_workers_subnet.subnet_ids
+  disk_size               = var.eks_worker_instance_storage_size
+  instance_types          = var.eks_nodegroup2_instance_types
+  ec2_ssh_key             = module.eks_workers_keypair.key_name
+
+  kubelet_extra_args = var.eks_nodegroup2_kubelet_extra_args
+
+  cloudwatch_agent_config_bucket  = var.eks_worker_cloudwatch_agent_config_deploy ? module.cloudwatch_agent_config_bucket.bucket_name : "none"
+  cloudwatch_agent_config_file    = var.eks_worker_cloudwatch_agent_config_file
+  cloudwatch_agent_enabled        = var.eks_worker_cloudwatch_agent_config_deploy
+  eks_endpoint                    = module.eks_cluster.eks_endpoint
+  eks_certificate_authority       = module.eks_cluster.eks_certificate_authority
+  worker_inotify_max_user_watches = var.eks_worker_inotify_max_user_watches
+  autoscale_security_group        = module.eks_cluster.autoscale_security_group
 }
+
+
+# --------------------------------------------------
+# OTHER
+# --------------------------------------------------
 
 module "blaster_configmap_bucket" {
   source    = "../../_sub/storage/s3-bucket"
@@ -191,4 +237,3 @@ module "cloudwatch_agent_config_bucket" {
   deploy    = var.eks_worker_cloudwatch_agent_config_deploy
   s3_bucket = "${var.eks_cluster_name}-cl-agent-config"
 }
-

--- a/compute/eks-ec2/outputs.tf
+++ b/compute/eks-ec2/outputs.tf
@@ -30,6 +30,7 @@ output "eks_worker_autoscaling_group_ids" {
   value = [
     module.eks_workers.autoscaling_group_id,
     module.eks_nodegroup1_workers.autoscaling_group_id,
+    module.eks_nodegroup2_workers.autoscaling_group_id,
   ]
 }
 

--- a/compute/eks-ec2/vars.tf
+++ b/compute/eks-ec2/vars.tf
@@ -126,11 +126,38 @@ variable "eks_nodegroup1_instance_types" {
   default = []
 }
 
+variable "eks_nodegroup1_kubelet_extra_args" {
+  type    = string
+  default = ""
+}
+
 variable "eks_nodegroup1_instance_min_count" {
   default = 0
 }
 
 variable "eks_nodegroup1_instance_max_count" {
+  default = 0
+}
+
+# --------------------------------------------------
+# EKS Nodegroup 2
+# --------------------------------------------------
+
+variable "eks_nodegroup2_instance_types" {
+  type    = list(string)
+  default = []
+}
+
+variable "eks_nodegroup2_kubelet_extra_args" {
+  type    = string
+  default = ""
+}
+
+variable "eks_nodegroup2_instance_min_count" {
+  default = 0
+}
+
+variable "eks_nodegroup2_instance_max_count" {
   default = 0
 }
 


### PR DESCRIPTION
* - Support for two node groups
- Allow passing kubelet_extra_args to ASG user data script (e.g. set node taints and labels)

* Minor change to test and link store [branch ch1238]

* Fixed issue where NG2 vars were required [ch1238]

Co-authored-by: janwiberg-dfds <44774288+janwiberg-dfds@users.noreply.github.com>