### PR TITLE
Fix various deprecations

### DIFF
--- a/_sub/compute/helm-atlantis/values/values.yaml
+++ b/_sub/compute/helm-atlantis/values/values.yaml
@@ -116,14 +116,14 @@ repoConfig: |
     terragrunt:
       plan:
         steps:
-        - run: terragrunt plan-all -no-color --terragrunt-non-interactive -input=false
+        - run: terragrunt run-all plan -no-color --terragrunt-non-interactive -input=false
       apply:
         steps:
         - run: exit 1
     eks-pipeline:
       plan:
         steps:
-        - run: terragrunt plan-all -no-color --terragrunt-non-interactive -input=false
+        - run: terragrunt run-all plan -no-color --terragrunt-non-interactive -input=false
       apply:
         steps:
         - run: exit 1

--- a/_sub/compute/helm-atlantis/vars.tf
+++ b/_sub/compute/helm-atlantis/vars.tf
@@ -70,13 +70,8 @@ variable "platform_fluxcd_github_token" {
     description = "Github token that the provider uses to perform Github operations for Flux."
 }
 
-variable "github_organization" {
-    description = "Github organization name. Conflicts with github_owner. Leaving unset will use GITHUB_ORGANIZATION environment variable if exists"
-    default = null
-}
-
 variable "github_owner" {
-    description = "Github owner(username). Conflicts with github_organization. Leaving unset will use GITHUB_OWNER environment variable if exists"
+    description = "Github owner (username). Leaving unset will use GITHUB_OWNER environment variable if exists"
     default = null
 }
 

--- a/_sub/compute/helm-atlantis/vars.tf
+++ b/_sub/compute/helm-atlantis/vars.tf
@@ -61,21 +61,11 @@ variable "storage_class" {
 
 ## Github ##
 
-#
-variable "github_token" {
-    description = "Github token that the provider uses to perform Github operations. Leaving unset will fall back to GITHUB_TOKEN environment variable"
-}
-
 variable "platform_fluxcd_github_token" {
     description = "Github token that the provider uses to perform Github operations for Flux."
 }
 
-variable "github_owner" {
-    description = "Github owner (username). Leaving unset will use GITHUB_OWNER environment variable if exists"
-    default = null
-}
 
-#
 variable "github_username" {
     description = "Github username of the account that will post Atlantis comments on PR's"
 }

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -63,9 +63,8 @@ provider "helm" {
 }
 
 provider "github" {
-  token        = var.atlantis_github_token != null ? var.atlantis_github_token : null
-  organization = var.atlantis_github_organization != null ? var.atlantis_github_organization : null
-  owner        = var.atlantis_github_owner != null ? var.atlantis_github_owner : null
+  token        = var.atlantis_github_token
+  owner        = var.atlantis_github_owner
   alias        = "atlantis"
 }
 

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -449,11 +449,6 @@ variable "atlantis_platform_fluxcd_github_token" {
   default     = ""
 }
 
-variable "atlantis_github_organization" {
-  description = "Github organization name. Conflicts with github_owner. Leaving unset will use GITHUB_ORGANIZATION environment variable if exists"
-  default     = null
-}
-
 variable "atlantis_github_owner" {
   description = "Github owner(username). Conflicts with github_organization. Leaving unset will use GITHUB_OWNER environment variable if exists"
   default     = null

--- a/src/qa-test-eks.sh
+++ b/src/qa-test-eks.sh
@@ -56,7 +56,7 @@ if [ "$ACTION" = "apply-shared" ]; then
     WORKDIR="${BASEPATH}/${SUBPATH}"
 
     # Apply the configuration
-    terragrunt apply-all --terragrunt-working-dir "$WORKDIR" --terragrunt-source-update --terragrunt-non-interactive -input=false -auto-approve
+    terragrunt run-all apply --terragrunt-working-dir "$WORKDIR" --terragrunt-source-update --terragrunt-non-interactive -input=false -auto-approve
 fi
 
 
@@ -66,7 +66,7 @@ if [ "$ACTION" = "apply-cluster" ]; then
     WORKDIR="${BASEPATH}/${REGION}/k8s-${CLUSTERNAME}"
 
     # Apply the configuration
-    terragrunt apply-all --terragrunt-working-dir "$WORKDIR" --terragrunt-source-update --terragrunt-non-interactive -input=false -auto-approve
+    terragrunt run-all apply --terragrunt-working-dir "$WORKDIR" --terragrunt-source-update --terragrunt-non-interactive -input=false -auto-approve
 fi
 
 
@@ -156,7 +156,7 @@ if [ "$ACTION" = "destroy-shared" ]; then
     WORKDIR="${BASEPATH}/${SUBPATH}"
 
     # Cleanup
-    terragrunt destroy-all --terragrunt-working-dir "$WORKDIR" --terragrunt-source-update --terragrunt-non-interactive -input=false -auto-approve || RETURN=1
+    terragrunt run-all destroy --terragrunt-working-dir "$WORKDIR" --terragrunt-source-update --terragrunt-non-interactive -input=false -auto-approve || RETURN=1
 
     # Remove specific resources that sometimes get left behind (always return true, as resource may have been successfully been cleaned up)
     cleanup_roles "Velero"

--- a/test/integration/eu-west-1/k8s-qa20/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa20/services/terragrunt.hcl
@@ -6,7 +6,7 @@ terraform {
 
 # Include all settings from the root terraform.tfvars file
 include {
-  path = "${find_in_parent_folders()}"
+  path = find_in_parent_folders()
 }
 
 dependencies {
@@ -37,8 +37,8 @@ inputs = {
   # --------------------------------------------------
 
   traefik_flux_github_owner = "dfds"
-  traefik_flux_repo_name = "platform-manifests-qa"
-  traefik_flux_repo_branch = "main"
+  traefik_flux_repo_name    = "platform-manifests-qa"
+  traefik_flux_repo_branch  = "main"
 
   # --------------------------------------------------
   # Blaster
@@ -107,7 +107,7 @@ inputs = {
   crossplane_admin_service_accounts = [
     {
       serviceaccount = "default"
-      namespace = "kube-system"
+      namespace      = "kube-system"
     }
   ]
 
@@ -122,7 +122,7 @@ inputs = {
 
   atlantis_github_username     = "devex-sa"
   atlantis_github_repositories = ["dfds/qa-dummy-atlantis"]
-  atlantis_github_organization = "dfds"
+  atlantis_github_owner        = "dfds"
   atlantis_webhook_events      = ["issue_comment", "pull_request", "pull_request_review", "push"]
   atlantis_chart_version       = "3.12.10"
 


### PR DESCRIPTION
```
WARN[0000] 'apply-all' is deprecated. Running 'terragrunt run-all apply -input=false -auto-approve' instead. Please update your workflows to use 'terragrunt run-all apply -input=false -auto-approve', as 'apply-all' may be removed in the future!
```

Also goes for `plan-all`.

```
Warning: "organization": [DEPRECATED] Use owner (or GITHUB_OWNER) instead of organization (or GITHUB_ORGANIZATION)
```