### PR TITLE
Add crossplane rbac lists

### DIFF
--- a/_sub/compute/helm-crossplane/main.tf
+++ b/_sub/compute/helm-crossplane/main.tf
@@ -21,3 +21,58 @@ resource "kubernetes_namespace" "namespace" {
     name = var.namespace
   }
 }
+
+
+resource "kubernetes_cluster_role_binding" "crossplane-admin" {
+  count = length(var.crossplane_admin_service_accounts)
+
+  metadata {
+    name = "crossplane-admin-${var.crossplane_admin_service_accounts[count.index].namespace}-${var.crossplane_admin_service_accounts[count.index].serviceaccount}"
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "crossplane-admin"
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = var.crossplane_admin_service_accounts[count.index].serviceaccount
+    namespace = var.crossplane_admin_service_accounts[count.index].namespace
+  }
+}
+
+resource "kubernetes_cluster_role_binding" "crossplane-edit" {
+  count = length(var.crossplane_edit_service_accounts)
+
+  metadata {
+    name = "crossplane-edit-${var.crossplane_edit_service_accounts[count.index].namespace}-${var.crossplane_edit_service_accounts[count.index].serviceaccount}"
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "crossplane-edit"
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = var.crossplane_edit_service_accounts[count.index].serviceaccount
+    namespace = var.crossplane_edit_service_accounts[count.index].namespace
+  }
+}
+
+resource "kubernetes_cluster_role_binding" "crossplane-view" {
+  count = length(var.crossplane_view_service_accounts)
+
+  metadata {
+    name = "crossplane-view-${var.crossplane_view_service_accounts[count.index].namespace}-${var.crossplane_view_service_accounts[count.index].serviceaccount}"
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "crossplane-view"
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = var.crossplane_view_service_accounts[count.index].serviceaccount
+    namespace = var.crossplane_view_service_accounts[count.index].namespace
+  }
+}

--- a/_sub/compute/helm-crossplane/vars.tf
+++ b/_sub/compute/helm-crossplane/vars.tf
@@ -27,3 +27,27 @@ variable "crossplane_providers" {
   type        = list(string)
   description = "List of Crossplane providers to install"
 }
+
+variable "crossplane_admin_service_accounts" {
+  type = list(object({
+    serviceaccount = string
+    namespace = string
+  }))
+  description = "List of service account objects that should have crossplane-admin access"
+}
+
+variable "crossplane_edit_service_accounts" {
+  type = list(object({
+    serviceaccount = string
+    namespace = string
+  }))
+  description = "List of service account objects that should have crossplane-edit access"
+}
+
+variable "crossplane_view_service_accounts" {
+  type = list(object({
+    serviceaccount = string
+    namespace = string
+  }))
+  description = "List of service account objects that should have crossplane-view access"
+}

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -519,4 +519,7 @@ module "crossplane" {
   recreate_pods        = var.crossplane_recreate_pods
   force_update         = var.crossplane_force_update
   crossplane_providers = var.crossplane_providers
+  crossplane_admin_service_accounts = var.crossplane_admin_service_accounts
+  crossplane_edit_service_accounts = var.crossplane_edit_service_accounts
+  crossplane_view_service_accounts = var.crossplane_view_service_accounts
 }

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -628,3 +628,30 @@ variable "crossplane_providers" {
   description = "List of Crossplane providers to install"
   default     = []
 }
+
+variable "crossplane_admin_service_accounts" {
+  type = list(object({
+    serviceaccount = string
+    namespace = string
+  }))
+  description = "List of service account objects that should have crossplane-admin access"
+  default = []
+}
+
+variable "crossplane_edit_service_accounts" {
+  type = list(object({
+    serviceaccount = string
+    namespace = string
+  }))
+  description = "List of service account objects that should have crossplane-edit access"
+  default = []
+}
+
+variable "crossplane_view_service_accounts" {
+  type = list(object({
+    serviceaccount = string
+    namespace = string
+  }))
+  description = "List of service account objects that should have crossplane-view access"
+  default = []
+}

--- a/test/integration/eu-west-1/k8s-qa18/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa18/services/terragrunt.hcl
@@ -105,6 +105,12 @@ inputs = {
   crossplane_deploy        = true
   crossplane_chart_version = "1.0.0"
   crossplane_providers     = ["crossplane/provider-aws:v0.16.0"]
+  crossplane_admin_service_accounts = [
+    {
+      serviceaccount = "default"
+      namespace = "kube-system"
+    }
+  ]
 
   # --------------------------------------------------
   # Atlantis

--- a/test/integration/eu-west-1/k8s-qa19/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa19/services/terragrunt.hcl
@@ -105,6 +105,12 @@ inputs = {
   crossplane_deploy        = true
   crossplane_chart_version = "1.0.0"
   crossplane_providers     = ["crossplane/provider-aws:v0.16.0"]
+  crossplane_admin_service_accounts = [
+    {
+      serviceaccount = "default"
+      namespace = "kube-system"
+    }
+  ]
 
   # --------------------------------------------------
   # Atlantis


### PR DESCRIPTION
This PR adds the ability to supply a list(object) of service accounts (and their namespaces) which will add a clusterrolebinding to the appropriate crossplane clusterrole (crossplane-admin, crossplane-edit, crossplane-view)