### PR TITLE
Eks kiam probes

### DIFF
--- a/_sub/compute/k8s-kiam/main.tf
+++ b/_sub/compute/k8s-kiam/main.tf
@@ -100,7 +100,17 @@ resource "helm_release" "kiam" {
 
   set {
     name  = "agent.image.tag"
-    value = "v3.5"
+    value = var.image_tag
+  }
+
+  set {
+    name  = "agent.deepLivenessProbe"
+    value = var.agent_deep_liveness
+  }
+
+  set {
+    name  = "agent.livenessProbe.timeoutSeconds"
+    value = var.agent_liveness_timeout
   }
 
   set {
@@ -130,7 +140,17 @@ resource "helm_release" "kiam" {
 
   set {
     name  = "server.image.tag"
-    value = "v3.5"
+    value = var.image_tag
+  }
+
+  set {
+    name  = "server.livenessProbe.timeoutSeconds"
+    value = var.server_liveness_timeout
+  }
+
+  set {
+    name  = "server.readinessProbe.timeoutSeconds"
+    value = var.server_readiness_timeout
   }
 
   set {

--- a/_sub/compute/k8s-kiam/vars.tf
+++ b/_sub/compute/k8s-kiam/vars.tf
@@ -22,7 +22,7 @@ variable "image_tag" {
 variable "agent_deep_liveness" {
   type        = bool
   description = "Fail agent liveness probe if the server is not accessible"
-  default     = true
+  default     = false
 }
 
 variable "agent_liveness_timeout" {

--- a/_sub/compute/k8s-kiam/vars.tf
+++ b/_sub/compute/k8s-kiam/vars.tf
@@ -7,13 +7,43 @@ variable "aws_workload_account_id" {
 }
 
 variable "cluster_name" {
-  type = string  
+  type = string
 }
 
 variable "worker_role_id" {
 }
 
+variable "image_tag" {
+  type        = string
+  description = "Image tag of KIAM to deploy"
+  default     = "v3.5"
+}
+
+variable "agent_deep_liveness" {
+  type        = bool
+  description = "Fail agent liveness probe if the server is not accessible"
+  default     = true
+}
+
+variable "agent_liveness_timeout" {
+  type        = number
+  description = "When the agent's liveness probe times out"
+  default     = 1
+}
+
+variable "server_liveness_timeout" {
+  type        = number
+  description = "When the server's liveness probe times out"
+  default     = 10
+}
+
+variable "server_readiness_timeout" {
+  type        = number
+  description = "When the server's readiness probe times out"
+  default     = 10
+}
+
 variable "priority_class" {
   description = "Name of the Kubernetes priority class pods should use"
-  type = string  
+  type        = string
 }

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -273,6 +273,8 @@ module "kiam_deploy" {
   priority_class          = "service-critical"
   aws_workload_account_id = var.aws_workload_account_id
   worker_role_id          = data.terraform_remote_state.cluster.outputs.eks_worker_role_id
+  agent_deep_liveness     = true
+  agent_liveness_timeout  = 5
 }
 
 # --------------------------------------------------


### PR DESCRIPTION
Parameterised several settings related to KIAM liveness and readiness probes.

Set defaults in sub-module do those of the Helm chart, added opinionated overrides on k8s-services main module (namely deep agent liveness probe, and agent liveness timeout of 5 sec).