### PR TITLE
Update prime pipeline docker image

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -17,7 +17,7 @@ schedules:
 resources:
   containers:
     - container: prime
-      image: dfdsdk/prime-pipeline:0.5.0
+      image: dfdsdk/prime-pipeline:0.5.2
       env:
         AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
         ARM_CLIENT_SECRET: $(ARM_CLIENT_SECRET)


### PR DESCRIPTION
Prime pipeline docker image updated to v0.5.2 to increment Terragrunt and Terraform versions for testing in QA.