### PR TITLE
Use 'key_name_prefix' instead of 'key_name' to allow easy key pair roll-over

### DIFF
--- a/_sub/compute/ec2-keypair/main.tf
+++ b/_sub/compute/ec2-keypair/main.tf
@@ -1,5 +1,5 @@
 resource "aws_key_pair" "pair" {
-  key_name   = var.name
-  public_key = var.public_key
+  key_name_prefix = "${var.name}-"
+  public_key      = var.public_key
 }
 


### PR DESCRIPTION
…ll-over