### PR TITLE
moved grafana iam role to own module

### DIFF
--- a/_sub/compute/helm-kube-prometheus-stack/dependencies.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/dependencies.tf
@@ -1,4 +1,1 @@
-locals {
-  kiam_server_role_arn = "arn:aws:iam::${var.aws_workload_account_id}:role/eks-${var.cluster_name}-kiam-server"
-}
 

--- a/_sub/compute/helm-kube-prometheus-stack/vars.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/vars.tf
@@ -1,13 +1,7 @@
-variable "aws_workload_account_id" {
-  type        = string
-  description = "Used to set the trust relationship with the correct account"
-}
-
 variable "cluster_name" {
   type        = string
   description = "Used to set the trust relationship with the correct cluster's kiam-server role"
 }
-
 
 variable "chart_version" {
   type        = string
@@ -47,10 +41,11 @@ variable "grafana_notifier_name" {
   description = "Grafana notifier name"
 }
 
-variable "grafana_iam_role_name" {
+variable "grafana_iam_role_arn" {
   type        = string
-  description = "Name to be given to the Grafana IAM role"
+  description = "Grafana IAM role ARN to add as pod annotation"
 }
+
 
 variable "slack_webhook" {
   type        = string

--- a/compute/k8s-services/dependencies.tf
+++ b/compute/k8s-services/dependencies.tf
@@ -157,3 +157,42 @@ locals {
   grafana_iam_role_name = "${var.eks_cluster_name}-monitoring-grafana-cloudwatch"
   monitoring_namespace_iam_roles = var.monitoring_kube_prometheus_stack_deploy ? join("|", [var.monitoring_namespace_iam_roles, local.grafana_iam_role_name]) : var.monitoring_namespace_iam_roles
 }
+
+# --------------------------------------------------
+# Grafana Cloudwatch IAM role
+# --------------------------------------------------
+
+data "aws_iam_policy_document" "cloudwatch_metrics" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+                "tag:GetResources",
+                "ec2:DescribeTags",
+                "ec2:DescribeRegions",
+                "ec2:DescribeInstances",
+                "cloudwatch:ListMetrics",
+                "cloudwatch:GetMetricStatistics",
+                "cloudwatch:GetMetricData",
+                "cloudwatch:DescribeAlarmsForMetric"
+                ]
+
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "cloudwatch_metrics_trust" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        module.kiam_deploy.server_role_arn,
+      ]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}


### PR DESCRIPTION
This PR creates the IAM role for grafana outside of kube-prometheus-stack to remove the circular dependency between kube-prometheus-stack and kiam that occurs