### PR TITLE
update pipeline container image

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -17,7 +17,7 @@ schedules:
 resources:
   containers:
     - container: prime
-      image: dfdsdk/prime-pipeline:0.5.3
+      image: dfdsdk/prime-pipeline:0.5.4
       env:
         AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
         ARM_CLIENT_SECRET: $(ARM_CLIENT_SECRET)


### PR DESCRIPTION
This updates the prime-pipeline image in the integration tests pipeline from 0.5.3 to 0.5.4 which replaces the helm2 executable with helm3