### PR TITLE
Changed bucket name from 13 to 15

### DIFF
--- a/test/integration/eu-west-1/k8s-qa15/cluster/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa15/cluster/terragrunt.hcl
@@ -47,7 +47,7 @@ inputs = {
   # --------------------------------------------------
 
   blaster_configmap_deploy = true
-  blaster_configmap_bucket = "dfds-qa13-k8s-configmap"
+  blaster_configmap_bucket = "dfds-qa15-k8s-configmap"
 
   # --------------------------------------------------
   # Cloudwatch agent


### PR DESCRIPTION
The config map bucket was named after the previous 13 version but should be updated to reflect the new 15