### PR TITLE
Feature/cloudplatform 382

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -17,7 +17,7 @@ schedules:
 resources:
   containers:
     - container: prime
-      image: dfdsdk/prime-pipeline:0.6.1
+      image: dfdsdk/prime-pipeline:0.6.2
       env:
         AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
         ARM_CLIENT_SECRET: $(ARM_CLIENT_SECRET)

--- a/test/integration/eu-west-1/k8s-qa21/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa21/services/terragrunt.hcl
@@ -118,7 +118,7 @@ inputs = {
 
   atlantis_deploy        = true
   atlantis_ingress       = "atlantis.qa21-alias1.dfds.cloud"
-  atlantis_image_tag     = "0.0.6"
+  atlantis_image_tag     = "0.0.7"
   atlantis_storage_class = "gp2"
 
   atlantis_github_username     = "devex-sa"


### PR DESCRIPTION
- Use dfdsdk/prime-pipeline:0.6.2 as pipeline container image, that got updated tools
- Use atlantis_image_tag = "0.0.7", and atlantis Docker image is based on dfdsdk/prime-pipeline:0.6.2

Ran successfully in QA: https://dev.azure.com/dfds/CloudEngineering/_build/results?buildId=394767&view=results 