### PR TITLE
Bump pipeline image (no Azure CLI)

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -17,7 +17,7 @@ schedules:
 resources:
   containers:
     - container: prime
-      image: dfdsdk/prime-pipeline:0.5.9
+      image: dfdsdk/prime-pipeline:0.5.10
       env:
         AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
         ARM_CLIENT_SECRET: $(ARM_CLIENT_SECRET)


### PR DESCRIPTION
Bump QA pipeline image to [0.5.10](https://github.com/dfds/prime-pipeline-docker/releases/tag/0.5.10) (no Azure CLI).