### PR TITLE
EKS log types and retention exposed as vars [ch1724]

### DIFF
--- a/_sub/compute/eks-cluster/eks.tf
+++ b/_sub/compute/eks-cluster/eks.tf
@@ -1,11 +1,14 @@
+resource "aws_cloudwatch_log_group" "eks" {
+  name              = "/aws/eks/${var.cluster_name}/cluster"
+  retention_in_days = var.log_retention_days
+}
+
 resource "aws_eks_cluster" "eks" {
   name     = var.cluster_name
   role_arn = aws_iam_role.eks.arn
   version  = var.cluster_version
 
-  enabled_cluster_log_types = ["api", "audit", "authenticator"]
-
-  #enabled_cluster_log_types = ["api", "audit", "authenticator","controllerManager","scheduler"]
+  enabled_cluster_log_types = var.log_types
 
   vpc_config {
     security_group_ids = [aws_security_group.eks-cluster.id]

--- a/_sub/compute/eks-cluster/vars.tf
+++ b/_sub/compute/eks-cluster/vars.tf
@@ -9,3 +9,14 @@ variable "cluster_version" {
 variable "cluster_zones" {
 }
 
+variable "log_types" {
+  type = list(string)
+  description = "A list of the desired control plane logging to enable: api, audit, authenticator, controllerManager, scheduler. See also https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html."
+  default = []
+}
+
+variable "log_retention_days" {
+  type = number
+  description = "Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653."
+  default = 90
+}

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -26,10 +26,12 @@ provider "kubernetes" {
 # --------------------------------------------------
 
 module "eks_cluster" {
-  source          = "../../_sub/compute/eks-cluster"
-  cluster_name    = var.eks_cluster_name
-  cluster_version = var.eks_cluster_version
-  cluster_zones   = var.eks_cluster_zones
+  source             = "../../_sub/compute/eks-cluster"
+  cluster_name       = var.eks_cluster_name
+  cluster_version    = var.eks_cluster_version
+  cluster_zones      = var.eks_cluster_zones
+  log_types          = var.eks_cluster_log_types
+  log_retention_days = var.eks_cluster_log_retention_days
 }
 
 module "eks_internet_gateway" {

--- a/compute/eks-ec2/vars.tf
+++ b/compute/eks-ec2/vars.tf
@@ -61,6 +61,18 @@ variable "eks_cluster_zones" {
   default = 2 # Set to the number of AZs Hellman currently uses, to reduce risk of destroying/recreating cluster, until a better solution is in place
 }
 
+variable "eks_cluster_log_types" {
+  type = list(string)
+  description = "A list of the desired control plane logging to enable: api, audit, authenticator, controllerManager, scheduler. See also https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html."
+  default = ["api", "audit", "authenticator"]
+}
+
+variable "eks_cluster_log_retention_days" {
+  type = number
+  description = "Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653."
+  default = 90 
+}
+
 variable "eks_worker_instance_type" {
   type = string
 }


### PR DESCRIPTION
CloudWatch log group, previously created implicitly by enabling EKS logging, is now explicitly created.

This has enabled specifying log retention, which, along with log types, have now been exposed as variables.