### PR TITLE
Fix Traefik install and config race conditions

### DIFF
--- a/_sub/compute/k8s-traefik-flux/main.tf
+++ b/_sub/compute/k8s-traefik-flux/main.tf
@@ -1,18 +1,46 @@
-resource "github_repository_file" "traefik_kustomization" {
+# This module depends on you using Flux CD 2, and have added https://github.com/dfds/platform-apps in your
+# flux-system as instructed in https://github.com/dfds/platform-apps/blob/main/README.md
+resource "github_repository_file" "traefik_helm" {
   repository = var.repo_name
   branch     = local.repo_branch
-  file       = "${local.base_repo_path}/kustomization.yaml"
-  content    = jsonencode(local.kustomization)
+  file       = "${local.cluster_repo_path}/${local.app_install_name}-helm.yaml"
+  content    = jsonencode(local.app_helm_path)
 }
 
-resource "github_repository_file" "traefik_patch" {
+resource "github_repository_file" "traefik_helm_install" {
   repository = var.repo_name
   branch     = local.repo_branch
-  file       = "${local.base_repo_path}/patch.yaml"
-  content    = jsonencode(local.patch)
+  file       = "${local.helm_repo_path}/kustomization.yaml"
+  content    = jsonencode(local.helm_install)
 }
 
-resource "kubectl_manifest" "traefik_fallback" {
-    count       = var.fallback_enabled ? 1 : 0
-    yaml_body   = local.fallback_manifest
+resource "github_repository_file" "traefik_helm_patch" {
+  repository = var.repo_name
+  branch     = local.repo_branch
+  file       = "${local.helm_repo_path}/patch.yaml"
+  content    = jsonencode(local.helm_patch)
+}
+
+resource "github_repository_file" "traefik_config_path" {
+  count      = var.fallback_enabled ? 1 : 0
+  repository = var.repo_name
+  branch     = local.repo_branch
+  file       = "${local.cluster_repo_path}/${local.app_install_name}-config.yaml"
+  content    = jsonencode(local.app_config_path)
+}
+
+resource "github_repository_file" "traefik_config_fallback_ingressroute" {
+  count       = var.fallback_enabled ? 1 : 0
+  repository  = var.repo_name
+  branch      = local.repo_branch
+  file        = "${local.config_repo_path}/ingressroute.yaml"
+  content     = jsonencode(local.config_fallback_ingressroute)
+}
+
+resource "github_repository_file" "traefik_config_init" {
+  count       = var.fallback_enabled ? 1 : 0
+  repository  = var.repo_name
+  branch      = local.repo_branch
+  file        = "${local.config_repo_path}/kustomization.yaml"
+  content     = jsonencode(local.config_init)
 }


### PR DESCRIPTION

It breaks the platform apps into multiple pieces to avoid using one parent app with sub folders (like apps/cluster/app-name(s)), because in that scenario one app with problems can kill reconciliation for all other apps under the same structure. 

Now there is one kustomization called platform-apps-sources which imports Flux sources from https://github.com/dfds/platform-apps/tree/main/sources. 

For each app in platform-apps, there will be a **appname**-helm (for installing and patching the helm chart) and a **appname**-config kustomization for changes that needs to go in AFTER the CRDs are in place. The contents in **appname**-helm and **appname**-config is created using Terraform.

So for traefik it will look like this:

```
flux get kustomizations
NAME                        	READY
apps                        	True
flux-system                 	True
infrastructure              	True
platform-apps-sources       	True
platform-apps-traefik-config	True
platform-apps-traefik-helm  	True
```