### PR TITLE
qa19 crossplane bump

### DIFF
--- a/test/integration/eu-west-1/k8s-qa19/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa19/services/terragrunt.hcl
@@ -101,8 +101,8 @@ inputs = {
   # --------------------------------------------------
 
   crossplane_deploy        = true
-  crossplane_chart_version = "1.0.0"
-  crossplane_providers     = ["crossplane/provider-aws:v0.16.0"]
+  crossplane_chart_version = "1.2.1"
+  crossplane_providers     = ["crossplane/provider-aws:v0.18.1"]
   crossplane_admin_service_accounts = [
     {
       serviceaccount = "default"


### PR DESCRIPTION
Bump the version of crossplane and aws-provider used in QA