### PR TITLE
Deprecated version in provider block

### DIFF
--- a/database/postgres/main.tf
+++ b/database/postgres/main.tf
@@ -3,16 +3,17 @@
 # --------------------------------------------------
 
 terraform {
-  backend "s3" {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.43"
+    }
   }
+  required_version = ">= 0.14"
 }
 
 provider "aws" {
   region  = var.aws_region
-  version = "~> 2.43"
-  #   assume_role {
-  #     role_arn = "${var.aws_assume_role_arn}"
-  #   }
 }
 
 # --------------------------------------------------


### PR DESCRIPTION
Since terraform 0.13 this is deprecated and gives this warning:
```sh
Warning: Version constraints inside provider configuration blocks are deprecated

  on .terraform/modules/database/database/postgres/main.tf line 12, in provider "aws":
  12:   version = "~> 2.43"
```

Aws provider is also now in v3, think it would be good to upgrade at some point.

Also, removing backend to let module users decide the backend themselves.