### PR TITLE
enable kube-prometheus-stack in qa after fix

### DIFF
--- a/test/integration/eu-west-1/k8s-qa18/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa18/services/terragrunt.hcl
@@ -93,14 +93,14 @@ inputs = {
   # Kube-prometheus-stack
   # --------------------------------------------------
 
-  // monitoring_kube_prometheus_stack_deploy                  = true
-  // monitoring_kube_prometheus_stack_chart_version           = "10.1.0"
-  // monitoring_kube_prometheus_stack_target_namespaces       = "kube-system|monitoring"
-  // monitoring_kube_prometheus_stack_prometheus_storage_size = "5Gi"
-  // monitoring_kube_prometheus_stack_prometheus_storageclass = "gp2"
-  // monitoring_kube_prometheus_stack_prometheus_retention    = "1d"
-  // monitoring_kube_prometheus_stack_slack_webhook           = "https://dummy.slack.webhook"
-  // monitoring_kube_prometheus_stack_slack_channel           = "#hellman-alerting"
+  monitoring_kube_prometheus_stack_deploy                  = true
+  monitoring_kube_prometheus_stack_chart_version           = "10.1.0"
+  monitoring_kube_prometheus_stack_target_namespaces       = "kube-system|monitoring"
+  monitoring_kube_prometheus_stack_prometheus_storage_size = "5Gi"
+  monitoring_kube_prometheus_stack_prometheus_storageclass = "gp2"
+  monitoring_kube_prometheus_stack_prometheus_retention    = "1d"
+  monitoring_kube_prometheus_stack_slack_webhook           = "https://dummy.slack.webhook"
+  monitoring_kube_prometheus_stack_slack_channel           = "#hellman-alerting"
 
   # --------------------------------------------------
   # Metrics server


### PR DESCRIPTION
This PR enables kube-prometheus-stack in QA which should now make use of the servicemonitor dependency fix