### PR TITLE
Ignore changes to target_group_arns on ASG resource

### DIFF
--- a/_sub/compute/eks-nodegroup-unmanaged/main.tf
+++ b/_sub/compute/eks-nodegroup-unmanaged/main.tf
@@ -57,6 +57,10 @@ resource "aws_autoscaling_group" "eks" {
     propagate_at_launch = true
   }
 
+  lifecycle {
+    ignore_changes = [ target_group_arns ]
+  }
+
 }
 
 


### PR DESCRIPTION
ASGs are deployed in the `cluster` phase. Target group and attachment to ASGs in the `services` phase.

After AWS provider bump to 3.x, this causes reconfig of ASGs on every run, where all target groups are detached, and not reattached until `services` phase has completed.

Now changes to `target_group_arns` are ignored on the ASG resource (in the `clusters` phase), as the attachment is managed in the `services` phase anyway.

See https://github.com/hashicorp/terraform-provider-aws/issues/14540.