### PR TITLE
First draft of Kubernetes clusterrole for CloudEngineer

### DIFF
--- a/_sub/security/iam-policies/main.tf
+++ b/_sub/security/iam-policies/main.tf
@@ -181,6 +181,16 @@ data "aws_iam_policy_document" "capability_access_shared" {
 
 # Admin
 data "aws_iam_policy_document" "cloudengineer" {
+  statement {
+    sid    = "CloudEngineerPlaceholder"
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket"
+    ]
+    resources = [
+      "arn:aws:s3:::/test/*"
+    ]
+  }
 }
 
 # ------------------------------------------------------------------------------

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -295,14 +295,19 @@ module "k8s_cloudengineer_clusterrole_and_binding" {
   name = "cloud-engineer"
   rules = [
     {
-      api_groups = [""]
-      resources  = ["namespaces"]
-      verbs      = ["get", "list", "watch"]
+      api_groups = ["*"]
+      resources  = ["*"]
+      verbs      = ["create", "get", "list", "watch"]
     },
     {
       api_groups = [""]
-      resources  = ["pod"]
-      verbs      = ["get", "list", "watch"]
+      resources  = ["pods", "pods/attach", "pods/exec", "pods/portforward", "pods/proxy"]
+      verbs      = ["*"]
+    },
+    {
+      api_groups = [""]
+      resources  = ["nodes"]
+      verbs      = ["patch"]
     }
   ]
 }


### PR DESCRIPTION
Don't worry to much about the aws role. It is a placeholder until we get it defined.