### PR TITLE
Avoid rapid ALB target group deregistation

### DIFF
--- a/_sub/compute/eks-alb-auth/main.tf
+++ b/_sub/compute/eks-alb-auth/main.tf
@@ -19,7 +19,7 @@ resource "aws_lb_target_group" "traefik_auth" {
   port                 = var.target_http_port
   protocol             = "HTTP"
   vpc_id               = var.vpc_id
-  deregistration_delay = 0
+  deregistration_delay = 300
 
   health_check {
     path     = var.health_check_path

--- a/_sub/compute/eks-alb/main.tf
+++ b/_sub/compute/eks-alb/main.tf
@@ -19,7 +19,7 @@ resource "aws_lb_target_group" "traefik" {
   port                 = var.target_http_port
   protocol             = "HTTP"
   vpc_id               = var.vpc_id
-  deregistration_delay = 0
+  deregistration_delay = 300
 
   health_check {
     path     = var.health_check_path


### PR DESCRIPTION
Setting the deregistration delay back to its default 300s (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group#deregistration_delay) in alignment with this postmortem https://github.com/dfds/postmortems/blob/master/PM2021-005%20-%20All%20services%20returning%20503%20in%20Kubernetes.md#contributing-factors