### PR TITLE
Added locals to allow multiple roles to be assumed from kube-system

### DIFF
--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -283,12 +283,19 @@ module "cloudwatch_agent_config_bucket" {
 # is a lightweight element with little cost.  If we wished to have it defined based on a feature toggle
 # then it would create additional complexity and require that the toggle variable exist in two places,
 # thus leading to confusion  
+locals {
+  kubesystem_permitted_base_role        = ["eks-${var.eks_cluster_name}-csi"]
+  kubesystem_permitted_role_list        = concat(local.kubesystem_permitted_base_role, var.kubesystem_permitted_extra_roles)
+  kubesystem_permitted_role_list_sorted = sort(local.kubesystem_permitted_role_list)
+  kubesystem_permitted_role_string      = join("|", local.kubesystem_permitted_role_list_sorted)
+}
+
 module "kube_system_namespace" {
   source          = "../../_sub/compute/k8s-annotate-namespace"
   depends_on      = [module.eks_heptio]
   namespace       = "kube-system"
   kubeconfig_path = local.kubeconfig_path
-  annotations     = { "iam.amazonaws.com/permitted" = "eks-${var.eks_cluster_name}-csi" }
+  annotations     = { "iam.amazonaws.com/permitted" = local.kubesystem_permitted_role_string }
 }
 
 

--- a/compute/eks-ec2/vars.tf
+++ b/compute/eks-ec2/vars.tf
@@ -95,7 +95,7 @@ variable "eks_addon_vpccni_version_override" {
 }
 
 variable "eks_public_s3_bucket" {
-  description = "The name of the public S3 bucket, where non-sensitive Kubeconfig will be copied to."
+  description = "The name of the public S3 bucket, where non-sensitive Kubeconfig will be copied to"
   type        = string
   default     = ""
 }
@@ -182,6 +182,17 @@ variable "eks_worker_cloudwatch_agent_config_deploy" {
 variable "eks_worker_cloudwatch_agent_config_file" {
   type    = string
   default = "aws-cloudwatch-agent-conf.json"
+}
+
+
+# --------------------------------------------------
+# Namespaces
+# --------------------------------------------------
+
+variable "kubesystem_permitted_extra_roles" {
+  type        = list(string)
+  default     = []
+  description = "Defines additional roles that can be assumed from the kube-system namespace"
 }
 
 


### PR DESCRIPTION
Together with Rasmus we added some locals to the Terraform code to allow us to support multiple roles being annotated on the kube-system namespace.