### PR TITLE
Ingress to Traefik. Secured by Basic Auth

### DIFF
--- a/_sub/compute/k8s-traefik/dependencies.tf
+++ b/_sub/compute/k8s-traefik/dependencies.tf
@@ -9,5 +9,4 @@ locals {
         "traefik.ingress.kubernetes.io/auth-type" = "basic"
         "traefik.ingress.kubernetes.io/auth-secret" = var.dashboard_secret_name
     }
-    dashboard_ingress_host = "${var.deploy_name}.${var.dns_zone_name}"
 }

--- a/_sub/compute/k8s-traefik/dependencies.tf
+++ b/_sub/compute/k8s-traefik/dependencies.tf
@@ -4,9 +4,14 @@ locals {
     http_port               = 80
     admin_name              = "admin"
     admin_port              = 8080
+    dashboard_secret_name = "${var.deploy_name}-basic-auth"
     dashboard_ingress_annotations   = {
         "kubernetes.io/ingress.class" = "traefik"
         "traefik.ingress.kubernetes.io/auth-type" = "basic"
-        "traefik.ingress.kubernetes.io/auth-secret" = var.dashboard_secret_name
+        "traefik.ingress.kubernetes.io/auth-secret" = local.dashboard_secret_name
+    }
+    dashboard_ingress_name = "${var.deploy_name}-dashboard"
+    dashboard_ingress_labels = {
+        "name" = local.dashboard_ingress_name
     }
 }

--- a/_sub/compute/k8s-traefik/dependencies.tf
+++ b/_sub/compute/k8s-traefik/dependencies.tf
@@ -1,7 +1,12 @@
 locals {
-    label_k8s-app  = var.deploy_name
-    http_name      = "http"
-    http_port      = 80
-    admin_name     = "admin"
-    admin_port     = 8080
+    label_k8s-app           = var.deploy_name
+    http_name               = "http"
+    http_port               = 80
+    admin_name              = "admin"
+    admin_port              = 8080
+    dashboard_ingress_annotations   = {
+        "kubernetes.io/ingress.class" = "traefik"
+        "traefik.ingress.kubernetes.io/auth-type" = "basic"
+        "traefik.ingress.kubernetes.io/auth-secret" = kubernetes_secret.secret.metadata[0].name
+    }
 }

--- a/_sub/compute/k8s-traefik/dependencies.tf
+++ b/_sub/compute/k8s-traefik/dependencies.tf
@@ -9,4 +9,5 @@ locals {
         "traefik.ingress.kubernetes.io/auth-type" = "basic"
         "traefik.ingress.kubernetes.io/auth-secret" = var.dashboard_secret_name
     }
+    dashboard_ingress_host = "${var.deploy_name}.${var.dns_zone_name}"
 }

--- a/_sub/compute/k8s-traefik/dependencies.tf
+++ b/_sub/compute/k8s-traefik/dependencies.tf
@@ -7,6 +7,6 @@ locals {
     dashboard_ingress_annotations   = {
         "kubernetes.io/ingress.class" = "traefik"
         "traefik.ingress.kubernetes.io/auth-type" = "basic"
-        "traefik.ingress.kubernetes.io/auth-secret" = kubernetes_secret.secret.metadata[0].name
+        "traefik.ingress.kubernetes.io/auth-secret" = var.dashboard_secret_name
     }
 }

--- a/_sub/compute/k8s-traefik/main.tf
+++ b/_sub/compute/k8s-traefik/main.tf
@@ -250,7 +250,7 @@ resource "kubernetes_ingress" "ingress" {
 
   spec {
     rule {
-        host = local.dashboard_ingress_host
+        host = var.dashboard_ingress_host
         http {
           path {
             path = var.dashboard_ingress_backend_path

--- a/_sub/compute/k8s-traefik/main.tf
+++ b/_sub/compute/k8s-traefik/main.tf
@@ -250,7 +250,7 @@ resource "kubernetes_ingress" "ingress" {
 
   spec {
     rule {
-        host = var.dashboard_ingress_rule_host
+        host = local.dashboard_ingress_host
         http {
           path {
             path = var.dashboard_ingress_backend_path

--- a/_sub/compute/k8s-traefik/main.tf
+++ b/_sub/compute/k8s-traefik/main.tf
@@ -214,7 +214,7 @@ resource "htpasswd_password" "hash" {
 resource "kubernetes_secret" "secret" {
   count = var.dashboard_deploy ? 1 : 0
   metadata {
-    name = var.dashboard_secret_name
+    name = local.dashboard_secret_name
     namespace = var.namespace
   }
 
@@ -242,10 +242,10 @@ resource "kubernetes_ingress" "ingress" {
   count = var.dashboard_deploy ? 1 : 0
 
   metadata {
-    name        = var.dashboard_ingress_name
+    name        = local.dashboard_ingress_name
     namespace   = var.namespace
     annotations = local.dashboard_ingress_annotations
-    labels      = var.dashboard_ingress_labels
+    labels      = local.dashboard_ingress_labels
   }
 
   spec {

--- a/_sub/compute/k8s-traefik/output.tf
+++ b/_sub/compute/k8s-traefik/output.tf
@@ -1,0 +1,3 @@
+output "dashboard_ingress_host" {
+    value = local.dashboard_ingress_host
+}

--- a/_sub/compute/k8s-traefik/output.tf
+++ b/_sub/compute/k8s-traefik/output.tf
@@ -1,3 +1,3 @@
 output "dashboard_ingress_host" {
-    value = local.dashboard_ingress_host
+    value = var.dashboard_ingress_host
 }

--- a/_sub/compute/k8s-traefik/vars.tf
+++ b/_sub/compute/k8s-traefik/vars.tf
@@ -84,8 +84,7 @@ variable "dashboard_ingress_backend_path" {
   default     = "/"
 }
 
-variable "dashboard_ingress_rule_host" {
+variable "dns_zone_name" {
   type        = string
-  description = "The hostname to access the Traefik dashboard on."
-  default     = null
+  description = "The dns_zone_name. For sandbox this is including the identity name."
 }

--- a/_sub/compute/k8s-traefik/vars.tf
+++ b/_sub/compute/k8s-traefik/vars.tf
@@ -46,6 +46,12 @@ variable "request_memory" {
   default = "128Mi"
 }
 
+variable "dashboard_deploy" {
+  type        = bool
+  description = "Deploy ingress for secure access to Traefik dashboard."
+  default     = false
+}
+
 variable "dashboard_username" {
   type        = string
   description = "Username used for basic authentication."

--- a/_sub/compute/k8s-traefik/vars.tf
+++ b/_sub/compute/k8s-traefik/vars.tf
@@ -49,7 +49,7 @@ variable "request_memory" {
 variable "dashboard_deploy" {
   type        = bool
   description = "Deploy ingress for secure access to Traefik dashboard."
-  default     = false
+  default     = true
 }
 
 variable "dashboard_username" {

--- a/_sub/compute/k8s-traefik/vars.tf
+++ b/_sub/compute/k8s-traefik/vars.tf
@@ -45,3 +45,41 @@ variable "request_memory" {
   description = "(optional) Describes the minimum amount of memory required"
   default = "128Mi"
 }
+
+variable "dashboard_username" {
+  type        = string
+  description = "Username used for basic authentication."
+  default     = "cloudengineer"
+}
+
+variable "dashboard_secret_name" {
+  type        = string
+  description = "Name of the k8s secret to store the credentials for basic authentication."
+  default     = "traefik-basic-auth"
+}
+
+variable "dashboard_ingress_name" {
+  type        = string
+  description = "Name of the ingress, must be unique."
+  default     = "traefik-dashboard"
+}
+
+variable "dashboard_ingress_labels" {
+  type        = map(string)
+  description = "Map of string keys and values that can be used to organize and categorize the ingress."
+  default     = {
+    "name" = "traefik-dashboard"
+  }
+}
+
+variable "dashboard_ingress_backend_path" {
+  type        = string
+  description = "The path for the service entry point."
+  default     = "/"
+}
+
+variable "dashboard_ingress_rule_host" {
+  type        = string
+  description = "The hostname to access the Traefik dashboard on."
+  default     = null
+}

--- a/_sub/compute/k8s-traefik/vars.tf
+++ b/_sub/compute/k8s-traefik/vars.tf
@@ -84,7 +84,7 @@ variable "dashboard_ingress_backend_path" {
   default     = "/"
 }
 
-variable "dns_zone_name" {
+variable "dashboard_ingress_host" {
   type        = string
-  description = "The dns_zone_name. For sandbox this is including the identity name."
+  description = "The alb auth dns name for accessing Traefik."
 }

--- a/_sub/compute/k8s-traefik/vars.tf
+++ b/_sub/compute/k8s-traefik/vars.tf
@@ -58,26 +58,6 @@ variable "dashboard_username" {
   default     = "cloudengineer"
 }
 
-variable "dashboard_secret_name" {
-  type        = string
-  description = "Name of the k8s secret to store the credentials for basic authentication."
-  default     = "traefik-basic-auth"
-}
-
-variable "dashboard_ingress_name" {
-  type        = string
-  description = "Name of the ingress, must be unique."
-  default     = "traefik-dashboard"
-}
-
-variable "dashboard_ingress_labels" {
-  type        = map(string)
-  description = "Map of string keys and values that can be used to organize and categorize the ingress."
-  default     = {
-    "name" = "traefik-dashboard"
-  }
-}
-
 variable "dashboard_ingress_backend_path" {
   type        = string
   description = "The path for the service entry point."

--- a/_sub/compute/k8s-traefik/versions.tf
+++ b/_sub/compute/k8s-traefik/versions.tf
@@ -1,4 +1,10 @@
-
 terraform {
   required_version = ">= 0.12"
+
+    required_providers {
+      htpasswd = {
+        source  = "loafoe/htpasswd"
+        version = "~> 0.9.0"
+      }
+  }
 }

--- a/compute/k8s-services/dependencies.tf
+++ b/compute/k8s-services/dependencies.tf
@@ -197,3 +197,17 @@ data "aws_iam_policy_document" "cloudwatch_metrics_trust" {
     actions = ["sts:AssumeRole"]
   }
 }
+
+# --------------------------------------------------
+# Traefik dashboard secure access
+# --------------------------------------------------
+
+locals {
+  traefik_dashboard_ingress_host = var.workload_dns_zone_name != "oxygen.dfds.cloud" ? "${element(
+    concat(
+      module.traefik_alb_auth_dns.record_name,
+      [""]
+    ),
+    0
+  )}.${var.workload_dns_zone_name}" : local.core_dns_zone_name
+}

--- a/compute/k8s-services/dependencies.tf
+++ b/compute/k8s-services/dependencies.tf
@@ -203,11 +203,14 @@ data "aws_iam_policy_document" "cloudwatch_metrics_trust" {
 # --------------------------------------------------
 
 locals {
-  traefik_dashboard_ingress_host = var.workload_dns_zone_name != "oxygen.dfds.cloud" ? "${element(
+  traefik_dashboard_ingress_host = contains(
+    var.traefik_alb_auth_core_alias,
+    "${var.traefik_svc_name}.${local.core_dns_zone_name}"
+  ) ? "${var.traefik_svc_name}.${local.core_dns_zone_name}" : "${element(
     concat(
       module.traefik_alb_auth_dns.record_name,
       [""]
     ),
     0
-  )}.${var.workload_dns_zone_name}" : local.core_dns_zone_name
+  )}.${var.workload_dns_zone_name}"
 }

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -102,15 +102,16 @@ module "ebs_csi_driver" {
 # --------------------------------------------------
 
 module "traefik_deploy" {
-  source         = "../../_sub/compute/k8s-traefik"
-  deploy         = var.traefik_deploy
-  image_version  = var.traefik_version
-  priority_class = "service-critical"
-  deploy_name    = "traefik"
-  cluster_name   = var.eks_cluster_name
-  replicas       = length(data.terraform_remote_state.cluster.outputs.eks_worker_subnet_ids)
-  http_nodeport  = var.traefik_http_nodeport
-  admin_nodeport = var.traefik_admin_nodeport
+  source            = "../../_sub/compute/k8s-traefik"
+  deploy            = var.traefik_deploy
+  image_version     = var.traefik_version
+  priority_class    = "service-critical"
+  deploy_name       = "traefik"
+  cluster_name      = var.eks_cluster_name
+  replicas          = length(data.terraform_remote_state.cluster.outputs.eks_worker_subnet_ids)
+  http_nodeport     = var.traefik_http_nodeport
+  admin_nodeport    = var.traefik_admin_nodeport
+  dashboard_deploy  = var.traefik_dashboard_deploy
 }
 
 module "traefik_alb_cert" {

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -106,7 +106,7 @@ module "traefik_deploy" {
   deploy                  = var.traefik_deploy
   image_version           = var.traefik_version
   priority_class          = "service-critical"
-  deploy_name             = var.traefik_svc_name
+  deploy_name             = "traefik"
   cluster_name            = var.eks_cluster_name
   replicas                = length(data.terraform_remote_state.cluster.outputs.eks_worker_subnet_ids)
   http_nodeport           = var.traefik_http_nodeport

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -106,7 +106,7 @@ module "traefik_deploy" {
   deploy                  = var.traefik_deploy
   image_version           = var.traefik_version
   priority_class          = "service-critical"
-  deploy_name             = "traefik"
+  deploy_name             = var.traefik_svc_name
   cluster_name            = var.eks_cluster_name
   replicas                = length(data.terraform_remote_state.cluster.outputs.eks_worker_subnet_ids)
   http_nodeport           = var.traefik_http_nodeport

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -102,17 +102,17 @@ module "ebs_csi_driver" {
 # --------------------------------------------------
 
 module "traefik_deploy" {
-  source            = "../../_sub/compute/k8s-traefik"
-  deploy            = var.traefik_deploy
-  image_version     = var.traefik_version
-  priority_class    = "service-critical"
-  deploy_name       = "traefik"
-  cluster_name      = var.eks_cluster_name
-  replicas          = length(data.terraform_remote_state.cluster.outputs.eks_worker_subnet_ids)
-  http_nodeport     = var.traefik_http_nodeport
-  admin_nodeport    = var.traefik_admin_nodeport
-  dns_zone_name     = var.eks_is_sandbox ? "${var.eks_cluster_name}.${var.workload_dns_zone_name}" : local.core_dns_zone_name
-  dashboard_deploy  = var.traefik_dashboard_deploy
+  source                  = "../../_sub/compute/k8s-traefik"
+  deploy                  = var.traefik_deploy
+  image_version           = var.traefik_version
+  priority_class          = "service-critical"
+  deploy_name             = "traefik"
+  cluster_name            = var.eks_cluster_name
+  replicas                = length(data.terraform_remote_state.cluster.outputs.eks_worker_subnet_ids)
+  http_nodeport           = var.traefik_http_nodeport
+  admin_nodeport          = var.traefik_admin_nodeport
+  dashboard_ingress_host  = local.traefik_dashboard_ingress_host
+  dashboard_deploy        = var.traefik_dashboard_deploy
 }
 
 module "traefik_alb_cert" {

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -111,6 +111,7 @@ module "traefik_deploy" {
   replicas          = length(data.terraform_remote_state.cluster.outputs.eks_worker_subnet_ids)
   http_nodeport     = var.traefik_http_nodeport
   admin_nodeport    = var.traefik_admin_nodeport
+  dns_zone_name     = var.eks_is_sandbox ? "${var.eks_cluster_name}.${var.workload_dns_zone_name}" : local.core_dns_zone_name
   dashboard_deploy  = var.traefik_dashboard_deploy
 }
 

--- a/compute/k8s-services/outputs.tf
+++ b/compute/k8s-services/outputs.tf
@@ -17,3 +17,7 @@ output "traefik_alb_anon_dns_name" {
 output "traefik_alb_auth_dns_name" {
   value = "${element(concat(module.traefik_alb_auth_dns.record_name, [""]), 0)}.${var.workload_dns_zone_name}"
 }
+
+output "traefik_dashboard_secure_url" {
+  value = "https://${module.traefik_deploy.dashboard_ingress_host}/dashboard/"
+}

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -129,6 +129,12 @@ variable "traefik_health_check_path" {
   default = "/dashboard/"
 }
 
+variable "traefik_dashboard_deploy" {
+  type        = bool
+  description = "Deploy ingress for secure access to Traefik dashboard."
+  default     = false
+}
+
 
 # --------------------------------------------------
 # Traefik Okta

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -67,11 +67,6 @@ variable "cloudwatchlogs_iam_role_deploy" {
 # Traefik
 # --------------------------------------------------
 
-variable "traefik_svc_name" {
-  type    = string
-  default = "traefik"
-}
-
 variable "traefik_deploy" {
   type    = bool
   default = true

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -137,7 +137,7 @@ variable "traefik_health_check_path" {
 variable "traefik_dashboard_deploy" {
   type        = bool
   description = "Deploy ingress for secure access to Traefik dashboard."
-  default     = false
+  default     = true
 }
 
 

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -67,6 +67,11 @@ variable "cloudwatchlogs_iam_role_deploy" {
 # Traefik
 # --------------------------------------------------
 
+variable "traefik_svc_name" {
+  type    = string
+  default = "traefik"
+}
+
 variable "traefik_deploy" {
   type    = bool
   default = true

--- a/test/integration/eu-west-1/k8s-qa19/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa19/services/terragrunt.hcl
@@ -30,7 +30,6 @@ inputs = {
   traefik_alb_anon_deploy = true
   # traefik_alb_auth_core_alias = ["qa-alias1.dfds.cloud", "qa-alias2.dfds.cloud"]
   traefik_alb_auth_core_alias = []
-  traefik_dashboard_deploy = true
 
   # --------------------------------------------------
   # Blaster

--- a/test/integration/eu-west-1/k8s-qa19/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa19/services/terragrunt.hcl
@@ -30,6 +30,7 @@ inputs = {
   traefik_alb_anon_deploy = true
   # traefik_alb_auth_core_alias = ["qa-alias1.dfds.cloud", "qa-alias2.dfds.cloud"]
   traefik_alb_auth_core_alias = []
+  traefik_dashboard_deploy = true
 
   # --------------------------------------------------
   # Blaster


### PR DESCRIPTION
**Requirements in services/terragrunt.hcl:**

```
traefik_alb_auth_deploy     = true
traefik_dashboard_deploy    = true
```

For production also another DNS alias is required:
`traefik_alb_auth_core_alias = ["build.dfds.cloud", "traefik.dfds.cloud"]`

**Logic:**

When traefik_dashboard_deploy is true, the following will happen:

- A random password will be generated. 32 characters long. Contains alphanumeric characters and symbols.
- This password will be stored as a secure string in the AWS Parameter Store.
- The password will be hashed. 
- Together with a username the hashed value of the password will be stored in a Kubernetes secret.
- This means that the clear text representation of the password can never be retrieved from the secret; only from Parameter Store.
- This Kubernetes secret is used to add Basic Authentication to a new Ingress into the Traefik dashboard.
- The new ingress to access the Traefik dashboard will also be protected by the authenticated ALB.
- The hostname used by the ingress depends on this being a production environment or not. The hostname logic is explained below.

**Ingress hostname logic:**

If the traefik_alb_auth_core_alias has an list item with the value _traefik.dfds.com_ (like it will have in production once the eks-pipeline is updated), the ingress hostname will be _traefik.dfds.com_.

Else (for other environments), the ingress hostname will be internal.cluster-name.capability-name.dfds.cloud