### PR TITLE
Add cloudwatch iam role for grafana

### DIFF
--- a/_sub/compute/helm-kube-prometheus-stack/dependencies.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/dependencies.tf
@@ -1,0 +1,4 @@
+locals {
+  kiam_server_role_arn = "arn:aws:iam::${var.aws_workload_account_id}:role/eks-${var.cluster_name}-kiam-server"
+}
+

--- a/_sub/compute/helm-kube-prometheus-stack/main.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/main.tf
@@ -83,7 +83,7 @@ data "aws_iam_policy_document" "cloudwatch_metrics" {
 
 
 resource "aws_iam_policy" "cloudwatch_metrics" {
-  name = "${var.cluster_name}-monitoring-grafana-cloudwatch"
+  name = var.grafana_iam_role_name
   policy = data.aws_iam_policy_document.cloudwatch_metrics.json
 }
 
@@ -93,7 +93,7 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_metrics" {
 }
 
 resource "aws_iam_role" "cloudwatch_metrics" {
-  name               = "${var.cluster_name}-monitoring-grafana-cloudwatch"
+  name               = var.grafana_iam_role_name
   assume_role_policy = data.aws_iam_policy_document.cloudwatch_metrics_trust.json
 }
 

--- a/_sub/compute/helm-kube-prometheus-stack/values/grafana.yaml
+++ b/_sub/compute/helm-kube-prometheus-stack/values/grafana.yaml
@@ -22,3 +22,5 @@ grafana:
       root_url: ${grafana_root_url}
   plugins:
   - grafana-polystat-panel
+  podAnnotations:
+    iam.amazonaws.com/role: ${grafana_cloudwatch_role}

--- a/_sub/compute/helm-kube-prometheus-stack/vars.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/vars.tf
@@ -44,6 +44,11 @@ variable "grafana_notifier_name" {
   description = "Grafana notifier name"
 }
 
+variable "grafana_iam_role_name" {
+  type        = string
+  description = "Name to be given to the Grafana IAM role"
+}
+
 variable "slack_webhook" {
   type        = string
   description = "Alert Slack webhook"

--- a/_sub/compute/helm-kube-prometheus-stack/vars.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/vars.tf
@@ -1,3 +1,11 @@
+variable "aws_workload_account_id" {
+}
+
+variable "cluster_name" {
+  type = string
+}
+
+
 variable "chart_version" {
   type        = string
   description = "Kube-prometheus-stack helm chart version"

--- a/_sub/compute/helm-kube-prometheus-stack/vars.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/vars.tf
@@ -1,8 +1,11 @@
 variable "aws_workload_account_id" {
+  type        = string
+  description = "Used to set the trust relationship with the correct account"
 }
 
 variable "cluster_name" {
-  type = string
+  type        = string
+  description = "Used to set the trust relationship with the correct cluster's kiam-server role"
 }
 
 

--- a/compute/k8s-services/dependencies.tf
+++ b/compute/k8s-services/dependencies.tf
@@ -148,3 +148,12 @@ locals {
     ]
   }
 }
+
+# --------------------------------------------------
+# Monitoring namespace iam role annotations
+# --------------------------------------------------
+
+locals {
+  grafana_iam_role_name = "${var.eks_cluster_name}-monitoring-grafana-cloudwatch"
+  monitoring_namespace_iam_roles = var.monitoring_kube_prometheus_stack_deploy ? join("|", [var.monitoring_namespace_iam_roles, local.grafana_iam_role_name]) : var.monitoring_namespace_iam_roles
+}

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -422,6 +422,8 @@ module "monitoring_goldpinger" {
 module "monitoring_kube_prometheus_stack" {
   source                          = "../../_sub/compute/helm-kube-prometheus-stack"
   count                           = var.monitoring_kube_prometheus_stack_deploy ? 1 : 0
+  aws_workload_account_id         = var.aws_workload_account_id
+  cluster_name                    = var.eks_cluster_name
   chart_version                   = var.monitoring_kube_prometheus_stack_chart_version
   namespace                       = module.monitoring_namespace[0].name
   priority_class                  = var.monitoring_kube_prometheus_stack_priority_class

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -395,7 +395,7 @@ module "monitoring_namespace" {
   source    = "../../_sub/compute/k8s-namespace"
   count     = var.monitoring_namespace_deploy ? 1 : 0
   name      = "monitoring"
-  iam_roles = var.monitoring_namespace_iam_roles
+  iam_roles = local.monitoring_namespace_iam_roles
 }
 
 
@@ -431,6 +431,7 @@ module "monitoring_kube_prometheus_stack" {
   grafana_ingress_path            = var.monitoring_kube_prometheus_stack_grafana_ingress_path
   grafana_host                    = "grafana.${var.eks_cluster_name}.${var.workload_dns_zone_name}"
   grafana_notifier_name           = "${var.eks_cluster_name}-alerting"
+  grafana_iam_role_name           = local.grafana_iam_role_name
   slack_webhook                   = var.monitoring_kube_prometheus_stack_slack_webhook
   prometheus_storageclass         = var.monitoring_kube_prometheus_stack_prometheus_storageclass
   prometheus_storage_size         = var.monitoring_kube_prometheus_stack_prometheus_storage_size


### PR DESCRIPTION
This PR creates an IAM role with the required permissions to retrieve Cloudwatch metrics. It annotates the Grafana pods and monitoring namespace which is a prerequisite to allow us to remove the IAM key/secret currently set in the Cloudwatch datasource in our Grafana deployment and replace it with the SDK option which will automatically assume the created role via the pod annotation applied