### PR TITLE
Set target group dereg delay to zero

### DIFF
--- a/_sub/compute/eks-alb-auth/main.tf
+++ b/_sub/compute/eks-alb-auth/main.tf
@@ -14,11 +14,12 @@ resource "aws_autoscaling_attachment" "traefik_auth" {
 }
 
 resource "aws_lb_target_group" "traefik_auth" {
-  count       = var.deploy ? 1 : 0
-  name_prefix = substr(var.cluster_name, 0, min(6, length(var.cluster_name)))
-  port        = var.target_http_port
-  protocol    = "HTTP"
-  vpc_id      = var.vpc_id
+  count                = var.deploy ? 1 : 0
+  name_prefix          = substr(var.cluster_name, 0, min(6, length(var.cluster_name)))
+  port                 = var.target_http_port
+  protocol             = "HTTP"
+  vpc_id               = var.vpc_id
+  deregistration_delay = 0
 
   health_check {
     path     = var.health_check_path
@@ -121,10 +122,10 @@ resource "aws_security_group" "traefik_auth" {
     Name = "${var.cluster_name}-traefik-auth-sg"
   }
 
- lifecycle {
+  lifecycle {
     create_before_destroy = true
   }
-  
+
 }
 
 resource "aws_security_group_rule" "allow_traefik_auth" {

--- a/_sub/compute/eks-alb/main.tf
+++ b/_sub/compute/eks-alb/main.tf
@@ -14,11 +14,12 @@ resource "aws_autoscaling_attachment" "traefik" {
 }
 
 resource "aws_lb_target_group" "traefik" {
-  count       = var.deploy ? 1 : 0
-  name_prefix = substr(var.cluster_name, 0, min(6, length(var.cluster_name)))
-  port        = var.target_http_port
-  protocol    = "HTTP"
-  vpc_id      = var.vpc_id
+  count                = var.deploy ? 1 : 0
+  name_prefix          = substr(var.cluster_name, 0, min(6, length(var.cluster_name)))
+  port                 = var.target_http_port
+  protocol             = "HTTP"
+  vpc_id               = var.vpc_id
+  deregistration_delay = 0
 
   health_check {
     path     = var.health_check_path
@@ -101,7 +102,7 @@ resource "aws_security_group" "traefik" {
     Name = "${var.cluster_name}-traefik-sg"
   }
 
- lifecycle {
+  lifecycle {
     create_before_destroy = true
   }
 


### PR DESCRIPTION
When scalling down ASGs during maintenance, there's a 5 minute delay for each ASG, meant to allow connections to train from the ALB.

However the maintenance process itself drains the workload from the nodes before triggering a scale-in operation, so it seems pointless to wait an arbitrary 5 minutes after. This reduces the delay to 0 seconds, which should remove quite a bit of overhead from the process.

Verify in sandbox cluster.