### PR TITLE
change atlantis service from nodeport to clusterip

### DIFF
--- a/_sub/compute/helm-atlantis/values/values.yaml
+++ b/_sub/compute/helm-atlantis/values/values.yaml
@@ -98,6 +98,9 @@ environmentSecrets:
 ingress:
   host: ${atlantis_ingress}
 
+service:
+  type: ClusterIP
+
 repoConfig: |
   ---
   repos:


### PR DESCRIPTION
This PR changes the Atlantis deployment service from its default of NodePort to a ClusterIP as there is no need for it to be bound to nodes when it sits behind an ingress