### PR TITLE
Update db minor version from 10.9 to recommended minor version 10.11

### DIFF
--- a/_sub/database/postgres/main.tf
+++ b/_sub/database/postgres/main.tf
@@ -38,7 +38,7 @@ resource "aws_db_parameter_group" "dbparams" {
 #Restore the postgres database with the pre-configured settings
 resource "aws_db_instance" "postgres" {
   engine                  = "postgres"
-  engine_version          = "10.9"
+  engine_version          = "10.11"
   publicly_accessible     = "true"
   backup_retention_period = 10
   apply_immediately       = true


### PR DESCRIPTION
As we're currently using the default setting on `auto_minor_version_upgrade` (which is `true`), a provisioned db could update it's minor version during the weekly maintenance window. This will break any scripts because the version is hard-coded in the terraform template. This is a short-term fix for our databases but we should probably make both `auto_minor_version_upgrade` and `engine_version` configurable. The currently recommended major postgres version on RDS is 11.x, so one could argue that that should be the default in this template as well.