### PR TITLE
Add support for passing additional arguments to the Traefik Helm chart 

### DIFF
--- a/_sub/compute/k8s-traefik-flux/dependencies.tf
+++ b/_sub/compute/k8s-traefik-flux/dependencies.tf
@@ -93,6 +93,7 @@ locals {
             "nodePort" = var.admin_nodeport
           }
         }
+        "additionalArguments" = var.additional_args
         "deployment" = {
           "replicas" = var.replicas
         }

--- a/_sub/compute/k8s-traefik-flux/vars.tf
+++ b/_sub/compute/k8s-traefik-flux/vars.tf
@@ -51,6 +51,12 @@ variable "helm_chart_version" {
   default     = null
 }
 
+variable "additional_args" {
+  type        = list
+  description = "Pass arguments to the additionalArguments node in the Traefik Helm chart"
+  default     = ["--metrics.prometheus"]
+}
+
 variable "fallback_enabled" {
   type        = bool
   description = "Should a fallback ingressroute be created that routes traffic to Traefik v1"

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -135,6 +135,7 @@ module "traefik_flux_manifests" {
   github_owner           = var.traefik_flux_github_owner
   repo_name              = var.traefik_flux_repo_name
   repo_branch            = var.traefik_flux_repo_branch
+  additional_args        = var.traefik_flux_additional_args
   fallback_enabled       = var.traefik_fallback_enabled
   fallback_svc_namespace = var.traefik_fallback_svc_namespace
   fallback_svc_name      = var.traefik_fallback_svc_name

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -709,6 +709,12 @@ variable "traefik_flux_health_check_path" {
   default     = "/ping/"
 }
 
+variable "traefik_flux_additional_args" {
+  type        = list
+  description = "Pass arguments to the additionalArguments node in the Traefik Helm chart"
+  default     = ["--metrics.prometheus"]
+}
+
 variable "traefik_fallback_enabled" {
   type        = bool
   description = "Should a fallback ingressroute be created that routes traffic to Traefik v1"


### PR DESCRIPTION
This was made because Traefik Helm chart 10.1.2 introduces a breaking change that denies creating IngressRoute to Service mappings across namespaces. That is good from a security point of view, but it is pretty bad during our migration phase, because we need to fallback to Traefik v1 in another namespace than the fallback ingress-route.

On the implementation side, the service config should for now use the folling settings to allow cross-namespace configuration:

```
traefik_flux_helm_chart_version = "10.1.2"
  traefik_flux_additional_args    = [
    "--metrics.prometheus",
    "--providers.kubernetescrd.allowCrossNamespace=true"
  ]
```