### PR TITLE
Add Crossplane module

### DIFF
--- a/_sub/compute/helm-crossplane/main.tf
+++ b/_sub/compute/helm-crossplane/main.tf
@@ -5,7 +5,7 @@ resource "helm_release" "crossplane" {
     name = var.release_name
     chart = "crossplane"
     repository    = "https://charts.crossplane.io/stable"
-    version       = var.chart_version != null ? var.chart_version : null
+    version       = var.chart_version
     namespace     = var.namespace
     recreate_pods = var.recreate_pods
     force_update  = var.force_update

--- a/_sub/compute/helm-crossplane/main.tf
+++ b/_sub/compute/helm-crossplane/main.tf
@@ -1,3 +1,6 @@
+locals {
+  packages_list = replace(yamlencode({provider:{packages:var.crossplane_providers}}), "\"", "")
+}
 resource "helm_release" "crossplane" {
     name = var.release_name
     chart = "crossplane"
@@ -9,6 +12,7 @@ resource "helm_release" "crossplane" {
 
     values = [
     templatefile("${path.module}/values/values.yaml", {
+      crossplane_providers = local.packages_list
   })]
 }
 

--- a/_sub/compute/helm-crossplane/main.tf
+++ b/_sub/compute/helm-crossplane/main.tf
@@ -1,0 +1,19 @@
+resource "helm_release" "crossplane" {
+    name = var.release_name
+    chart = "crossplane"
+    repository    = "https://charts.crossplane.io/stable"
+    version       = var.chart_version != null ? var.chart_version : null
+    namespace     = var.namespace
+    recreate_pods = var.recreate_pods
+    force_update  = var.force_update
+
+    values = [
+    templatefile("${path.module}/values/values.yaml", {
+  })]
+}
+
+resource "kubernetes_namespace" "namespace" {
+  metadata {
+    name = var.namespace
+  }
+}

--- a/_sub/compute/helm-crossplane/values/values.yaml
+++ b/_sub/compute/helm-crossplane/values/values.yaml
@@ -1,0 +1,1 @@
+${crossplane_providers}

--- a/_sub/compute/helm-crossplane/vars.tf
+++ b/_sub/compute/helm-crossplane/vars.tf
@@ -1,35 +1,29 @@
 variable "namespace" {
   type = string
   description = "Namespace in which to install Crossplane"
-  default = "crossplane-system"
 }
 
 variable "chart_version" {
   type = string
   description = "Specify a version of the Helm chart"
-  default = null
 }
 
 variable "release_name" {
   type = string
   description = "Name of the chart release"
-  default = "crossplane"
 }
 
 variable "recreate_pods" {
     type = bool
     description = "Recreate pods on deployment"
-    default = true
 }
 
 variable "force_update" {
     type = bool
     description = "Force resource updates through replacement"
-    default = false
 }
 
 variable "crossplane_providers" {
   type = list(string)
   description = "List of Crossplane providers to install"
-  default = []
 }

--- a/_sub/compute/helm-crossplane/vars.tf
+++ b/_sub/compute/helm-crossplane/vars.tf
@@ -1,0 +1,29 @@
+variable "namespace" {
+  type = string
+  description = "Namespace in which to install Crossplane"
+  default = "crossplane-system"
+}
+
+variable "chart_version" {
+  type = string
+  description = "Specify a version of the Helm chart"
+  default = null
+}
+
+variable "release_name" {
+  type = string
+  description = "Name of the chart release"
+  default = "crossplane"
+}
+
+variable "recreate_pods" {
+    type = bool
+    description = "Recreate pods on deployment"
+    default = true
+}
+
+variable "force_update" {
+    type = bool
+    description = "Force resource updates through replacement"
+    default = false
+}

--- a/_sub/compute/helm-crossplane/vars.tf
+++ b/_sub/compute/helm-crossplane/vars.tf
@@ -27,3 +27,9 @@ variable "force_update" {
     description = "Force resource updates through replacement"
     default = false
 }
+
+variable "crossplane_providers" {
+  type = list(string)
+  description = "List of Crossplane providers to install"
+  default = []
+}

--- a/_sub/compute/helm-crossplane/versions.tf
+++ b/_sub/compute/helm-crossplane/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -17,7 +17,7 @@ schedules:
 resources:
   containers:
     - container: prime
-      image: dfdsdk/prime-pipeline:0.5.4
+      image: dfdsdk/prime-pipeline:0.5.5
       env:
         AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
         ARM_CLIENT_SECRET: $(ARM_CLIENT_SECRET)

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -407,4 +407,5 @@ module "crossplane" {
   chart_version = var.crossplane_chart_version
   recreate_pods = var.crossplane_recreate_pods
   force_update = var.crossplane_force_update
+  crossplane_providers = var.crossplane_providers
 }

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -394,3 +394,17 @@ module "atlantis" {
   arm_client_id = var.arm_client_id
   arm_client_secret = var.arm_client_secret
 }
+
+# --------------------------------------------------
+# Crossplane
+# --------------------------------------------------
+
+module "crossplane" {
+  source = "../../_sub/compute/helm-crossplane"
+  release_name = var.crossplane_release_name
+  count = var.crossplane_deploy ? 1 : 0
+  namespace = var.crossplane_namespace
+  chart_version = var.crossplane_chart_version
+  recreate_pods = var.crossplane_recreate_pods
+  force_update = var.crossplane_force_update
+}

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -588,29 +588,35 @@ variable "crossplane_deploy" {
 variable "crossplane_namespace" {
   type = string
   description = "Namespace in which to install Crossplane"
+  default = "crossplane-system"
 }
 
 variable "crossplane_release_name" {
   type = string
   description = "Name of the chart release"
+  default = "crossplane"
 }
 
 variable "crossplane_chart_version" {
   type = string
   description = "Specify a version of the Helm chart"
+  default = null
 }
 
 variable "crossplane_recreate_pods" {
     type = bool
     description = "Recreate pods on deployment"
+    default = true
 }
 
 variable "crossplane_force_update" {
     type = bool
     description = "Force resource updates through replacement"
+    default = false
 }
 
 variable "crossplane_providers" {
   type = list(string)
   description = "List of Crossplane providers to install"
+  default = []
 }

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -503,3 +503,43 @@ variable "secret_key_master" {
   description = "Secret for Core account"
   default = null
 }
+
+# --------------------------------------------------
+# Crossplane
+# --------------------------------------------------
+
+variable "crossplane_deploy" {
+  type = bool
+  description = "Deploy Crossplane"
+  default = false
+}
+
+variable "crossplane_namespace" {
+  type = string
+  description = "Namespace in which to install Crossplane"
+  default = "crossplane-system"
+}
+
+variable "crossplane_release_name" {
+  type = string
+  description = "Name of the chart release"
+  default = "crossplane"
+}
+
+variable "crossplane_chart_version" {
+  type = string
+  description = "Specify a version of the Helm chart"
+  default = null
+}
+
+variable "crossplane_recreate_pods" {
+    type = bool
+    description = "Recreate pods on deployment"
+    default = true
+}
+
+variable "crossplane_force_update" {
+    type = bool
+    description = "Force resource updates through replacement"
+    default = false
+}

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -588,35 +588,29 @@ variable "crossplane_deploy" {
 variable "crossplane_namespace" {
   type = string
   description = "Namespace in which to install Crossplane"
-  default = "crossplane-system"
 }
 
 variable "crossplane_release_name" {
   type = string
   description = "Name of the chart release"
-  default = "crossplane"
 }
 
 variable "crossplane_chart_version" {
   type = string
   description = "Specify a version of the Helm chart"
-  default = null
 }
 
 variable "crossplane_recreate_pods" {
     type = bool
     description = "Recreate pods on deployment"
-    default = true
 }
 
 variable "crossplane_force_update" {
     type = bool
     description = "Force resource updates through replacement"
-    default = false
 }
 
 variable "crossplane_providers" {
   type = list(string)
   description = "List of Crossplane providers to install"
-  default = []
 }

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -543,3 +543,9 @@ variable "crossplane_force_update" {
     description = "Force resource updates through replacement"
     default = false
 }
+
+variable "crossplane_providers" {
+  type = list(string)
+  description = "List of Crossplane providers to install"
+  default = []
+}


### PR DESCRIPTION
This PR adds a [Crossplane](https://crossplane.io/ ) module that can be toggled on and off and allows for the installation of Crossplane provider packages if any are specified