### PR TITLE
enable goldpinger in qa

### DIFF
--- a/test/integration/eu-west-1/k8s-qa18/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa18/services/terragrunt.hcl
@@ -113,7 +113,7 @@ inputs = {
   # Goldpinger
   # --------------------------------------------------
 
-  // monitoring_goldpinger_deploy = true
+  monitoring_goldpinger_deploy = true
 
   # --------------------------------------------------
   # Crossplane


### PR DESCRIPTION
This PR enables goldpinger in QA now that ServiceMonitor fixes have been implemented