### PR TITLE
Add velero role cleanup to qa script

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -50,7 +50,7 @@ stages:
         steps:
           - bash: ./src/qa-test-eks.sh init
             displayName: "Init"
-          - bash: ./src/qa-test-eks.sh cleanup qa19
+          - bash: ./src/qa-test-eks.sh cleanup eu-west-1 qa19
             displayName: "Pre-apply cleanup"
             condition: eq(variables['PRE_CLEANUP'], 'true')
           - bash: ./src/qa-test-eks.sh plan-cluster eu-west-1 qa19

--- a/src/qa-test-eks.sh
+++ b/src/qa-test-eks.sh
@@ -6,8 +6,8 @@ ACTION=$1
 # $AWS_DEFAULT_REGION
 
 extra_cleanup () {
-    REGION=$1
-    export CLUSTERNAME=$2
+    REGION=$2
+    CLUSTERNAME=$3
 
     # Remove specific resources that sometimes get left behind (always return true, as resource may have been successfully been cleaned up)
     aws --region "$REGION" iam list-roles --output json | jq -r --arg ROLEPREFIX "eks-${CLUSTERNAME}-" '.Roles[] | select( .RoleName | contains($ROLEPREFIX, "Velero") ) | .RoleName' | xargs -r -L1 aws --region "$REGION" iam delete-role --role-name || true

--- a/src/qa-test-eks.sh
+++ b/src/qa-test-eks.sh
@@ -5,9 +5,7 @@ BASEPATH=./test/integration
 ACTION=$1
 # $AWS_DEFAULT_REGION
 
-extra_cleanup () {
-    REGION=$2
-    CLUSTERNAME=$3
+function extra_cleanup {
 
     # Remove specific resources that sometimes get left behind (always return true, as resource may have been successfully been cleaned up)
     aws --region "$REGION" iam list-roles --output json | jq -r --arg ROLEPREFIX "eks-${CLUSTERNAME}-" '.Roles[] | select( .RoleName | contains($ROLEPREFIX, "Velero") ) | .RoleName' | xargs -r -L1 aws --region "$REGION" iam delete-role --role-name || true
@@ -36,7 +34,7 @@ if [ "$ACTION" = "cleanup" ]; then
     CLUSTERNAME=$3
 
     # Remove specific resources that sometimes get left behind (always return true, as resource may have been successfully been cleaned up)
-    extra_cleanup "$REGION" "$CLUSTERNAME"
+    extra_cleanup
 fi
 
 
@@ -133,7 +131,7 @@ if [ "$ACTION" = "destroy-cluster" ]; then
     terragrunt destroy-all --terragrunt-working-dir "$WORKDIR" --terragrunt-source-update --terragrunt-non-interactive -input=false -auto-approve || RETURN=1
     
     # Remove specific resources that sometimes get left behind (always return true, as resource may have been successfully been cleaned up)
-    extra_cleanup "$REGION" "$CLUSTERNAME"
+    extra_cleanup
 
     # Return false, if any *eseential* commands failed
     if [ $RETURN -ne 0 ]; then

--- a/src/qa-test-eks.sh
+++ b/src/qa-test-eks.sh
@@ -10,7 +10,7 @@ extra_cleanup () {
     export CLUSTERNAME=$2
 
     # Remove specific resources that sometimes get left behind (always return true, as resource may have been successfully been cleaned up)
-    aws --region "$REGION" iam list-roles --output json | jq -r --arg ROLEPREFIX "eks-${CLUSTERNAME}-" '.Roles[] | select( .RoleName | contains($ROLEPREFIX) ) | .RoleName' | xargs -r -L1 aws --region "$REGION" iam delete-role --role-name || true
+    aws --region "$REGION" iam list-roles --output json | jq -r --arg ROLEPREFIX "eks-${CLUSTERNAME}-" '.Roles[] | select( .RoleName | contains($ROLEPREFIX, "Velero") ) | .RoleName' | xargs -r -L1 aws --region "$REGION" iam delete-role --role-name || true
     aws --region "$REGION" ec2 describe-network-interfaces --filters "Name=group-name,Values=eks-${CLUSTERNAME}-node" --query "NetworkInterfaces[].NetworkInterfaceId" --output text | xargs -r -L1 aws --region "$REGION" ec2 delete-network-interface --network-interface-id || true
 }
 


### PR DESCRIPTION
- Provide missing region to the cleanup action
- Remove unnecessary parameters from extra_cleanup function
- Added "Velero" prefix to list of IAM roles cleaned up