### PR TITLE
EKS: Separate ASG per AZ [ch1136]

### DIFF
--- a/_sub/compute/eks-nodegroup-unmanaged/dependencies.tf
+++ b/_sub/compute/eks-nodegroup-unmanaged/dependencies.tf
@@ -1,0 +1,29 @@
+data "aws_ami" "eks-node" {
+  filter {
+    name   = "name"
+    values = ["amazon-eks-node-${var.cluster_version}-*"]
+  }
+
+  most_recent = true
+  owners      = ["602401143452"] # Amazon Account ID
+}
+
+data "aws_ami" "eks-gpu-node" {
+  filter {
+    name   = "name"
+    values = ["amazon-eks-gpu-node-${var.cluster_version}-*"]
+  }
+
+  most_recent = true
+  owners      = ["602401143452"] # Amazon Account ID
+}
+
+locals {
+  # Use GPU AMI if 'gpu_ami' is true
+  node_ami = var.gpu_ami ? data.aws_ami.eks-gpu-node.id : data.aws_ami.eks-node.id
+}
+
+data "aws_subnet" "subnet" {
+  count = length(var.subnet_ids)
+  id    = var.subnet_ids[count.index]
+}

--- a/_sub/compute/eks-nodegroup-unmanaged/main.tf
+++ b/_sub/compute/eks-nodegroup-unmanaged/main.tf
@@ -71,8 +71,6 @@ resource "aws_placement_group" "cluster" {
 }
 
 resource "aws_autoscaling_group" "eks" {
-  # Generate local map (subnet_id = az), instead of typing out several clunky lookups into same source
-  # Since we're using for_each subnet, instead of count, in main module, only pass subnets if instance type specified
   count                = length(var.instance_types) > 0 ? length(var.subnet_ids) : 0
   name                 = "eks-${var.cluster_name}-${var.nodegroup_name}_${data.aws_subnet.subnet[count.index].availability_zone}"
   launch_configuration = try(aws_launch_configuration.eks[0].id, ["NA"])

--- a/_sub/compute/eks-nodegroup-unmanaged/main.tf
+++ b/_sub/compute/eks-nodegroup-unmanaged/main.tf
@@ -1,29 +1,3 @@
-data "aws_ami" "eks-node" {
-  filter {
-    name   = "name"
-    values = ["amazon-eks-node-${var.cluster_version}-*"]
-  }
-
-  most_recent = true
-  owners      = ["602401143452"] # Amazon Account ID
-}
-
-data "aws_ami" "eks-gpu-node" {
-  filter {
-    name   = "name"
-    values = ["amazon-eks-gpu-node-${var.cluster_version}-*"]
-  }
-
-  most_recent = true
-  owners      = ["602401143452"] # Amazon Account ID
-}
-
-locals {
-  # Use GPU AMI if 'gpu_ami' is true
-  node_ami = var.gpu_ami ? data.aws_ami.eks-gpu-node.id : data.aws_ami.eks-node.id
-}
-
-
 locals {
   /*
   https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/#example-use-cases
@@ -90,17 +64,25 @@ resource "aws_launch_configuration" "eks" {
   }
 }
 
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html
+resource "aws_placement_group" "cluster" {
+  name     = "eks_${var.cluster_name}_${var.nodegroup_name}"
+  strategy = "cluster"
+}
+
 resource "aws_autoscaling_group" "eks" {
-  count                = signum(length(var.instance_types))
-  name                 = "eks-${var.cluster_name}-${var.nodegroup_name}"
+  count                = length(var.instance_types) > 0 ? length(var.subnet_ids) : 0
+  name                 = "eks_${var.cluster_name}_${var.nodegroup_name}_${data.aws_subnet.subnet[count.index].availability_zone}"
   launch_configuration = element(concat(aws_launch_configuration.eks.*.id, [""]), 0)
-  min_size             = var.min_size
-  max_size             = var.max_size
-  desired_capacity     = var.desired_capacity
-  suspended_processes = [
-    "AZRebalance"
-  ]
-  vpc_zone_identifier  = var.subnet_ids
+  # launch_configuration = try(aws_launch_configuration.eks[0].id, [""])
+  availability_zones = toset([data.aws_subnet.subnet[count.index].availability_zone])
+  min_size           = var.min_size_per_subnet
+  max_size           = var.max_size_per_subnet
+  desired_capacity   = var.desired_size_per_subnet
+  # suspended_processes = [
+  #   "AZRebalance"
+  # ]
+  vpc_zone_identifier = toset([data.aws_subnet.subnet[count.index].id])
 
   # The following can be set in case of the default health check are not sufficient
   #health_check_grace_period = 5
@@ -108,7 +90,7 @@ resource "aws_autoscaling_group" "eks" {
 
   tag {
     key                 = "Name"
-    value               = "eks-${var.cluster_name}-${var.nodegroup_name}"
+    value               = "eks_${var.cluster_name}_${var.nodegroup_name}_${data.aws_subnet.subnet[count.index].availability_zone}"
     propagate_at_launch = true
   }
 

--- a/_sub/compute/eks-nodegroup-unmanaged/outputs.tf
+++ b/_sub/compute/eks-nodegroup-unmanaged/outputs.tf
@@ -1,4 +1,4 @@
 output "autoscaling_group_id" {
-  value = element(concat(aws_autoscaling_group.eks.*.id, [""]), 0)
+  value = [for asg in aws_autoscaling_group.eks : asg.id]
 }
 

--- a/_sub/compute/eks-nodegroup-unmanaged/vars.tf
+++ b/_sub/compute/eks-nodegroup-unmanaged/vars.tf
@@ -22,18 +22,18 @@ variable "security_groups" {
   type = list(string)
 }
 
-variable "desired_capacity" {
-  type = number
+variable "desired_size_per_subnet" {
+  type    = number
   default = 0
 }
 
-variable "min_size" {
-  type = number
+variable "min_size_per_subnet" {
+  type    = number
   default = 0
 }
 
-variable "max_size" {
-  type = number
+variable "max_size_per_subnet" {
+  type    = number
   default = 0
 }
 

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -140,22 +140,21 @@ Feature toggle nodegroups
 module "eks_nodegroup1_workers" {
   source = "../../_sub/compute/eks-nodegroup-unmanaged"
 
-  # deploy                          = "${signum(length(var.eks_nodegroup1_subnets))}"
   cluster_name    = var.eks_cluster_name
   cluster_version = var.eks_cluster_version
   nodegroup_name  = "ng1"
 
   # node_role_arn           = "${module.eks_workers_iam_role.arn}"
-  iam_instance_profile = module.eks_workers.iam_instance_profile_name
-  security_groups      = [module.eks_workers_security_group.id]
-  desired_capacity     = var.eks_nodegroup1_desired_capacity
-  min_size             = var.eks_nodegroup1_desired_capacity
-  max_size             = var.eks_nodegroup1_desired_capacity > 0 ? var.eks_nodegroup1_max_size : 0
-  subnet_ids           = module.eks_workers_subnet.subnet_ids
-  disk_size            = var.eks_worker_instance_storage_size
-  instance_types       = var.eks_nodegroup1_instance_types
-  gpu_ami              = var.eks_nodegroup1_gpu_ami
-  ec2_ssh_key          = module.eks_workers_keypair.key_name
+  iam_instance_profile    = module.eks_workers.iam_instance_profile_name
+  security_groups         = [module.eks_workers_security_group.id]
+  desired_size_per_subnet = var.eks_nodegroup1_desired_size_per_subnet
+  min_size_per_subnet     = var.eks_nodegroup1_desired_size_per_subnet
+  max_size_per_subnet     = var.eks_nodegroup1_desired_size_per_subnet > 0 ? var.eks_nodegroup1_max_size_per_subnet : 0
+  subnet_ids              = module.eks_workers_subnet.subnet_ids
+  disk_size               = var.eks_worker_instance_storage_size
+  instance_types          = var.eks_nodegroup1_instance_types
+  gpu_ami                 = var.eks_nodegroup1_gpu_ami
+  ec2_ssh_key             = module.eks_workers_keypair.key_name
 
   kubelet_extra_args = var.eks_nodegroup1_kubelet_extra_args
 
@@ -176,22 +175,21 @@ module "eks_nodegroup1_workers" {
 module "eks_nodegroup2_workers" {
   source = "../../_sub/compute/eks-nodegroup-unmanaged"
 
-  # deploy                          = "${signum(length(var.eks_nodegroup1_subnets))}"
   cluster_name    = var.eks_cluster_name
   cluster_version = var.eks_cluster_version
   nodegroup_name  = "ng2"
 
   # node_role_arn           = "${module.eks_workers_iam_role.arn}"
-  iam_instance_profile = module.eks_workers.iam_instance_profile_name
-  security_groups      = [module.eks_workers_security_group.id]
-  desired_capacity     = var.eks_nodegroup2_desired_capacity
-  min_size             = var.eks_nodegroup2_desired_capacity
-  max_size             = var.eks_nodegroup2_desired_capacity > 0 ? var.eks_nodegroup2_max_size : 0
-  subnet_ids           = module.eks_workers_subnet.subnet_ids
-  disk_size            = var.eks_worker_instance_storage_size
-  instance_types       = var.eks_nodegroup2_instance_types
-  gpu_ami              = var.eks_nodegroup2_gpu_ami
-  ec2_ssh_key          = module.eks_workers_keypair.key_name
+  iam_instance_profile    = module.eks_workers.iam_instance_profile_name
+  security_groups         = [module.eks_workers_security_group.id]
+  desired_size_per_subnet = var.eks_nodegroup2_desired_size_per_subnet
+  min_size_per_subnet     = var.eks_nodegroup2_desired_size_per_subnet
+  max_size_per_subnet     = var.eks_nodegroup2_desired_size_per_subnet > 0 ? var.eks_nodegroup2_max_size_per_subnet : 0
+  subnet_ids              = module.eks_workers_subnet.subnet_ids
+  disk_size               = var.eks_worker_instance_storage_size
+  instance_types          = var.eks_nodegroup2_instance_types
+  gpu_ami                 = var.eks_nodegroup2_gpu_ami
+  ec2_ssh_key             = module.eks_workers_keypair.key_name
 
   kubelet_extra_args = var.eks_nodegroup2_kubelet_extra_args
 

--- a/compute/eks-ec2/outputs.tf
+++ b/compute/eks-ec2/outputs.tf
@@ -30,11 +30,11 @@ output "eks_worker_role_id" {
 }
 
 output "eks_worker_autoscaling_group_ids" {
-  value = [
+  value = flatten([
     module.eks_workers.autoscaling_group_id,
     module.eks_nodegroup1_workers.autoscaling_group_id,
     module.eks_nodegroup2_workers.autoscaling_group_id,
-  ]
+  ])
 }
 
 output "eks_cluster_nodes_sg_id" {

--- a/compute/eks-ec2/vars.tf
+++ b/compute/eks-ec2/vars.tf
@@ -149,12 +149,12 @@ variable "eks_nodegroup1_kubelet_extra_args" {
   default = ""
 }
 
-variable "eks_nodegroup1_desired_capacity" {
+variable "eks_nodegroup1_desired_size_per_subnet" {
   type    = number
   default = 0
 }
 
-variable "eks_nodegroup1_max_size" {
+variable "eks_nodegroup1_max_size_per_subnet" {
   type    = number
   default = 10
 }
@@ -178,12 +178,12 @@ variable "eks_nodegroup2_kubelet_extra_args" {
   default = ""
 }
 
-variable "eks_nodegroup2_desired_capacity" {
+variable "eks_nodegroup2_desired_size_per_subnet" {
   type    = number
   default = 0
 }
 
-variable "eks_nodegroup2_max_size" {
+variable "eks_nodegroup2_max_size_per_subnet" {
   type    = number
   default = 10
 }


### PR DESCRIPTION
# New EKS "node groups" - migration needed

This release will now deploy a separate auto-scaling group per availability zone, to better control node distribution.

This means changes to some of the input variables to the `/compute/eks-ec2` main module:

| Before | After |
| --- | --- |
| eks_nodegroup1_desired_capacity | eks_nodegroup1_desired_size_per_subnet |
| eks_nodegroup1_max_size | eks_nodegroup1_max_size_per_subnet |
| eks_nodegroup2_desired_capacity | eks_nodegroup2_desired_size_per_subnet |
| eks_nodegroup2_max_size | eks_nodegroup2_max_size_per_subnet |

## Suggested migration path

Taking advantage of unused node group 2.

**1. Ensure infrastructure is up-to-date and nodes are labeled:**

- In `cluster/terragrunt.hcl`, ensure `eks_nodegroup1_kubelet_extra_args` and `eks_nodegroup2_kubelet_extra_args` set a node group label, by setting value to `--node-labels=nodegroup=ng1` and `--node-labels=nodegroup=ng2` respectively
- Run `terragrunt apply` in the `cluster` folder to ensure infrastructure is up-to-date
- Ensure the node group label has been applied by running `kubectl get nodes -L=nodegroup`
- If needed, manually apply the label to existing nodes: `nodegroup=ng1`

**2. Temporarily ramp up NG2 and drain NG1:**

- In `cluster/terragrunt.hcl`, update `eks_nodegroup2_desired_capacity` and `eks_nodegroup2_instance_types` match that of node group 1
- Run `terragrunt apply -target module.eks_nodegroup2_workers.aws_autoscaling_group.eks[0]` in the `cluster` folder
- Confirm nodes have joined cluster and are ready: `kubectl get nodes -l=nodegroup=ng2`
- Drain nodes in node group 1: `kubectl drain -l=nodegroup=ng1 --ignore-daemonsets --delete-local-data --grace-period=30 --timeout=2m --force`

**3. Convert NG1 to new node group (separate ASG per AZ):**

- In `cluster/terragrunt.hcl`, update source to use this release (0.2.38?)
- Replace the variable name `eks_nodegroup1_desired_capacity` to `eks_nodegroup1_desired_size_per_subnet` and divide the value by 3
- Deploy the new ASGs by running `terragrunt apply -target module.eks_nodegroup1_workers.aws_autoscaling_group.eks[0] -target module.eks_nodegroup1_workers.aws_autoscaling_group.eks[1] -target module.eks_nodegroup1_workers.aws_autoscaling_group.eks[2]`
- Confirm nodes have joined cluster and are ready: `kubectl get nodes -l=nodegroup=ng1`

**4. Drain and scale down NG2:**

- Drain nodes in node group 2: `kubectl drain -l=nodegroup=ng2 --ignore-daemonsets --delete-local-data --grace-period=30 --timeout=2m --force`
- Comment out all NG2 variables (will cause it to be destroyed at next step)
- Run `terragrunt apply` in the `cluster` folder