### PR TITLE
Changes for AzureAD TF provider bump to 2.2.x

### DIFF
--- a/_sub/security/azure-app-registration/main.tf
+++ b/_sub/security/azure-app-registration/main.tf
@@ -1,8 +1,10 @@
 resource "azuread_application" "app" {
   display_name    = var.name
-  homepage        = var.homepage
   identifier_uris = var.identifier_uris
-  reply_urls      = var.reply_urls
+  web {
+    homepage_url    = var.homepage_url
+    redirect_uris      = var.redirect_uris
+  }
 }
 
 resource "azuread_service_principal" "sp" {
@@ -17,6 +19,4 @@ resource "random_password" "password" {
 
 resource "azuread_service_principal_password" "key" {
   service_principal_id = azuread_service_principal.sp.id
-  end_date_relative    = "87660h" # 87660h = 10y
-  value                = random_password.password.result
 }

--- a/_sub/security/azure-app-registration/vars.tf
+++ b/_sub/security/azure-app-registration/vars.tf
@@ -8,7 +8,7 @@ variable "name" {
   description = "The name of the app registration"
 }
 
-variable "homepage" {
+variable "homepage_url" {
   type        = string
   description = "The URL to the application's home page"
 }
@@ -19,7 +19,7 @@ variable "identifier_uris" {
   description = "A list of user-defined URI(s) that uniquely identify a Web application within it's Azure AD tenant, or within a verified custom domain if the application is multi-tenant"
 }
 
-variable "reply_urls" {
+variable "redirect_uris" {
   type        = list(string)
   default     = []
   description = "A list of URLs that user tokens are sent to for sign in, or the redirect URIs that OAuth 2.0 authorization codes and access tokens are sent to"

--- a/_sub/security/azure-app-registration/versions.tf
+++ b/_sub/security/azure-app-registration/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azuread = {
       source  = "hashicorp/azuread"
-      version = ">= 1.2.2"
+      version = "~> 2.2.0"
     }
   }
 }

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -163,9 +163,9 @@ module "traefik_alb_auth_appreg" {
   source          = "../../_sub/security/azure-app-registration"
   count           = var.traefik_alb_auth_deploy ? 1 : 0
   name            = "Kubernetes EKS ${local.eks_fqdn} cluster"
-  homepage        = "https://${local.eks_fqdn}"
   identifier_uris = ["https://${local.eks_fqdn}"]
-  reply_urls      = local.traefik_alb_auth_appreg_reply_urls
+  homepage_url    = "https://${local.eks_fqdn}"
+  redirect_uris   = local.traefik_alb_auth_appreg_reply_urls
 }
 
 module "traefik_alb_auth" {

--- a/compute/k8s-services/versions.tf
+++ b/compute/k8s-services/versions.tf
@@ -25,7 +25,7 @@ terraform {
 
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 1.6.0"
+      version = "~> 2.2.0"
     }
 
     github = {


### PR DESCRIPTION
Includes modifications to allow the Terraform provider for AzureAD to be incremented from 1.6.x to 2.2.x.

Some variable names have also been updated in order to align them with the modified parameter names used by the new provider.