### PR TITLE
make atlantis variable names less generic

### DIFF
--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -65,9 +65,9 @@ provider "helm" {
 }
 
 provider "github" {
-  token        = var.github_token != null ? var.github_token : null
-  organization = var.github_organization != null ? var.github_organization : null
-  owner        = var.github_owner != null ? var.github_owner : null
+  token        = var.atlantis_github_token != null ? var.atlantis_github_token : null
+  organization = var.atlantis_github_organization != null ? var.atlantis_github_organization : null
+  owner        = var.atlantis_github_owner != null ? var.atlantis_github_owner : null
 
   alias = "atlantis"
 }
@@ -467,26 +467,26 @@ module "platform_fluxcd" {
 module "atlantis" {
   source              = "../../_sub/compute/helm-atlantis"
   count               = var.atlantis_deploy ? 1 : 0
-  namespace           = var.namespace
-  chart_version       = var.chart_version
+  namespace           = var.atlantis_namespace
+  chart_version       = var.atlantis_chart_version
   atlantis_image      = var.atlantis_image
   atlantis_image_tag  = var.atlantis_image_tag
   atlantis_ingress    = var.atlantis_ingress
-  github_token        = var.github_token
-  github_organization = var.github_organization
-  github_username     = var.github_username
-  github_repositories = var.github_repositories
-  webhook_secret      = var.webhook_secret
+  github_token        = var.atlantis_github_token
+  github_organization = var.atlantis_github_organization
+  github_username     = var.atlantis_github_username
+  github_repositories = var.atlantis_github_repositories
+  webhook_secret      = var.atlantis_webhook_secret
   webhook_url         = var.atlantis_ingress
-  webhook_events      = var.webhook_events
-  aws_access_key      = var.aws_access_key
-  aws_secret          = var.aws_secret
-  access_key_master   = var.access_key_master
-  secret_key_master   = var.secret_key_master
-  arm_tenant_id       = var.arm_tenant_id
-  arm_subscription_id = var.arm_subscription_id
-  arm_client_id       = var.arm_client_id
-  arm_client_secret   = var.arm_client_secret
+  webhook_events      = var.atlantis_webhook_events
+  aws_access_key      = var.atlantis_aws_access_key
+  aws_secret          = var.atlantis_aws_secret
+  access_key_master   = var.atlantis_access_key_master
+  secret_key_master   = var.atlantis_secret_key_master
+  arm_tenant_id       = var.atlantis_arm_tenant_id
+  arm_subscription_id = var.atlantis_arm_subscription_id
+  arm_client_id       = var.atlantis_arm_client_id
+  arm_client_secret   = var.atlantis_arm_client_secret
 
   providers = {
     github = github.atlantis

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -454,58 +454,58 @@ variable "atlantis_deploy" {
   default     = false
 }
 
-variable "github_token" {
+variable "atlantis_github_token" {
   description = "Github token that the provider uses to perform Github operations. Leaving unset will fall back to GITHUB_TOKEN environment variable"
   default     = null
 }
 
-variable "github_organization" {
+variable "atlantis_github_organization" {
   description = "Github organization name. Conflicts with github_owner. Leaving unset will use GITHUB_ORGANIZATION environment variable if exists"
   default     = null
 }
 
-variable "github_owner" {
+variable "atlantis_github_owner" {
   description = "Github owner(username). Conflicts with github_organization. Leaving unset will use GITHUB_OWNER environment variable if exists"
   default     = null
 }
 
-variable "github_username" {
+variable "atlantis_github_username" {
   description = "Github username of the account that will post Atlantis comments on PR's"
   default     = null
 }
 
-variable "github_repositories" {
+variable "atlantis_github_repositories" {
   description = "List of repositories to whitelist for Atlantis"
   type        = list(string)
   default     = []
 }
 
-variable "webhook_secret" {
+variable "atlantis_webhook_secret" {
   description = "Secret used by the Webhook to speak to Atlantis"
   default     = null
 }
 
-variable "webhook_content_type" {
+variable "atlantis_webhook_content_type" {
   default = "application/json"
 }
 
-variable "webhook_insecure_ssl" {
+variable "atlantis_webhook_insecure_ssl" {
   default = false
 }
 
-variable "webhook_events" {
+variable "atlantis_webhook_events" {
   description = "A list of events that should trigger the webhook"
   default     = []
   type        = list(string)
 }
 
-variable "namespace" {
+variable "atlantis_namespace" {
   type        = string
   description = ""
   default     = "atlantis"
 }
 
-variable "chart_version" {
+variable "atlantis_chart_version" {
   type        = string
   description = ""
   default     = null
@@ -529,47 +529,47 @@ variable "atlantis_image_tag" {
   default     = "latest"
 }
 
-variable "arm_tenant_id" {
+variable "atlantis_arm_tenant_id" {
   type        = string
   description = ""
   default     = null
 }
 
-variable "arm_subscription_id" {
+variable "atlantis_arm_subscription_id" {
   type        = string
   description = ""
   default     = null
 }
 
-variable "arm_client_id" {
+variable "atlantis_arm_client_id" {
   type        = string
   description = ""
   default     = null
 }
 
-variable "arm_client_secret" {
+variable "atlantis_arm_client_secret" {
   type        = string
   description = ""
   default     = null
 }
 
-variable "aws_access_key" {
+variable "atlantis_aws_access_key" {
   description = "AWS Access Key"
   default     = null
 }
 
-variable "aws_secret" {
+variable "atlantis_aws_secret" {
   description = "AWS Secret"
   default     = null
 }
 
-variable "access_key_master" {
+variable "atlantis_access_key_master" {
   type        = string
   description = "Access Key for Core account"
   default     = null
 }
 
-variable "secret_key_master" {
+variable "atlantis_secret_key_master" {
   type        = string
   description = "Secret for Core account"
   default     = null


### PR DESCRIPTION
This PR makes the Atlantis variable names less generic in computer/k8s-services to avoid potential conflicts or lack of clarity when using other modules