### PR TITLE
Traefik pod topology spread

### DIFF
--- a/_sub/compute/k8s-traefik-v2/main.tf
+++ b/_sub/compute/k8s-traefik-v2/main.tf
@@ -127,7 +127,7 @@ resource "kubernetes_deployment" "traefik" {
           name  = "traefik"
 
           resources {
-            requests {
+            requests = {
               cpu    = var.request_cpu
               memory = var.request_memory
             }

--- a/_sub/compute/k8s-traefik/main.tf
+++ b/_sub/compute/k8s-traefik/main.tf
@@ -99,13 +99,12 @@ resource "kubernetes_deployment" "traefik" {
         # https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
         topology_spread_constraint {
           topology_key       = "topology.kubernetes.io/zone"
-          when_unsatisfiable = "ScheduleAnyway"
+          when_unsatisfiable = "DoNotSchedule"
+          max_skew           = 2 # allows 1 AZ to be unvailable, while allowing an additional pod can be spun, when deployment is updated
 
           label_selector {
-            match_expressions {
-              key      = "k8s-app"
-              operator = "In"
-              values   = [local.label_k8s-app]
+            match_labels = {
+              k8s-app = local.label_k8s-app
             }
           }
         }

--- a/_sub/compute/k8s-traefik/main.tf
+++ b/_sub/compute/k8s-traefik/main.tf
@@ -99,8 +99,18 @@ resource "kubernetes_deployment" "traefik" {
         # https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
         topology_spread_constraint {
           topology_key       = "topology.kubernetes.io/zone"
+          when_unsatisfiable = "ScheduleAnyway"
+          label_selector {
+            match_labels = {
+              k8s-app = local.label_k8s-app
+            }
+          }
+        }
+
+        topology_spread_constraint {
+          topology_key       = "kubernetes.io/hostname"
           when_unsatisfiable = "DoNotSchedule"
-          max_skew           = 2 # allows 1 AZ to be unvailable, while allowing an additional pod can be spun, when deployment is updated
+          max_skew           = 1 # allow rolling updates on minimal clusters
 
           label_selector {
             match_labels = {

--- a/_sub/compute/k8s-traefik/main.tf
+++ b/_sub/compute/k8s-traefik/main.tf
@@ -95,17 +95,17 @@ resource "kubernetes_deployment" "traefik" {
           }
         }
 
-        affinity {
-          pod_anti_affinity {
-            required_during_scheduling_ignored_during_execution {
-              label_selector {
-                match_expressions {
-                  key = "k8s-app"
-                  operator = "In"
-                  values = [local.label_k8s-app]
-                }
-              }
-              topology_key = "failure-domain.beta.kubernetes.io/zone"
+        # Attempt to spread pods over different availability zones, but still schedule all pods if a zone is unavailable
+        # https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+        topology_spread_constraint {
+          topology_key       = "topology.kubernetes.io/zone"
+          when_unsatisfiable = "ScheduleAnyway"
+
+          label_selector {
+            match_expressions {
+              key      = "k8s-app"
+              operator = "In"
+              values   = [local.label_k8s-app]
             }
           }
         }
@@ -115,7 +115,7 @@ resource "kubernetes_deployment" "traefik" {
           name  = "traefik"
 
           resources {
-            requests {
+            requests = {
               cpu    = var.request_cpu
               memory = var.request_memory
             }
@@ -196,16 +196,16 @@ resource "kubernetes_service" "traefik" {
 # --------------------------------------------------
 
 resource "random_password" "password" {
-  count             = var.dashboard_deploy ? 1 : 0
-  length            = 32
-  special           = true
-  override_special  = "!@#$%&*-_=+:?"
+  count            = var.dashboard_deploy ? 1 : 0
+  length           = 32
+  special          = true
+  override_special = "!@#$%&*-_=+:?"
 }
 
 resource "htpasswd_password" "hash" {
-  count     = var.dashboard_deploy ? 1 : 0
-  password  = random_password.password[0].result
-  salt      = substr(sha512(random_password.password[0].result), 0, 8)
+  count    = var.dashboard_deploy ? 1 : 0
+  password = random_password.password[0].result
+  salt     = substr(sha512(random_password.password[0].result), 0, 8)
 }
 
 # --------------------------------------------------
@@ -214,7 +214,7 @@ resource "htpasswd_password" "hash" {
 resource "kubernetes_secret" "secret" {
   count = var.dashboard_deploy ? 1 : 0
   metadata {
-    name = local.dashboard_secret_name
+    name      = local.dashboard_secret_name
     namespace = var.namespace
   }
 
@@ -250,15 +250,15 @@ resource "kubernetes_ingress" "ingress" {
 
   spec {
     rule {
-        host = var.dashboard_ingress_host
-        http {
-          path {
-            path = var.dashboard_ingress_backend_path
-            backend {
-              service_name = var.deploy_name
-              service_port = local.admin_port
-            }
+      host = var.dashboard_ingress_host
+      http {
+        path {
+          path = var.dashboard_ingress_backend_path
+          backend {
+            service_name = var.deploy_name
+            service_port = local.admin_port
           }
+        }
       }
     }
   }

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -43,7 +43,6 @@ provider "kubernetes" {
   host                   = data.aws_eks_cluster.eks.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.eks.certificate_authority[0].data)
   token                  = data.aws_eks_cluster_auth.eks.token
-  load_config_file       = false
   # config_path            = pathexpand("~/.kube/${var.eks_cluster_name}.config") # no datasources in providers allowed when importing into state (remember to flip above bool to load config)
 }
 

--- a/compute/k8s-services/versions.tf
+++ b/compute/k8s-services/versions.tf
@@ -10,7 +10,7 @@ terraform {
 
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.13.3"
+      version = "~> 2.3.2"
     }
 
     kubectl = {


### PR DESCRIPTION
Currently, we use anti-affinity to ensure Traefik instances were distributed across our different availability zones. This mean:

- We can not scale the number of Traefik instances beyond the number of AZs (currently 3)
- If an AZ goes down, the Traefik instance going down with it, cannot be rescheduled to other AZs, decreasing the capacity of the Traefik service

This PR replaces pod anti-affinity with the more flexible "[Pod topology spread constraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/)". With this, you can use a topology to distribute pods on different AZs, while still allowing some deviation, which in turn allows all the desired instanced to be schedule-able.

On top of this, a second constraint will prevent multiple instances to be scheduled on the same node, but allowing a `max_skew` of 1, to allow for rolling updates on minimal clusters.

This PR includes a significant version bump for the Kubernetes provider.