### PR TITLE
Add helm metrics-server

### DIFF
--- a/_sub/compute/helm-metrics-server/main.tf
+++ b/_sub/compute/helm-metrics-server/main.tf
@@ -4,8 +4,9 @@ resource "helm_release" "metrics_server" {
     chart = "metrics-server"
     version = var.chart_version != null ? var.chart_version : null
     namespace = var.namespace != null ? var.namespace : null
+    recreate_pods = true
 
     values = [
     "${file("${path.module}/values/values.yaml")}"
-  ]
+    ]
 }

--- a/_sub/compute/helm-metrics-server/main.tf
+++ b/_sub/compute/helm-metrics-server/main.tf
@@ -1,0 +1,7 @@
+resource "helm_release" "metrics_server" {
+    name = "metrics-server"
+    repository = "https://charts.helm.sh/stable"
+    chart = "metrics-server"
+    version = var.chart_version != null ? var.chart_version : null
+    namespace = var.namespace != null ? var.namespace : null
+}

--- a/_sub/compute/helm-metrics-server/main.tf
+++ b/_sub/compute/helm-metrics-server/main.tf
@@ -4,4 +4,8 @@ resource "helm_release" "metrics_server" {
     chart = "metrics-server"
     version = var.chart_version != null ? var.chart_version : null
     namespace = var.namespace != null ? var.namespace : null
+
+    values = [
+    "${file("${path.module}/values/values.yaml")}"
+  ]
 }

--- a/_sub/compute/helm-metrics-server/values/values.yaml
+++ b/_sub/compute/helm-metrics-server/values/values.yaml
@@ -1,0 +1,1 @@
+args: ["--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname"]

--- a/_sub/compute/helm-metrics-server/vars.tf
+++ b/_sub/compute/helm-metrics-server/vars.tf
@@ -1,0 +1,11 @@
+variable "chart_version" {
+  type        = string
+  description = "metrics-server helm chart version"
+  default     = null
+}
+
+variable "namespace" {
+  type        = string
+  description = "Namespace to apply Kube-prometheus-stack in"
+  default     = "monitoring"
+}

--- a/_sub/compute/helm-metrics-server/vars.tf
+++ b/_sub/compute/helm-metrics-server/vars.tf
@@ -6,6 +6,6 @@ variable "chart_version" {
 
 variable "namespace" {
   type        = string
-  description = "Namespace to apply Kube-prometheus-stack in"
+  description = "Namespace to apply metrics-server in"
   default     = "monitoring"
 }

--- a/_sub/compute/helm-metrics-server/versions.tf
+++ b/_sub/compute/helm-metrics-server/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -341,8 +341,7 @@ module "monitoring_kube_prometheus_stack" {
 
 module "monitoring_metrics_server" {
   source         = "../../_sub/compute/helm-metrics-server"
-  count          = var.monitoring_metrics_server_deploy ? 1 : 0
+  count          = var.monitoring_metrics_server_deploy && var.monitoring_namespace_deploy ? 1 : 0
   chart_version  = var.monitoring_metrics_server_chart_version
   namespace      = module.monitoring_namespace[0].name
-  depends_on     = [module.monitoring_kube_prometheus_stack[0], module.monitoring_namespace[0]]
 }

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -335,3 +335,14 @@ module "monitoring_kube_prometheus_stack" {
   alertmanager_silence_namespaces = var.monitoring_alertmanager_silence_namespaces
 }
 
+# --------------------------------------------------
+# Metrics-Server
+# --------------------------------------------------
+
+module "monitoring_metrics_server" {
+  source         = "../../_sub/compute/helm-metrics-server"
+  count          = var.monitoring_metrics_server_deploy ? 1 : 0
+  chart_version  = var.monitoring_metrics_server_chart_version
+  namespace      = module.monitoring_namespace[0].name
+  depends_on     = [module.monitoring_kube_prometheus_stack[0], module.monitoring_namespace[0]]
+}

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -323,7 +323,7 @@ variable "monitoring_alertmanager_silence_namespaces" {
 
 variable "monitoring_metrics_server_deploy" {
   type        = bool
-  description = "Deploy kube-prometheus-stack helm chart switch"
+  description = "Deploy metrics-server helm chart switch"
   default     = false
 }
 
@@ -335,7 +335,7 @@ variable "monitoring_metrics_server_chart_version" {
 
 variable "monitoring_metrics_server_chart_namespace" {
   type        = string
-  description = "Namespace to apply Kube-prometheus-stack in"
+  description = "Namespace to apply metrics-server in"
   default     = "monitoring"
 }
 

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -319,6 +319,28 @@ variable "monitoring_alertmanager_silence_namespaces" {
 }
 
 # --------------------------------------------------
+# Metrics-Server
+# --------------------------------------------------
+
+variable "monitoring_metrics_server_deploy" {
+  type        = bool
+  description = "Deploy kube-prometheus-stack helm chart switch"
+  default     = false
+}
+
+variable "monitoring_metrics_server_chart_version" {
+  type        = string
+  description = "metrics-server helm chart version"
+  default     = null
+}
+
+variable "monitoring_metrics_server_chart_namespace" {
+  type        = string
+  description = "Namespace to apply Kube-prometheus-stack in"
+  default     = "monitoring"
+}
+
+# --------------------------------------------------
 # Unused variables - to provent TF warning/error:
 # Using a variables file to set an undeclared variable is deprecated and will
 # become an error in a future release. If you wish to provide certain "global"

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -323,7 +323,7 @@ variable "monitoring_alertmanager_silence_namespaces" {
 
 variable "monitoring_metrics_server_deploy" {
   type        = bool
-  description = "Deploy metrics-server helm chart switch"
+  description = "Deploy metrics-server helm chart switch. If setting to true, monitoring_namespace_deploy must also be set to true"
   default     = false
 }
 


### PR DESCRIPTION
This PR adds a metrics-server submodule to allow our metrics-server to be managed in state/pipeline, which it currently is not