### PR TITLE
added special char override to random_password

### DIFF
--- a/_sub/compute/helm-atlantis/main.tf
+++ b/_sub/compute/helm-atlantis/main.tf
@@ -10,6 +10,7 @@ locals {
 resource "random_password" "webhook_password" {
   length = 16
   special = true
+  override_special = "!@#$%&*-_=+:?"
 }
 
 resource "helm_release" "atlantis" {


### PR DESCRIPTION
This PR will restrict the use of certain characters in the random_password resource that can cause issues by using override_special

For example, if `{` is the first generated character in the password it will cause the issue `Error: failed parsing key "github.secret" with value {+H8cc&y1g[%Ny2), list must terminate with '}'` so we do not want to generate this character