### PR TITLE
fixes for servicemonitor dependencies

### DIFF
--- a/_sub/compute/helm-goldpinger/main.tf
+++ b/_sub/compute/helm-goldpinger/main.tf
@@ -19,7 +19,7 @@ resource "helm_release" "goldpinger" {
 
   set {
     name  = "serviceMonitor.enabled"
-    value = "true"
+    value = var.servicemonitor_enabled
   }
 
   set {

--- a/_sub/compute/helm-goldpinger/vars.tf
+++ b/_sub/compute/helm-goldpinger/vars.tf
@@ -14,3 +14,9 @@ variable "priority_class" {
   type        = string
   description = "Name of priority class to apply"
 }
+
+variable "servicemonitor_enabled" {
+  type = bool
+  description = "Deploy servicemonitor to enable metrics scraping"
+  default = false
+}

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -294,6 +294,9 @@ module "kiam_deploy" {
   agent_liveness_timeout  = 5
   server_gateway_timeout  = "5s"
   servicemonitor_enabled  = var.monitoring_kube_prometheus_stack_deploy
+
+  // Depends_on for servicemonitor is ignored if prometheus stack is not deployed but required otherwise
+  depends_on              = [module.monitoring_kube_prometheus_stack] 
 }
 
 
@@ -401,17 +404,19 @@ module "monitoring_namespace" {
 # --------------------------------------------------
 
 module "monitoring_goldpinger" {
-  source         = "../../_sub/compute/helm-goldpinger"
-  count          = var.monitoring_goldpinger_deploy ? 1 : 0
-  chart_version  = var.monitoring_goldpinger_chart_version
-  priority_class = var.monitoring_goldpinger_priority_class
-  namespace      = module.monitoring_namespace[0].name
-  depends_on     = [module.monitoring_kube_prometheus_stack]
+  source                  = "../../_sub/compute/helm-goldpinger"
+  count                   = var.monitoring_goldpinger_deploy ? 1 : 0
+  chart_version           = var.monitoring_goldpinger_chart_version
+  priority_class          = var.monitoring_goldpinger_priority_class
+  namespace               = module.monitoring_namespace[0].name
+  servicemonitor_enabled  = var.monitoring_kube_prometheus_stack_deploy
+
+  depends_on              = [module.monitoring_kube_prometheus_stack]
 }
 
 
 # --------------------------------------------------
-# Kube-prometheus-stacktw
+# Kube-prometheus-stack
 # --------------------------------------------------
 
 module "monitoring_kube_prometheus_stack" {


### PR DESCRIPTION
- add depends_on to kiam module
- remove true hardcode from goldpinger

This PR adds a depends_on to the kiam module which will deploy a servicemonitor if prometheus_stack is deployed, and deploy after prometheus_stack. The depends_on is ignored if prometheus_stack is not deployed. Goldpinger now follows the same behaviour rather than always trying to deploy a servicemonitor, now it will only use one if prometheus_stack is deployed