### PR TITLE
Enable allow volume expansion on storage classes

### DIFF
--- a/_sub/compute/helm-ebs-csi-driver/main.tf
+++ b/_sub/compute/helm-ebs-csi-driver/main.tf
@@ -100,31 +100,34 @@ resource "helm_release" "aws-ebs-csi-driver" {
 resource "kubernetes_storage_class" "csi-gp2" {
   metadata {
     name = "csi-gp2"
+    annotations {
+      "storageclass.kubernetes.io/is-default-class" = "true"
+    }
   }
   storage_provisioner    = "ebs.csi.aws.com"
   reclaim_policy         = "Delete"
   volume_binding_mode    = "WaitForFirstConsumer"
-  allow_volume_expansion = "false"
+  allow_volume_expansion = "true"
   parameters = {
     type = "gp2"
   }
 
 }
 
-# change gp2 so it's no longer the default storageclass
-resource "null_resource" "gp2_removedefault_patch" {
-  provisioner "local-exec" {
-    command = "kubectl --kubeconfig ${var.kubeconfig_path} patch storageclass gp2 -p '{\"metadata\": {\"annotations\":{\"storageclass.kubernetes.io/is-default-class\":\"false\"}}}'"
-  }
+# # change gp2 so it's no longer the default storageclass
+# resource "null_resource" "gp2_removedefault_patch" {
+#   provisioner "local-exec" {
+#     command = "kubectl --kubeconfig ${var.kubeconfig_path} patch storageclass gp2 -p '{\"metadata\": {\"annotations\":{\"storageclass.kubernetes.io/is-default-class\":\"false\"}}}'"
+#   }
 
-  depends_on = [kubernetes_storage_class.csi-gp2]
-}
+#   depends_on = [kubernetes_storage_class.csi-gp2]
+# }
 
-# change csi-gp2 so it becomes the default storageclass
-resource "null_resource" "csi_gp2_adddefault_patch" {
-  provisioner "local-exec" {
-    command = "kubectl --kubeconfig ${var.kubeconfig_path} patch storageclass csi-gp2 -p '{\"metadata\": {\"annotations\":{\"storageclass.kubernetes.io/is-default-class\":\"true\"}}}'"
-  }
+# # change csi-gp2 so it becomes the default storageclass
+# resource "null_resource" "csi_gp2_adddefault_patch" {
+#   provisioner "local-exec" {
+#     command = "kubectl --kubeconfig ${var.kubeconfig_path} patch storageclass csi-gp2 -p '{\"metadata\": {\"annotations\":{\"storageclass.kubernetes.io/is-default-class\":\"true\"}}}'"
+#   }
 
-  depends_on = [kubernetes_storage_class.csi-gp2]
-}
+#   depends_on = [kubernetes_storage_class.csi-gp2]
+# }

--- a/_sub/compute/helm-ebs-csi-driver/main.tf
+++ b/_sub/compute/helm-ebs-csi-driver/main.tf
@@ -121,24 +121,14 @@ locals {
 }
 
 resource "null_resource" "gp2_removedefault_patch" {
-  provisioner "local-exec" {
-    command = "kubectl --kubeconfig ${var.kubeconfig_path} patch storageclass gp2 -p '{\"metadata\": {\"annotations\":{\"storageclass.kubernetes.io/is-default-class\":\"${local.gp2_is_default}\"}}}'"
-  }
 
   depends_on = [kubernetes_storage_class.csi-gp2]
-
   triggers = {
     is_default = local.gp2_is_default
   }
 
+  provisioner "local-exec" {
+    command = "kubectl --kubeconfig ${var.kubeconfig_path} patch storageclass gp2 -p '{\"metadata\": {\"annotations\":{\"storageclass.kubernetes.io/is-default-class\":\"${local.gp2_is_default}\"}}}'"
+  }
 
 }
-
-# # change csi-gp2 so it becomes the default storageclass
-# resource "null_resource" "csi_gp2_adddefault_patch" {
-#   provisioner "local-exec" {
-#     command = "kubectl --kubeconfig ${var.kubeconfig_path} patch storageclass csi-gp2 -p '{\"metadata\": {\"annotations\":{\"storageclass.kubernetes.io/is-default-class\":\"true\"}}}'"
-#   }
-
-#   depends_on = [kubernetes_storage_class.csi-gp2]
-# }


### PR DESCRIPTION
Removal of null resource used to set csi-gp2 as default storage class.  Now handled using the annotations in metadata.
Set allowVolumeExpansion to true for the csi-gp2 storage class.  Note that this only works for new clusters unless you taint the existing instance of the storage class.
