### PR TITLE
Needed to add single quotes to kubectl command

### DIFF
--- a/_sub/compute/k8s-annotate-namespace/main.tf
+++ b/_sub/compute/k8s-annotate-namespace/main.tf
@@ -1,7 +1,7 @@
 resource "null_resource" "annotate" {
   for_each = var.annotations
   provisioner "local-exec" {
-    command = "kubectl --kubeconfig ${var.kubeconfig_path} annotate ns ${var.namespace} ${each.key}=${each.value} --overwrite"
+    command = "kubectl --kubeconfig ${var.kubeconfig_path} annotate ns ${var.namespace} ${each.key}='${each.value}' --overwrite"
   }
 
   triggers = {


### PR DESCRIPTION
Needed to add single quotes to kubectl command as annotations may now include the pipe delimiter.

The absence of the quotes was causing the pipeline to fail.  This should resolve the issue.
