### PR TITLE
Added tolerations to goldpinger

### DIFF
--- a/_sub/compute/helm-goldpinger/main.tf
+++ b/_sub/compute/helm-goldpinger/main.tf
@@ -36,4 +36,8 @@ resource "helm_release" "goldpinger" {
     name  = "resources.requests.memory"
     value = "50Mi"
   }
+
+  values = [
+    file("${path.module}/tolerations.yaml")
+  ]
 }


### PR DESCRIPTION
We need to add tolerations to Goldpinger in order to make sure it runs on all nodes.