### PR TITLE
removed aggregatedapidown alert silence

### DIFF
--- a/_sub/compute/helm-kube-prometheus-stack/values/alertmanager-slack.yaml
+++ b/_sub/compute/helm-kube-prometheus-stack/values/alertmanager-slack.yaml
@@ -18,11 +18,6 @@ alertmanager:
       - match_re:
           namespace: ${alertmanager_silence_namespaces}
         receiver: 'null'
-      - match:
-          alertname: AggregatedAPIDown
-          name: 'v1beta1.metrics.k8s.io'
-          namespace: 'default'
-        receiver: 'null'
     receivers:
     - name: 'general'
       slack_configs:


### PR DESCRIPTION
Removed AggregatedAPIDown alert silence (null receiver) from Prometheus. Silence is no longer required after upgrade to Kubernetes 1.18