### PR TITLE
Fix atlantis for flux

### DIFF
--- a/_sub/compute/helm-atlantis/main.tf
+++ b/_sub/compute/helm-atlantis/main.tf
@@ -104,6 +104,7 @@ resource "kubernetes_secret" "gh" {
 
     data = {
         github_token = var.github_token
+        github_token_flux = var.platform_fluxcd_github_token
     }
     depends_on = [ kubernetes_namespace.namespace ]
 }

--- a/_sub/compute/helm-atlantis/values/values.yaml
+++ b/_sub/compute/helm-atlantis/values/values.yaml
@@ -29,41 +29,65 @@ environmentSecrets:
     secretKeyRef:
       name: aws-credentials
       key: secret_key_master
-
-  - name: TF_VAR_arm_tenant_id
-    secretKeyRef:
-      name: az-credentials
-      key: arm_tenant_id
   - name: ARM_TENANT_ID
     secretKeyRef:
       name: az-credentials
       key: arm_tenant_id
-  - name: TF_VAR_arm_subscription_id
-    secretKeyRef:
-      name: az-credentials
-      key: arm_subscription_id
   - name: ARM_SUBSCRIPTION_ID
     secretKeyRef:
       name: az-credentials
       key: arm_subscription_id
-  - name: TF_VAR_arm_client_id
-    secretKeyRef:
-      name: az-credentials
-      key: arm_client_id
   - name: ARM_CLIENT_ID
     secretKeyRef:
       name: az-credentials
       key: arm_client_id
-  - name: TF_VAR_arm_client_secret
-    secretKeyRef:
-      name: az-credentials
-      key: arm_client_secret
   - name: ARM_CLIENT_SECRET
     secretKeyRef:
       name: az-credentials
       key: arm_client_secret
+  - name: TF_VAR_platform_fluxcd_github_token
+    secretKeyRef:
+      name: gh-credentials
+      key: github_token_flux
 
-  - name: TF_VAR_github_token
+  - name: TF_VAR_atlantis_aws_access_key
+    secretKeyRef:
+      name: aws-credentials
+      key: aws_access_key
+  - name: TF_VAR_atlantis_aws_secret
+    secretKeyRef:
+      name: aws-credentials
+      key: aws_secret
+  - name: TF_VAR_atlantis_access_key_master
+    secretKeyRef:
+      name: aws-credentials
+      key: access_key_master
+  - name: TF_VAR_atlantis_secret_key_master
+    secretKeyRef:
+      name: aws-credentials
+      key: secret_key_master
+  - name: TF_VAR_atlantis_arm_tenant_id
+    secretKeyRef:
+      name: az-credentials
+      key: arm_tenant_id
+  - name: TF_VAR_atlantis_arm_subscription_id
+    secretKeyRef:
+      name: az-credentials
+      key: arm_subscription_id
+  - name: TF_VAR_atlantis_arm_client_id
+    secretKeyRef:
+      name: az-credentials
+      key: arm_client_id
+  - name: TF_VAR_atlantis_arm_client_secret
+    secretKeyRef:
+      name: az-credentials
+      key: arm_client_secret
+  - name: TF_VAR_atlantis_platform_fluxcd_github_token
+    secretKeyRef:
+      name: gh-credentials
+      key: github_token_flux
+   
+  - name: TF_VAR_atlantis_github_token
     secretKeyRef:
       name: gh-credentials
       key: github_token

--- a/_sub/compute/helm-atlantis/vars.tf
+++ b/_sub/compute/helm-atlantis/vars.tf
@@ -62,6 +62,11 @@ variable "github_token" {
     default = null
 }
 
+variable "platform_fluxcd_github_token" {
+    description = "Github token that the provider uses to perform Github operations for Flux."
+    default = null
+}
+
 variable "github_organization" {
     description = "Github organization name. Conflicts with github_owner. Leaving unset will use GITHUB_ORGANIZATION environment variable if exists"
     default = null

--- a/_sub/compute/helm-atlantis/vars.tf
+++ b/_sub/compute/helm-atlantis/vars.tf
@@ -59,12 +59,10 @@ variable "arm_client_secret" {
 #
 variable "github_token" {
     description = "Github token that the provider uses to perform Github operations. Leaving unset will fall back to GITHUB_TOKEN environment variable"
-    default = null
 }
 
 variable "platform_fluxcd_github_token" {
     description = "Github token that the provider uses to perform Github operations for Flux."
-    default = null
 }
 
 variable "github_organization" {

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -68,14 +68,12 @@ provider "github" {
   token        = var.atlantis_github_token != null ? var.atlantis_github_token : null
   organization = var.atlantis_github_organization != null ? var.atlantis_github_organization : null
   owner        = var.atlantis_github_owner != null ? var.atlantis_github_owner : null
-
   alias = "atlantis"
 }
 
 provider "github" {
-  owner = var.platform_fluxcd_github_owner
   token = var.platform_fluxcd_github_token
-
+  owner = var.platform_fluxcd_github_owner
   alias = "fluxcd"
 }
 
@@ -477,6 +475,7 @@ module "atlantis" {
   atlantis_image_tag  = var.atlantis_image_tag
   atlantis_ingress    = var.atlantis_ingress
   github_token        = var.atlantis_github_token
+  github_token_flux   = var.atlantis_github_token_flux
   github_organization = var.atlantis_github_organization
   github_username     = var.atlantis_github_username
   github_repositories = var.atlantis_github_repositories
@@ -491,6 +490,7 @@ module "atlantis" {
   arm_subscription_id = var.atlantis_arm_subscription_id
   arm_client_id       = var.atlantis_arm_client_id
   arm_client_secret   = var.atlantis_arm_client_secret
+  platform_fluxcd_github_token = var.atlantis_platform_fluxcd_github_token
 
   providers = {
     github = github.atlantis

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -475,7 +475,6 @@ module "atlantis" {
   atlantis_image_tag  = var.atlantis_image_tag
   atlantis_ingress    = var.atlantis_ingress
   github_token        = var.atlantis_github_token
-  github_token_flux   = var.atlantis_github_token_flux
   github_organization = var.atlantis_github_organization
   github_username     = var.atlantis_github_username
   github_repositories = var.atlantis_github_repositories

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -459,6 +459,11 @@ variable "atlantis_github_token" {
   default     = null
 }
 
+variable "atlantis_platform_fluxcd_github_token" {
+  description = "Github token that the provider uses to perform Github operations for Flux."
+  default     = null
+}
+
 variable "atlantis_github_organization" {
   description = "Github organization name. Conflicts with github_owner. Leaving unset will use GITHUB_ORGANIZATION environment variable if exists"
   default     = null

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -461,7 +461,7 @@ variable "atlantis_github_token" {
 
 variable "atlantis_platform_fluxcd_github_token" {
   description = "Github token that the provider uses to perform Github operations for Flux."
-  default     = null
+  default     = ""
 }
 
 variable "atlantis_github_organization" {
@@ -506,25 +506,25 @@ variable "atlantis_webhook_events" {
 
 variable "atlantis_namespace" {
   type        = string
-  description = ""
+  description = "Namespace for Atlantis deployment"
   default     = "atlantis"
 }
 
 variable "atlantis_chart_version" {
   type        = string
-  description = ""
+  description = "Version of the helm chart to deploy"
   default     = null
 }
 
 variable "atlantis_ingress" {
   type        = string
-  description = ""
+  description = "URL for Atlantis Ingress"
   default     = null
 }
 
 variable "atlantis_image" {
   type        = string
-  description = ""
+  description = "Name of the image to use for Atlantis"
   default     = "dfdsdk/atlantis-prime-pipeline"
 }
 
@@ -536,48 +536,48 @@ variable "atlantis_image_tag" {
 
 variable "atlantis_arm_tenant_id" {
   type        = string
-  description = ""
-  default     = null
+  description = "Used to set environment variable for ARM tenant ID"
+  default     = ""
 }
 
 variable "atlantis_arm_subscription_id" {
   type        = string
-  description = ""
-  default     = null
+  description = "Used to set environment variable for ARM subscription ID"
+  default     = ""
 }
 
 variable "atlantis_arm_client_id" {
   type        = string
-  description = ""
-  default     = null
+  description = "Used to set environment variable for ARM client ID"
+  default     = ""
 }
 
 variable "atlantis_arm_client_secret" {
   type        = string
-  description = ""
-  default     = null
+  description = "Used to set environment variable for ARM client secret"
+  default     = ""
 }
 
 variable "atlantis_aws_access_key" {
   description = "AWS Access Key"
-  default     = null
+  default     = ""
 }
 
 variable "atlantis_aws_secret" {
   description = "AWS Secret"
-  default     = null
+  default     = ""
 }
 
 variable "atlantis_access_key_master" {
   type        = string
   description = "Access Key for Core account"
-  default     = null
+  default     = ""
 }
 
 variable "atlantis_secret_key_master" {
   type        = string
   description = "Secret for Core account"
-  default     = null
+  default     = ""
 }
 
 # --------------------------------------------------


### PR DESCRIPTION
- add flux github token for atlantis
- fix creation of env vars to match atlantis_ prefix var name changes
- set defaults for values that end up as env vars to empty string to avoid errors if left absent (i.e if flux is disabled you do not need to set the flux github token for flux)
- remove duplicate vars in submodule to be consistent with other submodules