### PR TITLE
Add missing provider config for aws

### DIFF
--- a/_sub/network/route53-record/versions.tf
+++ b/_sub/network/route53-record/versions.tf
@@ -1,4 +1,10 @@
 
 terraform {
   required_version = ">= 0.12"
+
+  required_providers {
+    aws = {
+        source = "hashicorp/aws"
+    }
+  }
 }

--- a/_sub/security/iam-role/versions.tf
+++ b/_sub/security/iam-role/versions.tf
@@ -1,4 +1,10 @@
 
 terraform {
   required_version = ">= 0.12"
+
+  required_providers {
+    aws = {
+        source = "hashicorp/aws"
+    }
+  }
 }


### PR DESCRIPTION
This PR is to avoid warnings like this:

```
Warning: Provider aws is undefined
│
│   on main.tf line 210, in module "traefik_alb_auth_dns_core_alias":
│  210:     aws = aws.core
│
│ Module module.traefik_alb_auth_dns_core_alias does not declare a provider
│ named aws.
│ If you wish to specify a provider configuration for the module, add an
│ entry for aws in the required_providers block within the module.
│
│ (and 2 more similar warnings elsewhere)
```