### PR TITLE
Upgrade CNI for EKS 1.20 to v1.8.0-eksbuild.1

### DIFF
--- a/_sub/compute/eks-addons/dependencies.tf
+++ b/_sub/compute/eks-addons/dependencies.tf
@@ -9,21 +9,18 @@
 
 locals {
   vpccni_version_map = {
-    "1.18" = "v1.7.5-eksbuild.2"
     "1.19" = "v1.7.5-eksbuild.2"
-    "1.20" = "v1.7.5-eksbuild.2"
-    "1.21" = "v1.7.5-eksbuild.2"
+    "1.20" = "v1.8.0-eksbuild.1"
+    "1.21" = "v1.9.0-eksbuild.1"
   }
 
   coredns_version_map = {
-    "1.18" = "v1.7.0-eksbuild.1"
     "1.19" = "v1.8.0-eksbuild.1"
     "1.20" = "v1.8.3-eksbuild.1"
     "1.21" = "v1.8.3-eksbuild.1"
   }
 
   kubeproxy_version_map = {
-    "1.18" = "v1.18.8-eksbuild.1"
     "1.19" = "v1.19.6-eksbuild.2"
     "1.20" = "v1.20.4-eksbuild.2"
     "1.21" = "v1.21.2-eksbuild.2"


### PR DESCRIPTION
Upgrade CNI for EKS 1.20 to v1.8.0-eksbuild.1
Upgrade CNI for EKS 1.21 to v1.9.0-eksbuild.1
Remove support for EKS 1.18