### PR TITLE
Traefikv2 ALB config

### DIFF
--- a/_sub/compute/k8s-traefik-flux/dependencies.tf
+++ b/_sub/compute/k8s-traefik-flux/dependencies.tf
@@ -28,6 +28,11 @@ locals {
       "namespace" = var.namespace
     }
     "spec" = {
+      "chart" = {
+        "spec" = {
+          "version" = var.helm_chart_version
+        }
+      }
       "values" = {
         "ports" = {
           "web" = {

--- a/_sub/compute/k8s-traefik-flux/vars.tf
+++ b/_sub/compute/k8s-traefik-flux/vars.tf
@@ -45,6 +45,12 @@ variable "repo_branch" {
   default     = null
 }
 
+variable "helm_chart_version" {
+  type        = string
+  description = "The version of the Traefik v2 Helm Chart that should be used"
+  default     = null
+}
+
 variable "fallback_enabled" {
   type        = bool
   description = "Should a fallback ingressroute be created that routes traffic to Traefik v1"

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -248,6 +248,46 @@ module "traefik_alb_anon_dns_core_alias" {
 
 
 # --------------------------------------------------
+# Traefik v2: For validation and testing
+# --------------------------------------------------
+
+module "traefikv2_alb_anon" {
+  source                = "../../_sub/compute/eks-alb"
+  deploy                = var.traefikv2_test_alb_deploy
+  name                  = "${var.eks_cluster_name}-traefikv2-alb"
+  cluster_name          = var.eks_cluster_name
+  vpc_id                = data.aws_eks_cluster.eks.vpc_config[0].vpc_id
+  subnet_ids            = data.terraform_remote_state.cluster.outputs.eks_worker_subnet_ids
+  autoscaling_group_ids = data.terraform_remote_state.cluster.outputs.eks_worker_autoscaling_group_ids
+  alb_certificate_arn   = module.traefik_alb_cert.certificate_arn
+  nodes_sg_id           = data.terraform_remote_state.cluster.outputs.eks_cluster_nodes_sg_id
+  target_http_port      = var.traefikv2_http_nodeport
+  target_admin_port     = var.traefikv2_admin_nodeport
+  health_check_path     = var.traefikv2_health_check_path
+  access_logs_bucket    = module.traefik_alb_s3_access_logs.name
+}
+
+module "traefikv2_alb_auth" {
+  source                = "../../_sub/compute/eks-alb-auth"
+  deploy                = var.traefikv2_test_alb_deploy
+  name                  = "${var.eks_cluster_name}-traefikv2-alb-auth"
+  cluster_name          = var.eks_cluster_name
+  vpc_id                = data.aws_eks_cluster.eks.vpc_config[0].vpc_id
+  subnet_ids            = data.terraform_remote_state.cluster.outputs.eks_worker_subnet_ids
+  autoscaling_group_ids = data.terraform_remote_state.cluster.outputs.eks_worker_autoscaling_group_ids
+  alb_certificate_arn   = module.traefik_alb_cert.certificate_arn
+  nodes_sg_id           = data.terraform_remote_state.cluster.outputs.eks_cluster_nodes_sg_id
+  azure_tenant_id       = try(module.traefik_alb_auth_appreg[0].tenant_id, "")
+  azure_client_id       = try(module.traefik_alb_auth_appreg[0].application_id, "")
+  azure_client_secret   = try(module.traefik_alb_auth_appreg[0].application_key, "")
+  target_http_port      = var.traefikv2_http_nodeport
+  target_admin_port     = var.traefikv2_admin_nodeport
+  health_check_path     = var.traefikv2_health_check_path
+  access_logs_bucket    = module.traefik_alb_s3_access_logs.name
+}
+
+
+# --------------------------------------------------
 # KIAM
 # --------------------------------------------------
 

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -128,6 +128,7 @@ module "traefik_flux_manifests" {
   source                 = "../../_sub/compute/k8s-traefik-flux"
   count                  = var.traefik_flux_deploy ? 1 : 0
   cluster_name           = var.eks_cluster_name
+  helm_chart_version     = var.traefik_flux_helm_chart_version
   replicas               = length(data.terraform_remote_state.cluster.outputs.eks_worker_subnet_ids)
   http_nodeport          = var.traefik_flux_http_nodeport
   admin_nodeport         = var.traefik_flux_admin_nodeport

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -691,6 +691,12 @@ variable "traefik_flux_repo_branch" {
   default     = null
 }
 
+variable "traefik_flux_helm_chart_version" {
+  type        = string
+  description = "Helm Chart version to be used to deploy Traefik"
+  default     = null
+}
+
 variable "traefik_flux_http_nodeport" {
   type        = number
   description = "Nodeport used by ALB's to connect to the Traefik instance"

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -145,6 +145,30 @@ variable "traefik_dashboard_deploy" {
 
 
 # --------------------------------------------------
+# Traefikv2
+# --------------------------------------------------
+variable "traefikv2_test_alb_deploy" {
+  type    = bool
+  default = false
+}
+
+variable "traefikv2_http_nodeport" {
+  type    = number
+  default = 31000
+}
+
+variable "traefikv2_admin_nodeport" {
+  type    = number
+  default = 31001
+}
+
+variable "traefikv2_health_check_path" {
+  type    = string
+  default = "/dashboard/"
+}
+
+
+# --------------------------------------------------
 # Blaster
 # --------------------------------------------------
 


### PR DESCRIPTION
- Adds flag to allow test ALB's to be deployed with routing to Traefik v2 Node Ports.
- Adds version lock option for Traefik v2 Helm Chart.
- 