### PR TITLE
update goldpinger helm repo from obsolete url

### DIFF
--- a/_sub/compute/helm-goldpinger/main.tf
+++ b/_sub/compute/helm-goldpinger/main.tf
@@ -1,7 +1,7 @@
 resource "helm_release" "goldpinger" {
   name          = "goldpinger"
   chart         = "goldpinger"
-  repository    = "https://kubernetes-charts.storage.googleapis.com"
+  repository    = "https://charts.helm.sh/stable"
   version       = var.chart_version != null ? var.chart_version : null
   namespace     = var.namespace
   recreate_pods = true


### PR DESCRIPTION
https://helm.sh/blog/new-location-stable-incubator-charts/

See above URL. Relevant change made with this PR