### PR TITLE
add crossplane metrics toggle

### DIFF
--- a/_sub/compute/helm-crossplane/main.tf
+++ b/_sub/compute/helm-crossplane/main.tf
@@ -13,6 +13,7 @@ resource "helm_release" "crossplane" {
   values = [
     templatefile("${path.module}/values/values.yaml", {
       crossplane_providers = local.packages_list
+      crossplane_metrics_enabled = var.crossplane_metrics_enabled
   })]
 }
 

--- a/_sub/compute/helm-crossplane/values/values.yaml
+++ b/_sub/compute/helm-crossplane/values/values.yaml
@@ -1,1 +1,4 @@
 ${crossplane_providers}
+
+metrics:
+  enabled: ${crossplane_metrics_enabled}

--- a/_sub/compute/helm-crossplane/vars.tf
+++ b/_sub/compute/helm-crossplane/vars.tf
@@ -51,3 +51,8 @@ variable "crossplane_view_service_accounts" {
   }))
   description = "List of service account objects that should have crossplane-view access"
 }
+
+variable "crossplane_metrics_enabled" {
+  type        = bool
+  description = "Enable crossplane metrics"
+}

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -523,4 +523,5 @@ module "crossplane" {
   crossplane_admin_service_accounts = var.crossplane_admin_service_accounts
   crossplane_edit_service_accounts = var.crossplane_edit_service_accounts
   crossplane_view_service_accounts = var.crossplane_view_service_accounts
+  crossplane_metrics_enabled = var.crossplane_metrics_enabled
 }

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -659,3 +659,9 @@ variable "crossplane_view_service_accounts" {
   description = "List of service account objects that should have crossplane-view access"
   default = []
 }
+
+variable "crossplane_metrics_enabled" {
+  type        = bool
+  description = "Enable crossplane metrics"
+  default = true
+}


### PR DESCRIPTION
This PR lets you enable metrics for Crossplane using the crossplane_metrics_enabled variable set to true or false. It will default to true if crossplane is deployed