### PR TITLE
Add parameter family variable

### DIFF
--- a/_sub/database/postgres/main.tf
+++ b/_sub/database/postgres/main.tf
@@ -1,3 +1,6 @@
+locals {
+  engine_family = "${var.engine}${var.engine_version}"
+}
 resource "aws_security_group" "pgsg" {
   name_prefix = "${var.application}-postgres10-sg-${var.environment}"
   description = "Allow all inbound traffic on port ${var.db_port}"
@@ -21,9 +24,9 @@ resource "aws_security_group" "pgsg" {
 
 #Enable SSL on the database by default
 resource "aws_db_parameter_group" "dbparams" {
-  name        = "${var.application}-postgres10-force-ssl-${var.environment}"
-  description = "Force SSL encryption for postgres10"
-  family      = "postgres10"
+  name        = "${var.application}-${var.engine_family}-force-ssl-${var.environment}"
+  description = "Force SSL encryption for ${var.engine_family}"
+  family      = var.engine_family
 
   parameter {
     name  = "rds.force_ssl"

--- a/_sub/database/postgres/main.tf
+++ b/_sub/database/postgres/main.tf
@@ -1,5 +1,5 @@
 locals {
-  engine_family = "${var.engine}${var.engine_version}"
+  engine_family = "${aws_db_instance.postgres.engine}${var.engine_version}"
 }
 resource "aws_security_group" "pgsg" {
   name_prefix = "${var.application}-postgres10-sg-${var.environment}"

--- a/_sub/database/postgres/main.tf
+++ b/_sub/database/postgres/main.tf
@@ -1,8 +1,8 @@
 locals {
-  engine_family = "${aws_db_instance.postgres.engine}${var.engine_version}"
+  engine_family = var.engine_version == null ? "postgres13" : "postgres${var.engine_version}"
 }
 resource "aws_security_group" "pgsg" {
-  name_prefix = "${var.application}-postgres10-sg-${var.environment}"
+  name_prefix = "${var.application}-postgres-sg-${var.environment}"
   description = "Allow all inbound traffic on port ${var.db_port}"
 
   ingress {
@@ -41,7 +41,7 @@ resource "aws_db_parameter_group" "dbparams" {
 #Restore the postgres database with the pre-configured settings
 resource "aws_db_instance" "postgres" {
   engine                  = "postgres"
-  engine_version          = var.engine_version != null ? var.engine_version : null
+  engine_version          = var.engine_version
   publicly_accessible     = "true"
   backup_retention_period = 10
   apply_immediately       = true

--- a/_sub/database/postgres/vars.tf
+++ b/_sub/database/postgres/vars.tf
@@ -46,10 +46,6 @@ variable "skip_final_snapshot" {
 
 variable "engine_version" {
   type        = string
-  description = "RDS engine version"
-  default     = 10
-  validation {
-    condition     = can(regex("^[0-9]+$", var.engine_version))
-    error_message = "Must choose digits-only version (major version), fx 13 in stead of 13.1."
-  }
+  description = "RDS engine version (expects major version)"
+  default     = null
 }

--- a/_sub/database/postgres/vars.tf
+++ b/_sub/database/postgres/vars.tf
@@ -47,5 +47,9 @@ variable "skip_final_snapshot" {
 variable "engine_version" {
   type        = string
   description = "RDS engine version"
-  default     = null
+  default     = 10
+  validation {
+    condition     = can(regex("^[0-9]+$", var.engine_version))
+    error_message = "Must choose digits-only version (major version), fx 13 in stead of 13.1."
+  }
 }

--- a/database/postgres/README.md
+++ b/database/postgres/README.md
@@ -1,12 +1,15 @@
 # Terraform aws rds postgres module
+
 This module is designed to create a database based on an existing snapshot with the recommended settings like ssl.
 
 The connection strings, passwords etc can be found in parameter store in the same account/region as the database.
 
 ## Input requirements (Values are only for examples)
-* db_name = "papp" (Destructive if changed)
-* aws_region = "eu-central-1" (Destructive if changed)
-* application = "application" (Destrutive if changed)
-* db_master_username = "test" (Destrutive if changed)
-* db_master_password = "testtesttest" (Can be used for changing password)
-* skip_final_snapshot = false (Optional and should NOT be set to true for production)
+
+- db_name = "papp" (Destructive if changed)
+- aws_region = "eu-central-1" (Destructive if changed)
+- application = "application" (Destrutive if changed)
+- db_master_username = "test" (Destrutive if changed)
+- db_master_password = "testtesttest" (Can be used for changing password)
+- skip_final_snapshot = false (Optional and should NOT be set to true for production)
+- engine_version = 10 (Must be major version. Cannot be downgraded. Optional, but defaults to 10)

--- a/database/postgres/vars.tf
+++ b/database/postgres/vars.tf
@@ -36,7 +36,7 @@ variable "skip_final_snapshot" {
 variable "engine_version" {
   type        = string
   description = "RDS engine version"
-  default     = null
+  default     = 10
 }
 variable "db_instance_class" {
   type        = string


### PR DESCRIPTION
# UPDATE

After a quick chat, we decided to
1. Use the officially supported terraform rds module if possible
2. Change the approach taken to this feature to string concatenation in stead of anoter variable

--------------

Hardcoded parameter group family makes it impossible to use a db engine version >10. Therefore, I have added another parameter. The change is backwards compatible because the default is still postgres10. I've observed that engine_version is not supplied, terraform will default to the latest version, unless the parameter group is not compatible, in which case it will go for the newest version compatible.

For my use case, I will be ommitting the engine_version variable, but supply the parameter family variable. This will keep my database at the latest compatible version.

I have only manually tested this with this configuration:
```HCL
module "database" {
  source                    = "git::https://github.com/dingobar/infrastructure-modules.git//database/postgres?ref=780afa09a2d9d2674b878703fd708c2f33536e69"
  db_name                   = "mlflow${var.environment[terraform.workspace]}"
  aws_region                = data.aws_region.current.name
  application               = "dfds-mlflow"
  db_master_username        = "superadmin"
  db_master_password        = random_password.rds_master_password.result
  skip_final_snapshot       = var.skip_snapshot[terraform.workspace]
  db_instance_class         = "db.t3.micro"
  db_parameter_group_family = "postgres12"
}
```
as well as with no `db_parameter_group_family`.


Changing `db_parameter_group_family` causes the whole parameter group to be destroyed and re-created, which probably is not an issue.
```sh
  # module.database.module.postgres.aws_db_parameter_group.dbparams must be replaced
-/+ resource "aws_db_parameter_group" "dbparams" {
      [...]
      ~ description = "Force SSL encryption for postgres10" -> "Force SSL encryption for postgres13" # forces replacement
      ~ family      = "postgres10" -> "postgres13" # forces replacement
      [...]
      ~ name        = "dfds-mlflow-postgres10-force-ssl-prod" -> "dfds-mlflow-postgres13-force-ssl-prod" # forces replacement
    }
```