### PR TITLE
Prepare Traefik v2 dashboard access

### DIFF
--- a/_sub/compute/k8s-traefik-flux/dependencies.tf
+++ b/_sub/compute/k8s-traefik-flux/dependencies.tf
@@ -104,7 +104,10 @@ locals {
   config_init = {
     "apiVersion" = "kustomize.config.k8s.io/v1beta1"
     "kind" = "Kustomization"
-    "resources" = ["ingressroute.yaml"]
+    "resources" = [
+      "ingressroute-fallback.yaml",
+      "ingressroute-dashboard.yaml"
+    ]
   }
 
   config_fallback_ingressroute = {
@@ -127,6 +130,29 @@ locals {
               "name" = var.fallback_svc_name
               "namespace" = var.fallback_svc_namespace
               "port" = var.fallback_svc_port
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+  config_dashboard_ingressroute = {
+    "apiVersion" = "traefik.containo.us/v1alpha1"
+    "kind" = "IngressRoute"
+    "metadata" = {
+      "name" = "${var.deploy_name}-external-dashboard"
+      "namespace" = var.namespace
+    }
+    "spec" = {
+      "routes" = [
+        {
+          "kind" = "Rule"
+          "match" = "Host(`${var.dashboard_ingress_host}`) && (PathPrefix(`/api`) || PathPrefix(`/dashboard`))"
+          "services" = [
+            {
+              "kind" = "TraefikService"
+              "name" = "api@internal"
             }
           ]
         }

--- a/_sub/compute/k8s-traefik-flux/dependencies.tf
+++ b/_sub/compute/k8s-traefik-flux/dependencies.tf
@@ -145,6 +145,7 @@ locals {
       "namespace" = var.namespace
     }
     "spec" = {
+      "entryPoints" = ["web"]
       "routes" = [
         {
           "kind" = "Rule"

--- a/_sub/compute/k8s-traefik-flux/dependencies.tf
+++ b/_sub/compute/k8s-traefik-flux/dependencies.tf
@@ -149,10 +149,9 @@ locals {
     }
   }
 
-  # The var.is_sandbox ? local.dashboard_middlewares : []
-  # turns on Basic Authentication in sandbox environments.
-  # In prod environments it will depend on ADSF since it is going through the
-  # authenticated ALB and has to match the alias in traefik_alb_auth_core_alias
+  # The var.is_using_alb_auth ? []: local.dashboard_middlewares
+  # turns on Basic Authentication in environments where trafik is not mentioned in the
+  # DNS aliases in var.traefik_alb_auth_core_alias in the service configuration.
   config_dashboard_ingressroute = {
     "apiVersion" = "traefik.containo.us/v1alpha1"
     "kind" = "IngressRoute"
@@ -172,7 +171,7 @@ locals {
               "name" = "api@internal"
             }
           ]
-          "middlewares" = var.is_sandbox ? local.dashboard_middlewares : []
+          "middlewares" = var.is_using_alb_auth ? [] : local.dashboard_middlewares
         }
       ]
     }

--- a/_sub/compute/k8s-traefik-flux/main.tf
+++ b/_sub/compute/k8s-traefik-flux/main.tf
@@ -1,5 +1,9 @@
 # This module depends on you using Flux CD 2, and have added https://github.com/dfds/platform-apps in your
 # flux-system as instructed in https://github.com/dfds/platform-apps/blob/main/README.md
+
+# --------------------------------------------------
+# Create JSON files to be picked up by Flux CD
+# --------------------------------------------------
 resource "github_repository_file" "traefik_helm" {
   repository = var.repo_name
   branch     = local.repo_branch
@@ -45,9 +49,54 @@ resource "github_repository_file" "traefik_config_dashboard_ingressroute" {
   content     = jsonencode(local.config_dashboard_ingressroute)
 }
 
+resource "github_repository_file" "traefik_config_dashboard_secret" {
+  count       = var.dashboard_deploy ? 1 : 0
+  repository  = var.repo_name
+  branch      = local.repo_branch
+  file        = "${local.config_repo_path}/secret-dashboard.yaml"
+  content     = jsonencode(local.config_dashboard_secret)
+}
+
+resource "github_repository_file" "traefik_config_dashboard_middleware" {
+  count       = var.dashboard_deploy ? 1 : 0
+  repository  = var.repo_name
+  branch      = local.repo_branch
+  file        = "${local.config_repo_path}/middleware-dashboard.yaml"
+  content     = jsonencode(local.config_dashboard_middleware)
+}
+
 resource "github_repository_file" "traefik_config_init" {
   repository  = var.repo_name
   branch      = local.repo_branch
   file        = "${local.config_repo_path}/kustomization.yaml"
   content     = jsonencode(local.config_init)
+}
+
+# --------------------------------------------------
+# Generate random password and create a hash for it
+# --------------------------------------------------
+
+resource "random_password" "password" {
+  count            = var.dashboard_deploy ? 1 : 0
+  length           = 32
+  special          = true
+  override_special = "!@#$%&*-_=+:?"
+}
+
+resource "htpasswd_password" "hash" {
+  count    = var.dashboard_deploy ? 1 : 0
+  password = random_password.password[0].result
+  salt     = substr(sha512(random_password.password[0].result), 0, 8)
+}
+
+# --------------------------------------------------
+# Save password in AWS Parameter Store
+# --------------------------------------------------
+resource "aws_ssm_parameter" "param_traefik_dashboard" {
+  count       = var.dashboard_deploy ? 1 : 0
+  name        = "/eks/${var.cluster_name}/traefik-dashboard"
+  description = "Password for accessing the Traefik dashboard"
+  type        = "SecureString"
+  value       = random_password.password[0].result
+  overwrite   = true
 }

--- a/_sub/compute/k8s-traefik-flux/main.tf
+++ b/_sub/compute/k8s-traefik-flux/main.tf
@@ -46,7 +46,6 @@ resource "github_repository_file" "traefik_config_dashboard_ingressroute" {
 }
 
 resource "github_repository_file" "traefik_config_init" {
-  count       = var.fallback_enabled ? 1 : 0 || var.dashboard_deploy ? 1 : 0
   repository  = var.repo_name
   branch      = local.repo_branch
   file        = "${local.config_repo_path}/kustomization.yaml"

--- a/_sub/compute/k8s-traefik-flux/main.tf
+++ b/_sub/compute/k8s-traefik-flux/main.tf
@@ -33,12 +33,20 @@ resource "github_repository_file" "traefik_config_fallback_ingressroute" {
   count       = var.fallback_enabled ? 1 : 0
   repository  = var.repo_name
   branch      = local.repo_branch
-  file        = "${local.config_repo_path}/ingressroute.yaml"
+  file        = "${local.config_repo_path}/ingressroute-fallback.yaml"
   content     = jsonencode(local.config_fallback_ingressroute)
 }
 
+resource "github_repository_file" "traefik_config_dashboard_ingressroute" {
+  count       = var.dashboard_deploy ? 1 : 0
+  repository  = var.repo_name
+  branch      = local.repo_branch
+  file        = "${local.config_repo_path}/ingressroute-dashboard.yaml"
+  content     = jsonencode(local.config_dashboard_ingressroute)
+}
+
 resource "github_repository_file" "traefik_config_init" {
-  count       = var.fallback_enabled ? 1 : 0
+  count       = var.fallback_enabled ? 1 : 0 || var.dashboard_deploy ? 1 : 0
   repository  = var.repo_name
   branch      = local.repo_branch
   file        = "${local.config_repo_path}/kustomization.yaml"

--- a/_sub/compute/k8s-traefik-flux/vars.tf
+++ b/_sub/compute/k8s-traefik-flux/vars.tf
@@ -96,7 +96,7 @@ variable "fallback_svc_port" {
   description = "The service port used for fallback ingress"
 }
 
-variable "is_sandbox" {
+variable "is_using_alb_auth" {
   type    = bool
   default = false
 }

--- a/_sub/compute/k8s-traefik-flux/vars.tf
+++ b/_sub/compute/k8s-traefik-flux/vars.tf
@@ -95,3 +95,14 @@ variable "fallback_svc_port" {
   type        = number
   description = "The service port used for fallback ingress"
 }
+
+variable "dashboard_deploy" {
+  type        = bool
+  description = "Deploy ingressroute for external access to Traefik dashboard."
+  default     = true
+}
+
+variable "dashboard_ingress_host" {
+  type        = string
+  description = "The alb auth dns name for accessing Traefik."
+}

--- a/_sub/compute/k8s-traefik-flux/vars.tf
+++ b/_sub/compute/k8s-traefik-flux/vars.tf
@@ -96,10 +96,21 @@ variable "fallback_svc_port" {
   description = "The service port used for fallback ingress"
 }
 
+variable "is_sandbox" {
+  type    = bool
+  default = false
+}
+
 variable "dashboard_deploy" {
   type        = bool
   description = "Deploy ingressroute for external access to Traefik dashboard."
   default     = true
+}
+
+variable "dashboard_username" {
+  type        = string
+  description = "Username used for basic authentication."
+  default     = "cloudengineer"
 }
 
 variable "dashboard_ingress_host" {

--- a/_sub/compute/k8s-traefik-flux/versions.tf
+++ b/_sub/compute/k8s-traefik-flux/versions.tf
@@ -9,5 +9,10 @@ terraform {
     kubectl = {
       source  = "gavinbunney/kubectl"
     }
+
+    htpasswd = {
+        source  = "loafoe/htpasswd"
+        version = "~> 0.9.0"
+      }
   }
 }

--- a/_sub/compute/k8s-traefik/dependencies.tf
+++ b/_sub/compute/k8s-traefik/dependencies.tf
@@ -4,13 +4,13 @@ locals {
     http_port               = 80
     admin_name              = "admin"
     admin_port              = 8080
-    dashboard_secret_name = "${var.deploy_name}-basic-auth"
+    dashboard_secret_name = "${var.deploy_name}-legacy-basic-auth"
     dashboard_ingress_annotations   = {
         "kubernetes.io/ingress.class" = "traefik"
         "traefik.ingress.kubernetes.io/auth-type" = "basic"
         "traefik.ingress.kubernetes.io/auth-secret" = local.dashboard_secret_name
     }
-    dashboard_ingress_name = "${var.deploy_name}-dashboard"
+    dashboard_ingress_name = "${var.deploy_name}-legacy-dashboard"
     dashboard_ingress_labels = {
         "name" = local.dashboard_ingress_name
     }

--- a/_sub/compute/k8s-traefik/main.tf
+++ b/_sub/compute/k8s-traefik/main.tf
@@ -237,7 +237,7 @@ resource "kubernetes_secret" "secret" {
 # --------------------------------------------------
 resource "aws_ssm_parameter" "param_traefik_dashboard" {
   count       = var.dashboard_deploy ? 1 : 0
-  name        = "/eks/${var.cluster_name}/traefik-dashboard"
+  name        = "/eks/${var.cluster_name}/traefik-legacy-dashboard"
   description = "Password for accessing the Traefik dashboard"
   type        = "SecureString"
   value       = random_password.password[0].result

--- a/compute/k8s-services/dependencies.tf
+++ b/compute/k8s-services/dependencies.tf
@@ -216,12 +216,19 @@ data "aws_iam_policy_document" "cloudwatch_metrics_trust" {
 # ---------------------------------------------------------------------
 
 locals {
-  traefik_dashboard_ingress_prod_host = "traefik.${local.core_dns_zone_name}"
-  traefik_alb_auth_dns_name           = try(module.traefik_alb_auth_dns.record_name["0"], "traefik.${var.eks_cluster_name}")
+  traefik_dashboard_ingress_prod_host = "traefik-legacy.${local.core_dns_zone_name}"
+  traefik_alb_auth_dns_name           = try(module.traefik_alb_auth_dns.record_name["0"], "traefik-legacy.${var.eks_cluster_name}")
   traefik_dashboard_ingress_host = contains(
     var.traefik_alb_auth_core_alias,
     local.traefik_dashboard_ingress_prod_host
   ) ? local.traefik_dashboard_ingress_prod_host : "${local.traefik_alb_auth_dns_name}.${var.workload_dns_zone_name}"
+
+  traefik_flux_dashboard_ingress_prod_host = "traefik.${local.core_dns_zone_name}"
+  traefik_flux_alb_auth_dns_name           = try(module.traefik_alb_auth_dns.record_name["0"], "traefik.${var.eks_cluster_name}")
+  traefik_flux_dashboard_ingress_host = contains(
+    var.traefik_alb_auth_core_alias,
+    local.traefik_flux_dashboard_ingress_prod_host
+  ) ? local.traefik_flux_dashboard_ingress_prod_host : "${local.traefik_flux_alb_auth_dns_name}.${var.workload_dns_zone_name}"
 }
 
 # --------------------------------------------------

--- a/compute/k8s-services/dependencies.tf
+++ b/compute/k8s-services/dependencies.tf
@@ -229,6 +229,7 @@ locals {
     var.traefik_alb_auth_core_alias,
     local.traefik_flux_dashboard_ingress_prod_host
   ) ? local.traefik_flux_dashboard_ingress_prod_host : "${local.traefik_flux_alb_auth_dns_name}.${var.workload_dns_zone_name}"
+  traefik_flux_is_using_alb_auth = contains(var.traefik_alb_auth_core_alias, "traefik") ? true : false
 }
 
 # --------------------------------------------------

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -142,6 +142,7 @@ module "traefik_flux_manifests" {
   fallback_svc_port      = var.traefik_fallback_svc_port
   dashboard_deploy       = var.traefik_flux_dashboard_deploy
   dashboard_ingress_host = local.traefik_flux_dashboard_ingress_host
+  is_sandbox             = var.eks_is_sandbox
 
   providers = {
     github = github.fluxcd

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -140,6 +140,8 @@ module "traefik_flux_manifests" {
   fallback_svc_namespace = var.traefik_fallback_svc_namespace
   fallback_svc_name      = var.traefik_fallback_svc_name
   fallback_svc_port      = var.traefik_fallback_svc_port
+  dashboard_deploy       = var.traefik_flux_dashboard_deploy
+  dashboard_ingress_host = local.traefik_flux_dashboard_ingress_host
 
   providers = {
     github = github.fluxcd

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -142,7 +142,7 @@ module "traefik_flux_manifests" {
   fallback_svc_port      = var.traefik_fallback_svc_port
   dashboard_deploy       = var.traefik_flux_dashboard_deploy
   dashboard_ingress_host = local.traefik_flux_dashboard_ingress_host
-  is_sandbox             = var.eks_is_sandbox
+  is_using_alb_auth      = local.traefik_flux_is_using_alb_auth
 
   providers = {
     github = github.fluxcd

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -178,8 +178,8 @@ module "traefik_alb_auth" {
   azure_tenant_id       = try(module.traefik_alb_auth_appreg[0].tenant_id, "")
   azure_client_id       = try(module.traefik_alb_auth_appreg[0].application_id, "")
   azure_client_secret   = try(module.traefik_alb_auth_appreg[0].application_key, "")
-  target_http_port      = var.traefik_http_nodeport
-  target_admin_port     = var.traefik_admin_nodeport
+  target_http_port      = var.traefik_flux_http_nodeport
+  target_admin_port     = var.traefik_flux_admin_nodeport
   health_check_path     = var.traefik_health_check_path
   access_logs_bucket    = module.traefik_alb_s3_access_logs.name
 }
@@ -218,8 +218,8 @@ module "traefik_alb_anon" {
   autoscaling_group_ids = data.terraform_remote_state.cluster.outputs.eks_worker_autoscaling_group_ids
   alb_certificate_arn   = module.traefik_alb_cert.certificate_arn
   nodes_sg_id           = data.terraform_remote_state.cluster.outputs.eks_cluster_nodes_sg_id
-  target_http_port      = var.traefik_http_nodeport
-  target_admin_port     = var.traefik_admin_nodeport
+  target_http_port      = var.traefik_flux_http_nodeport
+  target_admin_port     = var.traefik_flux_admin_nodeport
   health_check_path     = var.traefik_health_check_path
   access_logs_bucket    = module.traefik_alb_s3_access_logs.name
 }

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -181,8 +181,8 @@ module "traefik_alb_auth" {
   azure_tenant_id       = try(module.traefik_alb_auth_appreg[0].tenant_id, "")
   azure_client_id       = try(module.traefik_alb_auth_appreg[0].application_id, "")
   azure_client_secret   = try(module.traefik_alb_auth_appreg[0].application_key, "")
-  target_http_port      = var.traefik_flux_http_nodeport
-  target_admin_port     = var.traefik_flux_admin_nodeport
+  target_http_port      = var.traefik_http_nodeport
+  target_admin_port     = var.traefik_admin_nodeport
   health_check_path     = var.traefik_health_check_path
   access_logs_bucket    = module.traefik_alb_s3_access_logs.name
 }
@@ -221,8 +221,8 @@ module "traefik_alb_anon" {
   autoscaling_group_ids = data.terraform_remote_state.cluster.outputs.eks_worker_autoscaling_group_ids
   alb_certificate_arn   = module.traefik_alb_cert.certificate_arn
   nodes_sg_id           = data.terraform_remote_state.cluster.outputs.eks_cluster_nodes_sg_id
-  target_http_port      = var.traefik_flux_http_nodeport
-  target_admin_port     = var.traefik_flux_admin_nodeport
+  target_http_port      = var.traefik_http_nodeport
+  target_admin_port     = var.traefik_admin_nodeport
   health_check_path     = var.traefik_health_check_path
   access_logs_bucket    = module.traefik_alb_s3_access_logs.name
 }

--- a/compute/k8s-services/outputs.tf
+++ b/compute/k8s-services/outputs.tf
@@ -22,3 +22,8 @@ output "traefik_alb_auth_dns_name" {
 output "traefik_dashboard_secure_url" {
   value = try("https://${module.traefik_deploy.dashboard_ingress_host}/dashboard/", "Not enabled in service configuration.")
 }
+
+output "traefik_flux_dashboard_external_url" {
+  # try() can't be used on module outputs due to: module.traefik_flux_manifests is a list of object, known only after apply
+  value = var.traefik_flux_dashboard_deploy ? "https://${local.traefik_flux_dashboard_ingress_host}/dashboard/" : "Not enabled in service configuration."
+}

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -761,3 +761,9 @@ variable "traefik_flux_deploy" {
   type    = bool
   default = true
 }
+
+variable "traefik_flux_dashboard_deploy" {
+  type        = bool
+  description = "Deploy ingressroute for external access to Traefik dashboard."
+  default     = true
+}


### PR DESCRIPTION
- Rename existing dashboard resources to include the "-legacy" postfix.
- Create a new access to Traefik v2 dashboard.
- When cluster is configured to use Traefik through authenticated ALB, no basic auth is configured. If configured to go through the anonymous ALB, then basic auth is added. 