### PR TITLE
set atlantis module to generate webhook password

### DIFF
--- a/_sub/compute/helm-atlantis/main.tf
+++ b/_sub/compute/helm-atlantis/main.tf
@@ -7,6 +7,11 @@ locals {
   ]
 }
 
+resource "random_password" "webhook_password" {
+  length = 16
+  special = true
+}
+
 resource "helm_release" "atlantis" {
   name          = "atlantis"
   chart         = "atlantis"
@@ -24,7 +29,7 @@ resource "helm_release" "atlantis" {
 
   set_sensitive {
     name = "github.secret"
-    value = var.webhook_secret
+    value = random_password.webhook_password.result
   }
 
   values = [
@@ -57,7 +62,7 @@ resource "github_repository_webhook" "hook" {
     configuration {
         url = "https://${var.webhook_url}/events"
         content_type = var.webhook_content_type
-        secret = var.webhook_secret
+        secret = random_password.webhook_password.result
         insecure_ssl = false
     }
 

--- a/_sub/compute/helm-atlantis/vars.tf
+++ b/_sub/compute/helm-atlantis/vars.tf
@@ -84,10 +84,6 @@ variable "webhook_url" {
     description = "URL for the deployed Atlantis endpoint listener"
 }
 
-variable "webhook_secret" {
-    description = "Secret used by the Webhook to speak to Atlantis"
-}
-
 variable "webhook_content_type" {
     default = "application/json"
 }

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -486,7 +486,6 @@ module "atlantis" {
   github_organization          = var.atlantis_github_organization
   github_username              = var.atlantis_github_username
   github_repositories          = var.atlantis_github_repositories
-  webhook_secret               = var.atlantis_webhook_secret
   webhook_url                  = var.atlantis_ingress
   webhook_events               = var.atlantis_webhook_events
   aws_access_key               = var.atlantis_aws_access_key

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -485,11 +485,6 @@ variable "atlantis_github_repositories" {
   default     = []
 }
 
-variable "atlantis_webhook_secret" {
-  description = "Secret used by the Webhook to speak to Atlantis"
-  default     = null
-}
-
 variable "atlantis_webhook_content_type" {
   default = "application/json"
 }


### PR DESCRIPTION
This PR removes the provided password from Atlantis for the webhooks it creates and instead uses random_password to generate one. This is preferable as we do not need to see or reuse this password