### PR TITLE
More deprecation fixes

### DIFF
--- a/_sub/compute/helm-atlantis/values/values.yaml
+++ b/_sub/compute/helm-atlantis/values/values.yaml
@@ -116,14 +116,14 @@ repoConfig: |
     terragrunt:
       plan:
         steps:
-        - run: terragrunt plan-all -no-color --terragrunt-non-interactive -input=false
+        - run: terragrunt run-all plan -no-color --terragrunt-non-interactive -input=false
       apply:
         steps:
         - run: exit 1
     eks-pipeline:
       plan:
         steps:
-        - run: terragrunt plan-all -no-color --terragrunt-non-interactive -input=false
+        - run: terragrunt run-all plan -no-color --terragrunt-non-interactive -input=false
       apply:
         steps:
         - run: exit 1

--- a/_sub/compute/helm-atlantis/vars.tf
+++ b/_sub/compute/helm-atlantis/vars.tf
@@ -70,13 +70,8 @@ variable "platform_fluxcd_github_token" {
     description = "Github token that the provider uses to perform Github operations for Flux."
 }
 
-variable "github_organization" {
-    description = "Github organization name. Conflicts with github_owner. Leaving unset will use GITHUB_ORGANIZATION environment variable if exists"
-    default = null
-}
-
 variable "github_owner" {
-    description = "Github owner(username). Conflicts with github_organization. Leaving unset will use GITHUB_OWNER environment variable if exists"
+    description = "Github owner (username). Leaving unset will use GITHUB_OWNER environment variable if exists"
     default = null
 }
 

--- a/_sub/compute/helm-atlantis/vars.tf
+++ b/_sub/compute/helm-atlantis/vars.tf
@@ -61,21 +61,11 @@ variable "storage_class" {
 
 ## Github ##
 
-#
-variable "github_token" {
-    description = "Github token that the provider uses to perform Github operations. Leaving unset will fall back to GITHUB_TOKEN environment variable"
-}
-
 variable "platform_fluxcd_github_token" {
     description = "Github token that the provider uses to perform Github operations for Flux."
 }
 
-variable "github_owner" {
-    description = "Github owner (username). Leaving unset will use GITHUB_OWNER environment variable if exists"
-    default = null
-}
 
-#
 variable "github_username" {
     description = "Github username of the account that will post Atlantis comments on PR's"
 }

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -464,8 +464,6 @@ module "atlantis" {
   atlantis_image               = var.atlantis_image
   atlantis_image_tag           = var.atlantis_image_tag
   atlantis_ingress             = var.atlantis_ingress
-  github_token                 = var.atlantis_github_token
-  github_organization          = var.atlantis_github_organization
   github_username              = var.atlantis_github_username
   github_repositories          = var.atlantis_github_repositories
   webhook_url                  = var.atlantis_ingress

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -63,9 +63,8 @@ provider "helm" {
 }
 
 provider "github" {
-  token        = var.atlantis_github_token != null ? var.atlantis_github_token : null
-  organization = var.atlantis_github_organization != null ? var.atlantis_github_organization : null
-  owner        = var.atlantis_github_owner != null ? var.atlantis_github_owner : null
+  token        = var.atlantis_github_token
+  owner        = var.atlantis_github_owner
   alias        = "atlantis"
 }
 

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -449,11 +449,6 @@ variable "atlantis_platform_fluxcd_github_token" {
   default     = ""
 }
 
-variable "atlantis_github_organization" {
-  description = "Github organization name. Conflicts with github_owner. Leaving unset will use GITHUB_ORGANIZATION environment variable if exists"
-  default     = null
-}
-
 variable "atlantis_github_owner" {
   description = "Github owner(username). Conflicts with github_organization. Leaving unset will use GITHUB_OWNER environment variable if exists"
   default     = null

--- a/database/postgres-restore/main.tf
+++ b/database/postgres-restore/main.tf
@@ -3,16 +3,11 @@
 # --------------------------------------------------
 
 terraform {
-  backend "s3" {
-  }
+  backend "s3" {}
 }
 
 provider "aws" {
-  region  = var.aws_region
-  version = "~> 2.0"
-  #   assume_role {
-  #     role_arn = "${var.aws_assume_role_arn}"
-  #   }
+  region = var.aws_region
 }
 
 # --------------------------------------------------

--- a/database/postgres-restore/versions.tf
+++ b/database/postgres-restore/versions.tf
@@ -1,4 +1,9 @@
-
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.0.0"
+    }
 }

--- a/database/postgres/main.tf
+++ b/database/postgres/main.tf
@@ -3,16 +3,11 @@
 # --------------------------------------------------
 
 terraform {
-  backend "s3" {
-  }
+  backend "s3" {}
 }
 
 provider "aws" {
-  region  = var.aws_region
-  version = "~> 2.43"
-  #   assume_role {
-  #     role_arn = "${var.aws_assume_role_arn}"
-  #   }
+  region = var.aws_region
 }
 
 # --------------------------------------------------

--- a/database/postgres/versions.tf
+++ b/database/postgres/versions.tf
@@ -1,4 +1,9 @@
-
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.43.0"
+    }
 }

--- a/network/route53-sub-zone/main.tf
+++ b/network/route53-sub-zone/main.tf
@@ -1,12 +1,10 @@
 provider "aws" {
-  region  = var.aws_region
-  version = "~> 2.43"
+  region = var.aws_region
 }
 
 provider "aws" {
-  region  = var.aws_region
-  version = "~> 2.43"
-  alias   = "workload"
+  region = var.aws_region
+  alias  = "workload"
 
   assume_role {
     role_arn = "arn:aws:iam::${var.aws_workload_account_id}:role/${var.prime_role_name}"
@@ -14,10 +12,7 @@ provider "aws" {
 }
 
 terraform {
-  # The configuration for this backend will be filled in by Terragrunt
-  # The configuration for this backend will be filled in by Terragrunt
-  backend "s3" {
-  }
+  backend "s3" {}
 }
 
 # Create zone in workload account

--- a/network/route53-sub-zone/versions.tf
+++ b/network/route53-sub-zone/versions.tf
@@ -1,4 +1,9 @@
-
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.43.0"
+    }
 }

--- a/security/adsync-qa-env/main.tf
+++ b/security/adsync-qa-env/main.tf
@@ -3,13 +3,11 @@
 # --------------------------------------------------
 
 terraform {
-  backend "s3" {
-  }
+  backend "s3" {}
 }
 
 provider "aws" {
-  region  = var.aws_region
-  version = "~> 2.43"
+  region = var.aws_region
   # profile = "qa-orgrole"
 
   #   assume_role {

--- a/security/adsync-qa-env/versions.tf
+++ b/security/adsync-qa-env/versions.tf
@@ -1,4 +1,9 @@
-
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.43.0"
+    }
 }

--- a/security/cloudtrail-master/main.tf
+++ b/security/cloudtrail-master/main.tf
@@ -1,12 +1,9 @@
 provider "aws" {
-  region  = var.aws_region
-  version = "~> 2.43"
+  region = var.aws_region
 }
 
 terraform {
-  # The configuration for this backend will be filled in by Terragrunt
-  backend "s3" {
-  }
+  backend "s3" {}
 }
 
 module "cloudtrail_central" {

--- a/security/cloudtrail-master/versions.tf
+++ b/security/cloudtrail-master/versions.tf
@@ -1,4 +1,9 @@
-
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.43.0"
+    }
 }

--- a/security/iam-roles-master/main.tf
+++ b/security/iam-roles-master/main.tf
@@ -1,10 +1,8 @@
 provider "aws" {
-  version = "~> 2.43"
-  region  = var.aws_region
+  region = var.aws_region
 }
 
 terraform {
-  # The configuration for this backend will be filled in by Terragrunt
   backend "s3" {
   }
 }

--- a/security/iam-roles-master/versions.tf
+++ b/security/iam-roles-master/versions.tf
@@ -1,4 +1,9 @@
-
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.43.0"
+    }
 }

--- a/security/iam-roles-qa/main.tf
+++ b/security/iam-roles-qa/main.tf
@@ -1,11 +1,9 @@
 provider "aws" {
-  version = "~> 2.43"
   region  = var.aws_region
 }
 
 provider "aws" {
   region  = var.aws_region
-  version = "~> 2.43"
   alias   = "workload"
 
   assume_role {
@@ -14,8 +12,6 @@ provider "aws" {
 }
 
 terraform {
-  # The configuration for this backend will be filled in by Terragrunt
-  # The configuration for this backend will be filled in by Terragrunt
   backend "s3" {
   }
 }

--- a/security/iam-roles-qa/versions.tf
+++ b/security/iam-roles-qa/versions.tf
@@ -1,4 +1,9 @@
-
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.43.0"
+    }
 }

--- a/security/iam-users-master/main.tf
+++ b/security/iam-users-master/main.tf
@@ -1,11 +1,8 @@
 provider "aws" {
-  region  = var.aws_region
-  version = "~> 2.43"
+  region = var.aws_region
 }
 
 terraform {
-  # The configuration for this backend will be filled in by Terragrunt
-  # The configuration for this backend will be filled in by Terragrunt
   backend "s3" {
   }
 }
@@ -25,7 +22,6 @@ resource "aws_iam_access_key" "master_user_key" {
   user = aws_iam_user.master_user.name
 }
 
-# 
 resource "aws_iam_user_policy" "assume_noncore_accounts" {
   name   = var.assume_noncore_accounts_iam_policy_name
   user   = aws_iam_user.master_user.id

--- a/security/iam-users-master/versions.tf
+++ b/security/iam-users-master/versions.tf
@@ -1,4 +1,9 @@
-
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.43.0"
+    }
 }

--- a/security/org-account-assume/main.tf
+++ b/security/org-account-assume/main.tf
@@ -1,5 +1,4 @@
 provider "aws" {
-  version = "~> 2.43.0"
   region  = var.aws_region
 
   # Assume role in Master account
@@ -9,13 +8,11 @@ provider "aws" {
 }
 
 provider "aws" {
-  version = "~> 2.43.0"
   region  = var.aws_region
   alias   = "core"
 }
 
 provider "aws" {
-  version = "~> 2.43.0"
   region  = var.aws_region
 
   # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account

--- a/security/org-account-assume/versions.tf
+++ b/security/org-account-assume/versions.tf
@@ -1,4 +1,9 @@
-
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.43.0"
+    }
 }

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -3,7 +3,6 @@
 # --------------------------------------------------
 
 provider "aws" {
-  version = "~> 2.43"
   region  = var.aws_region
 
   # Assume role in Master account
@@ -13,13 +12,11 @@ provider "aws" {
 }
 
 provider "aws" {
-  version = "~> 2.43"
   region  = var.aws_region
   alias   = "core" # this provider does not seem to be used?
 }
 
 provider "aws" {
-  version = "~> 2.43"
   region  = var.aws_region
   alias   = "shared"
 
@@ -30,7 +27,6 @@ provider "aws" {
 }
 
 provider "aws" {
-  version = "~> 2.43"
   region  = var.aws_region
   alias   = "workload"
 

--- a/security/org-account-context/versions.tf
+++ b/security/org-account-context/versions.tf
@@ -1,4 +1,9 @@
-
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.43.0"
+    }
 }

--- a/security/org-capability-root/main.tf
+++ b/security/org-capability-root/main.tf
@@ -7,8 +7,6 @@ provider "aws" {
 }
 
 terraform {
-  # The configuration for this backend will be filled in by Terragrunt
-  # The configuration for this backend will be filled in by Terragrunt
   backend "s3" {
   }
 }

--- a/security/org-capability-root/main.tf
+++ b/security/org-capability-root/main.tf
@@ -3,7 +3,6 @@
 # --------------------------------------------------
 
 provider "aws" {
-  version = "~> 2.43"
   region  = var.aws_region
 }
 

--- a/security/org-capability-root/versions.tf
+++ b/security/org-capability-root/versions.tf
@@ -1,4 +1,9 @@
-
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.43.0"
+    }
 }

--- a/security/ssh-keypair/main.tf
+++ b/security/ssh-keypair/main.tf
@@ -8,8 +8,7 @@ terraform {
 }
 
 provider "aws" {
-  region  = var.aws_region
-  version = "~> 2.43"
+  region = var.aws_region
 
   assume_role {
     role_arn = var.aws_assume_role_arn

--- a/security/ssh-keypair/versions.tf
+++ b/security/ssh-keypair/versions.tf
@@ -1,4 +1,9 @@
-
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.43.0"
+    }
 }

--- a/src/qa-test-eks.sh
+++ b/src/qa-test-eks.sh
@@ -56,7 +56,7 @@ if [ "$ACTION" = "apply-shared" ]; then
     WORKDIR="${BASEPATH}/${SUBPATH}"
 
     # Apply the configuration
-    terragrunt apply-all --terragrunt-working-dir "$WORKDIR" --terragrunt-source-update --terragrunt-non-interactive -input=false -auto-approve
+    terragrunt run-all apply --terragrunt-working-dir "$WORKDIR" --terragrunt-source-update --terragrunt-non-interactive -input=false -auto-approve
 fi
 
 
@@ -66,7 +66,7 @@ if [ "$ACTION" = "apply-cluster" ]; then
     WORKDIR="${BASEPATH}/${REGION}/k8s-${CLUSTERNAME}"
 
     # Apply the configuration
-    terragrunt apply-all --terragrunt-working-dir "$WORKDIR" --terragrunt-source-update --terragrunt-non-interactive -input=false -auto-approve
+    terragrunt run-all apply --terragrunt-working-dir "$WORKDIR" --terragrunt-source-update --terragrunt-non-interactive -input=false -auto-approve
 fi
 
 
@@ -156,7 +156,7 @@ if [ "$ACTION" = "destroy-shared" ]; then
     WORKDIR="${BASEPATH}/${SUBPATH}"
 
     # Cleanup
-    terragrunt destroy-all --terragrunt-working-dir "$WORKDIR" --terragrunt-source-update --terragrunt-non-interactive -input=false -auto-approve || RETURN=1
+    terragrunt run-all destroy --terragrunt-working-dir "$WORKDIR" --terragrunt-source-update --terragrunt-non-interactive -input=false -auto-approve || RETURN=1
 
     # Remove specific resources that sometimes get left behind (always return true, as resource may have been successfully been cleaned up)
     cleanup_roles "Velero"

--- a/storage/s3-eks-public/main.tf
+++ b/storage/s3-eks-public/main.tf
@@ -5,7 +5,6 @@
 terraform {
   backend "s3" {
   }
-  # required_version = "~> 0.11.7"
 }
 
 provider "aws" {

--- a/storage/s3-velero-backup/main.tf
+++ b/storage/s3-velero-backup/main.tf
@@ -5,7 +5,6 @@ terraform {
 
 provider "aws" {
   region  = var.aws_region
-  version = "~> 2.43"
 
   assume_role {
     role_arn = var.aws_assume_role_arn

--- a/storage/s3-velero-backup/versions.tf
+++ b/storage/s3-velero-backup/versions.tf
@@ -1,3 +1,10 @@
+
 terraform {
   required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.43.0"
+    }
 }

--- a/test/integration/eu-west-1/k8s-qa20/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa20/services/terragrunt.hcl
@@ -6,7 +6,7 @@ terraform {
 
 # Include all settings from the root terraform.tfvars file
 include {
-  path = "${find_in_parent_folders()}"
+  path = find_in_parent_folders()
 }
 
 dependencies {
@@ -37,8 +37,8 @@ inputs = {
   # --------------------------------------------------
 
   traefik_flux_github_owner = "dfds"
-  traefik_flux_repo_name = "platform-manifests-qa"
-  traefik_flux_repo_branch = "main"
+  traefik_flux_repo_name    = "platform-manifests-qa"
+  traefik_flux_repo_branch  = "main"
 
   # --------------------------------------------------
   # Blaster
@@ -107,7 +107,7 @@ inputs = {
   crossplane_admin_service_accounts = [
     {
       serviceaccount = "default"
-      namespace = "kube-system"
+      namespace      = "kube-system"
     }
   ]
 
@@ -122,7 +122,7 @@ inputs = {
 
   atlantis_github_username     = "devex-sa"
   atlantis_github_repositories = ["dfds/qa-dummy-atlantis"]
-  atlantis_github_organization = "dfds"
+  atlantis_github_owner        = "dfds"
   atlantis_webhook_events      = ["issue_comment", "pull_request", "pull_request_review", "push"]
   atlantis_chart_version       = "3.12.10"
 


### PR DESCRIPTION
Primarily moving provider version locks into the `required_providers` block in `versions.tf`, but also removing some old comments.