### PR TITLE
Add Flux CRD delay script.

### DIFF
--- a/_sub/compute/k8s-fluxcd/main.tf
+++ b/_sub/compute/k8s-fluxcd/main.tf
@@ -115,7 +115,7 @@ resource "github_repository_file" "install" {
   Error: flux-system/flux-system failed to run apply: error when creating "/tmp/875186376kubectl_manifest.yaml": the server could not find the requested resource (post kustomizations.kustomize.toolkit.fluxcd.io)
   */
   provisioner "local-exec" {
-    command = "sleep 60"
+    command = "until kubectl --kubeconfig ${var.kubeconfig_path} get crd kustomizations.kustomize.toolkit.fluxcd.io gitrepositories.source.toolkit.fluxcd.io; do sleep 10; done"
   }
 
   lifecycle {

--- a/test/integration/eu-west-1/k8s-qa18/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa18/services/terragrunt.hcl
@@ -56,9 +56,10 @@ inputs = {
   # Platform Flux CD
   # --------------------------------------------------
 
-  // platform_fluxcd_deploy       = true
-  // platform_fluxcd_repo_name    = "platform-manifests-qa"
-  // platform_fluxcd_github_owner = "dfds"
+  platform_fluxcd_deploy       = true
+  platform_fluxcd_release_tag  = "v0.8.2"
+  platform_fluxcd_repo_name    = "platform-manifests-qa"
+  platform_fluxcd_github_owner = "dfds"
 
   # --------------------------------------------------
   # AWS EBS CSI Driver

--- a/test/integration/eu-west-1/k8s-qa18/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa18/services/terragrunt.hcl
@@ -57,7 +57,6 @@ inputs = {
   # --------------------------------------------------
 
   platform_fluxcd_deploy       = true
-  platform_fluxcd_release_tag  = "v0.8.2"
   platform_fluxcd_repo_name    = "platform-manifests-qa"
   platform_fluxcd_github_owner = "dfds"
 

--- a/test/integration/eu-west-1/k8s-qa19/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa19/services/terragrunt.hcl
@@ -56,9 +56,10 @@ inputs = {
   # Platform Flux CD
   # --------------------------------------------------
 
-  // platform_fluxcd_deploy       = true
-  // platform_fluxcd_repo_name    = "platform-manifests-qa"
-  // platform_fluxcd_github_owner = "dfds"
+  platform_fluxcd_deploy       = true
+  platform_fluxcd_release_tag  = "v0.8.2"
+  platform_fluxcd_repo_name    = "platform-manifests-qa"
+  platform_fluxcd_github_owner = "dfds"
 
   # --------------------------------------------------
   # AWS EBS CSI Driver

--- a/test/integration/eu-west-1/k8s-qa19/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa19/services/terragrunt.hcl
@@ -57,10 +57,9 @@ inputs = {
   # --------------------------------------------------
 
   platform_fluxcd_deploy       = true
-  platform_fluxcd_release_tag  = "v0.8.2"
   platform_fluxcd_repo_name    = "platform-manifests-qa"
   platform_fluxcd_github_owner = "dfds"
-
+  
   # --------------------------------------------------
   # AWS EBS CSI Driver
   # --------------------------------------------------


### PR DESCRIPTION
Previously a fixed timeframe delay was used but this caused failures in QA because CRDs were not fully deployed before being utilised.  This change introduces a small bash script that will cause a delay until the CRD's are in place.