### PR TITLE
Add basic auth to Atlantis deployment

### DIFF
--- a/_sub/compute/helm-atlantis/dependencies.tf
+++ b/_sub/compute/helm-atlantis/dependencies.tf
@@ -1,0 +1,5 @@
+locals {
+  auth_secret_name      = "atlantis-basic-auth"
+  ingress_class         = "traefik"
+  ingress_auth_type     = "basic"
+}

--- a/_sub/compute/helm-atlantis/values/values.yaml
+++ b/_sub/compute/helm-atlantis/values/values.yaml
@@ -93,15 +93,18 @@ environmentSecrets:
     secretKeyRef:
       name: gh-credentials
       key: github_token_flux
-   
+
   - name: TF_VAR_atlantis_github_token
     secretKeyRef:
       name: gh-credentials
       key: github_token
 
-
 ingress:
   host: ${atlantis_ingress}
+  annotations:
+    kubernetes.io/ingress.class: ${ingress_class}
+    traefik.ingress.kubernetes.io/auth-type: ${ingress_auth_type}
+    traefik.ingress.kubernetes.io/auth-secret: ${auth_secret_name}
 
 service:
   type: ClusterIP
@@ -127,4 +130,3 @@ repoConfig: |
       apply:
         steps:
         - run: exit 1
-

--- a/_sub/compute/helm-atlantis/vars.tf
+++ b/_sub/compute/helm-atlantis/vars.tf
@@ -110,3 +110,14 @@ variable "secret_key_master" {
   type = string
   description = "Secret for Core account"
 }
+
+variable "auth_username" {
+  type        = string
+  description = "Username used for basic authentication."
+  default     = "cloudengineer"
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "The name of the Kubernetes cluster"
+}

--- a/_sub/compute/helm-atlantis/versions.tf
+++ b/_sub/compute/helm-atlantis/versions.tf
@@ -13,6 +13,11 @@ terraform {
       source = "integrations/github"
     }
 
+    htpasswd = {
+      source  = "loafoe/htpasswd"
+      version = "~> 0.9.0"
+    }
+
   }
 
 }

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -519,6 +519,7 @@ module "atlantis" {
   arm_client_secret            = var.atlantis_arm_client_secret
   platform_fluxcd_github_token = var.atlantis_platform_fluxcd_github_token
   storage_class                = var.atlantis_storage_class
+  cluster_name                 = var.eks_cluster_name
 
   providers = {
     github = github.atlantis


### PR DESCRIPTION
This change implements a few features regarding Atlantis security plus one technical debt.

1. Atlantis UI is getting protected by Basic Authentication in order to prevent random users on the internet accessing the Atlantis UI, and possibly releasing locks on Terraform plans related to pull requests.
2. The password for basic authenticated is automatically generated, and stored in AWS Parameter store. 
3. A hashed value of the password is also stored in a Kubernetes secret.
4. Add the username and urlencoded value of the basic auth password to the webhook payload URL. This is to ensure that authentication doesn't break from Github to Atlantis after basic authentication is added.
5. All the files in helm-atlantis were in CRLF line endings, which doesn't foster platform independency. This was changed to LF lin endings. 

This PR look much greater that it really is. This is due to fixing the line endings from CRLF to LF.

The real changes are:
1. A new file called dependencies.tf that contains locals.
2. Two new vars auth_username and cluster_name in vars.tf
3. htpasswd provider added to versions.tf
4. Three annotations added to the helm values.yaml file
5. New resources in main.tf: random_password.password, htpasswd_password.hash, kubernetes_secret.secret, aws_ssm_parameter.param_atlantis_ui_auth.
6. In main.tf, the new local variables are passed on to the annotations in values.yaml
7. In main.tf, a new URL is constructed to the webhook.


