### PR TITLE
Exclude all namespaced alerts not matching target namespaces feature

### DIFF
--- a/_sub/compute/helm-kube-prometheus-stack/main.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/main.tf
@@ -42,7 +42,7 @@ resource "helm_release" "kube_prometheus_stack" {
       alertmanager_priorityclass      = var.priority_class
       alertmanager_slack_channel      = var.slack_channel
       alertmanager_slack_webhook      = var.slack_webhook
-      alertmanager_silence_namespaces = var.alertmanager_silence_namespaces
+      target_namespaces = var.target_namespaces
     }) : file("${path.module}/values/alertmanager-disabled.yaml"),
 
     templatefile("${path.module}/values/rules.yaml", {

--- a/_sub/compute/helm-kube-prometheus-stack/values/alertmanager-slack.yaml
+++ b/_sub/compute/helm-kube-prometheus-stack/values/alertmanager-slack.yaml
@@ -16,8 +16,12 @@ alertmanager:
           alertname: Watchdog
         receiver: 'null'
       - match_re:
-          namespace: ${alertmanager_silence_namespaces}
+          namespace: '.*'
         receiver: 'null'
+        routes:
+          - match_re:
+              namespace: ${target_namespaces}
+            receiver: 'general'
       - match_re:
           alertname: CPUThrottlingHigh
         receiver: 'null'

--- a/_sub/compute/helm-kube-prometheus-stack/vars.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/vars.tf
@@ -78,8 +78,3 @@ variable "target_namespaces" {
   type        = string
   description = "Filter on namespaces"
 }
-
-variable "alertmanager_silence_namespaces" {
-  type        = string
-  description = "Silence namespaces"
-}

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -456,7 +456,6 @@ module "monitoring_kube_prometheus_stack" {
   prometheus_retention            = var.monitoring_kube_prometheus_stack_prometheus_retention
   slack_channel                   = var.monitoring_kube_prometheus_stack_slack_channel
   target_namespaces               = var.monitoring_kube_prometheus_stack_target_namespaces
-  alertmanager_silence_namespaces = var.monitoring_alertmanager_silence_namespaces
 }
 
 

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -327,12 +327,6 @@ variable "monitoring_kube_prometheus_stack_target_namespaces" {
   default     = ".*"
 }
 
-variable "monitoring_alertmanager_silence_namespaces" {
-  type        = string
-  description = "Silence noisy namespaces via alertmanager"
-  default     = ""
-}
-
 # --------------------------------------------------
 # Metrics-Server
 # --------------------------------------------------


### PR DESCRIPTION
We can now get rid of and stop maintaining that long list of unwanted namespace alerts.

See example config on [alertmanager's github page](https://github.com/prometheus/alertmanager#example) to understand more in dept how it works.