### PR TITLE
Handle EKS add-ons with native Terraform instead of kubectl

### DIFF
--- a/_sub/compute/eks-addons/dependencies.tf
+++ b/_sub/compute/eks-addons/dependencies.tf
@@ -1,42 +1,35 @@
 # Apply specific versions of Kubernetes add-ons depending on EKS version
-# https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html
+# Cluster:    https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html
+# CNI:        https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
+# CoreDNS:    https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html
+# Kube-proxy: https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html
+
+# Get current default build of an add-on (e.g. 'coredns'):
+# aws eks describe-addon-versions --kubernetes-version 1.18 --addon-name coredns | jq -r '.addons[].addonVersions[] | select(.compatibilities[].defaultVersion == true) | .addonVersion'
 
 locals {
   vpccni_version_map = {
-    "1.15" = "1.7.5"
-    "1.16" = "1.7.5"
-    "1.17" = "1.7.5"
-    "1.18" = "1.7.5"
-    "1.19" = "1.7.5"
-    "1.20" = ""
+    "1.18" = "v1.7.5-eksbuild.2"
+    "1.19" = "v1.7.5-eksbuild.2"
+    "1.20" = "v1.7.5-eksbuild.2"
   }
 
   coredns_version_map = {
-    "1.15" = "1.6.6"
-    "1.16" = "1.6.6"
-    "1.17" = "1.6.6"
-    "1.18" = "1.7.0"
-    "1.19" = "1.8.0"
-    "1.20" = ""
+    "1.18" = "v1.7.0-eksbuild.1"
+    "1.19" = "v1.8.0-eksbuild.1"
+    "1.20" = "v1.8.3-eksbuild.1"
   }
 
   kubeproxy_version_map = {
-    "1.15" = "1.15.11"
-    "1.16" = "1.16.13"
-    "1.17" = "1.17.9"
-    "1.18" = "1.18.9"
-    "1.19" = "1.19.6"
-    "1.20" = ""
+    "1.18" = "v1.18.8-eksbuild.1"
+    "1.19" = "v1.19.6-eksbuild.2"
+    "1.20" = "v1.20.4-eksbuild.2"
   }
 }
 
 # Lookup actual add-on versions
 locals {
-  vpccni_version      = var.vpccni_version_override == "" ? local.vpccni_version_map[var.cluster_version] : var.vpccni_version_override
-  vpccni_minorversion = join(".", slice(split(".", local.vpccni_version), 0, 2))
-  coredns_version     = var.coredns_version_override == "" ? local.coredns_version_map[var.cluster_version] : var.coredns_version_override
-  kubeproxy_version   = var.kubeproxy_version_override == "" ? local.kubeproxy_version_map[var.cluster_version] : var.kubeproxy_version_override
+  vpccni_version    = var.vpccni_version_override == "" ? local.vpccni_version_map[var.cluster_version] : var.vpccni_version_override
+  coredns_version   = var.coredns_version_override == "" ? local.coredns_version_map[var.cluster_version] : var.coredns_version_override
+  kubeproxy_version = var.kubeproxy_version_override == "" ? local.kubeproxy_version_map[var.cluster_version] : var.kubeproxy_version_override
 }
-
-# Get current AWS region
-data "aws_region" "current" {}

--- a/_sub/compute/eks-addons/main.tf
+++ b/_sub/compute/eks-addons/main.tf
@@ -1,36 +1,20 @@
-resource "null_resource" "kubeproxy" {
-  provisioner "local-exec" {
-    command = "kubectl --kubeconfig ${var.kubeconfig_path} -n kube-system set image daemonset.apps/kube-proxy kube-proxy=602401143452.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/eks/kube-proxy:v${local.kubeproxy_version}-eksbuild.1"
-  }
-
-  triggers = {
-    kubeproxy_version = local.kubeproxy_version
-  }
-
-  depends_on = [local.kubeproxy_version]
-
+resource "aws_eks_addon" "vpc-cni" {
+  cluster_name      = var.cluster_name
+  addon_name        = "vpc-cni"
+  addon_version     = local.vpccni_version
+  resolve_conflicts = "OVERWRITE"
 }
 
-resource "null_resource" "coredns" {
-  provisioner "local-exec" {
-    command = "kubectl --kubeconfig ${var.kubeconfig_path} -n kube-system set image deployment.apps/coredns coredns=602401143452.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/eks/coredns:v${local.coredns_version}-eksbuild.1"
-  }
-
-  triggers = {
-    coredns_version = local.coredns_version
-  }
-
-  depends_on = [null_resource.kubeproxy, local.coredns_version]
+resource "aws_eks_addon" "coredns" {
+  cluster_name      = var.cluster_name
+  addon_name        = "coredns"
+  addon_version     = local.coredns_version
+  resolve_conflicts = "OVERWRITE"
 }
 
-resource "null_resource" "vpccni" {
-  provisioner "local-exec" {
-    command = "kubectl --kubeconfig ${var.kubeconfig_path} apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v${local.vpccni_version}/config/v${local.vpccni_minorversion}/aws-k8s-cni.yaml"
-  }
-
-  triggers = {
-    vpccni_version = local.vpccni_version
-  }
-
-  depends_on = [null_resource.coredns, local.vpccni_version]
+resource "aws_eks_addon" "kube-proxy" {
+  cluster_name      = var.cluster_name
+  addon_name        = "kube-proxy"
+  addon_version     = local.kubeproxy_version
+  resolve_conflicts = "OVERWRITE"
 }

--- a/_sub/compute/eks-addons/vars.tf
+++ b/_sub/compute/eks-addons/vars.tf
@@ -1,10 +1,9 @@
-variable "cluster_version" {
+variable "cluster_name" {
   type = string
 }
 
-variable "kubeconfig_path" {
-  type    = string
-  default = null
+variable "cluster_version" {
+  type = string
 }
 
 variable "kubeproxy_version_override" {

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 provider "aws" {
-  region  = var.aws_region
+  region = var.aws_region
 
   assume_role {
     role_arn = var.aws_assume_role_arn
@@ -214,12 +214,12 @@ module "eks_heptio" {
 
 module "eks_addons" {
   source                     = "../../_sub/compute/eks-addons"
-  depends_on                 = [module.eks_heptio]
-  kubeconfig_path            = local.kubeconfig_path
-  cluster_version            = var.eks_cluster_version
+  depends_on                 = [module.eks_cluster]
+  cluster_name               = var.eks_cluster_name
   kubeproxy_version_override = var.eks_addon_kubeproxy_version_override
   coredns_version_override   = var.eks_addon_coredns_version_override
   vpccni_version_override    = var.eks_addon_vpccni_version_override
+  cluster_version            = var.eks_cluster_version
 }
 
 module "k8s_priority_class" {


### PR DESCRIPTION
Replace null resources using `kubectl` with native [`aws_eks_addon`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) resources.

Has the added benefit that the CNI will now be pulled from the ECR registry in the same region as cluster, instead of "us-west-2".

Minimum supported Kubernetes cluster version as of this change is 1.18.