### PR TITLE
Use AWS provider 3.55.0 for EC2 and k8s-services provisioning

### DIFF
--- a/_sub/compute/eks-nodegroup-unmanaged/main.tf
+++ b/_sub/compute/eks-nodegroup-unmanaged/main.tf
@@ -61,11 +61,6 @@ resource "aws_autoscaling_group" "eks" {
     ignore_changes = [target_group_arns]
   }
 
-  provisioner "local-exec" {
-    command = "sleep 60" # added arbitrary delay to allow ASG to spin up instances, as a workaround to dfds/cloudplatform#380 and hashicorp/terraform-provider-aws#20404
-  }
-
-
 }
 
 

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -213,11 +213,7 @@ module "eks_heptio" {
 
 module "eks_addons" {
   source = "../../_sub/compute/eks-addons"
-  depends_on = [
-    module.eks_cluster,
-    module.eks_nodegroup1_workers,
-    module.eks_nodegroup2_workers
-  ] # added explicit dependencies on node group modules, as a workaround to dfds/cloudplatform#380 and hashicorp/terraform-provider-aws#20404
+  depends_on = [module.eks_cluster]
   cluster_name               = var.eks_cluster_name
   kubeproxy_version_override = var.eks_addon_kubeproxy_version_override
   coredns_version_override   = var.eks_addon_coredns_version_override

--- a/compute/eks-ec2/versions.tf
+++ b/compute/eks-ec2/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.47.0"
+      version = "~> 3.55.0"
     }
 
     kubernetes = {

--- a/compute/k8s-services/versions.tf
+++ b/compute/k8s-services/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.45.0"
+      version = "~> 3.55.0"
     }
 
     kubernetes = {


### PR DESCRIPTION
Remove hacks introduced to circumvent a coredns addon race condition.

Tested with success in volantis sandbox. (I did a destroy first)

Tested with success in QA20 and QA21: https://dev.azure.com/dfds/CloudEngineering/_build/results?buildId=392870&view=results