### PR TITLE
Fix qa destroy shared

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -86,5 +86,5 @@ stages:
           - destroy_eks_1_20
         condition: ne(variables['NO_DESTROY'], 'true')
         steps:
-          - bash: ./src/qa-test-eks.sh destroy-shared _global eu-west-1
+          - bash: ./src/qa-test-eks.sh destroy-shared eu-west-1 _global
             displayName: "Destroy shared all resources"

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -86,5 +86,5 @@ stages:
           - destroy_eks_1_20
         condition: ne(variables['NO_DESTROY'], 'true')
         steps:
-          - bash: ./src/qa-test-eks.sh destroy-shared _global
+          - bash: ./src/qa-test-eks.sh destroy-shared _global eu-west-1
             displayName: "Destroy shared all resources"

--- a/src/qa-test-eks.sh
+++ b/src/qa-test-eks.sh
@@ -152,7 +152,8 @@ fi
 
 if [ "$ACTION" = "destroy-shared" ]; then
     RETURN=0
-    SUBPATH=$2
+    REGION=$2
+    SUBPATH=$3
     WORKDIR="${BASEPATH}/${SUBPATH}"
 
     # Cleanup


### PR DESCRIPTION
This PR fixes the issue with QA being unable to remove shared roles (i.e Velero) due to a missing region variable by passing the region through the pipeline to the shell script