### PR TITLE
Cleanup redundant null logic

### DIFF
--- a/_sub/compute/helm-atlantis/main.tf
+++ b/_sub/compute/helm-atlantis/main.tf
@@ -59,7 +59,7 @@ resource "helm_release" "atlantis" {
   name             = "atlantis"
   chart            = "atlantis"
   repository       = "https://runatlantis.github.io/helm-charts"
-  version          = var.chart_version != null ? var.chart_version : null
+  version          = var.chart_version
   namespace        = var.namespace
   create_namespace = false
   recreate_pods    = true
@@ -77,15 +77,15 @@ resource "helm_release" "atlantis" {
 
   values = [
     templatefile("${path.module}/values/values.yaml", {
-      atlantis_ingress    = var.atlantis_ingress,
-      ingress_class       = local.ingress_class,
-      ingress_auth_type   = local.ingress_auth_type,
-      auth_secret_name    = local.auth_secret_name,
-      atlantis_image      = var.atlantis_image,
-      atlantis_image_tag  = var.atlantis_image_tag,
-      github_username     = var.github_username,
-      github_repos        = join(",", local.full_github_repo_names)
-      storage_class       = var.storage_class
+      atlantis_ingress   = var.atlantis_ingress,
+      ingress_class      = local.ingress_class,
+      ingress_auth_type  = local.ingress_auth_type,
+      auth_secret_name   = local.auth_secret_name,
+      atlantis_image     = var.atlantis_image,
+      atlantis_image_tag = var.atlantis_image_tag,
+      github_username    = var.github_username,
+      github_repos       = join(",", local.full_github_repo_names)
+      storage_class      = var.storage_class
   })]
 
   depends_on = [kubernetes_secret.aws]

--- a/_sub/compute/helm-atlantis/vars.tf
+++ b/_sub/compute/helm-atlantis/vars.tf
@@ -1,113 +1,114 @@
 ## Atlantis ##
 
 variable "namespace" {
-  type = string
+  type        = string
   description = ""
-  default = "atlantis"
+  default     = "atlantis"
 }
 
 variable "chart_version" {
-  type = string
+  type        = string
   description = ""
+  default     = null
 }
 
 variable "atlantis_ingress" {
-  type = string
+  type        = string
   description = ""
 }
 
 variable "atlantis_image" {
-  type = string
+  type        = string
   description = ""
-  default = "dfdsdk/atlantis-prime-pipeline"
+  default     = "dfdsdk/atlantis-prime-pipeline"
 }
 
 variable "atlantis_image_tag" {
-  type = string
+  type        = string
   description = "Tag of the Atlantis image to use"
-  default = "latest"
+  default     = "latest"
 }
 
 variable "github_repositories" {
-    description = "List of repositories to whitelist for Atlantis"
-    type = list(string)
-    default = []
+  description = "List of repositories to whitelist for Atlantis"
+  type        = list(string)
+  default     = []
 }
 
 variable "arm_tenant_id" {
-  type = string
+  type        = string
   description = ""
 }
 
 variable "arm_subscription_id" {
-  type = string
+  type        = string
   description = ""
 }
 
 variable "arm_client_id" {
-  type = string
+  type        = string
   description = ""
 }
 
 variable "arm_client_secret" {
-  type = string
+  type        = string
   description = ""
 }
 
 variable "storage_class" {
-  type = string
+  type        = string
   description = "Storage class to use for the persistent volume"
 }
 
 ## Github ##
 variable "github_token" {
-    description = "Github token that the provider uses to perform Github operations. Leaving unset will fall back to GITHUB_TOKEN environment variable"
+  description = "Github token that the provider uses to perform Github operations. Leaving unset will fall back to GITHUB_TOKEN environment variable"
 }
 
 variable "platform_fluxcd_github_token" {
-    description = "Github token that the provider uses to perform Github operations for Flux."
+  description = "Github token that the provider uses to perform Github operations for Flux."
 }
 
 
 variable "github_username" {
-    description = "Github username of the account that will post Atlantis comments on PR's"
+  description = "Github username of the account that will post Atlantis comments on PR's"
 }
 
 variable "webhook_url" {
-    description = "URL for the deployed Atlantis endpoint listener"
+  description = "URL for the deployed Atlantis endpoint listener"
 }
 
 variable "webhook_content_type" {
-    default = "application/json"
+  default = "application/json"
 }
 
 variable "webhook_insecure_ssl" {
-    default = false
+  default = false
 }
 
 variable "webhook_events" {
-    description = "A list of events that should trigger the webhook"
-    default = []
-    type = list(string)
+  description = "A list of events that should trigger the webhook"
+  default     = []
+  type        = list(string)
 }
 
 ## Kubernetes ##
 
 variable "aws_access_key" {
-    description = "AWS Access Key"
+  description = "AWS Access Key"
 }
 
 variable "aws_secret" {
-    description = "AWS Secret"
+  description = "AWS Secret"
 }
 
 variable "access_key_master" {
-  type = string
+  type        = string
   description = "Access Key for Core account"
 }
 
 variable "secret_key_master" {
-  type = string
+  type        = string
   description = "Secret for Core account"
 }
 

--- a/_sub/compute/helm-goldpinger/main.tf
+++ b/_sub/compute/helm-goldpinger/main.tf
@@ -2,7 +2,7 @@ resource "helm_release" "goldpinger" {
   name          = "goldpinger"
   chart         = "goldpinger"
   repository    = "https://charts.helm.sh/stable"
-  version       = var.chart_version != null ? var.chart_version : null
+  version       = var.chart_version
   namespace     = var.namespace
   recreate_pods = true
   force_update  = false
@@ -23,7 +23,7 @@ resource "helm_release" "goldpinger" {
   }
 
   set {
-    name = "serviceMonitor.selector.release"
+    name  = "serviceMonitor.selector.release"
     value = "monitoring"
   }
 

--- a/_sub/compute/helm-goldpinger/vars.tf
+++ b/_sub/compute/helm-goldpinger/vars.tf
@@ -8,6 +8,10 @@ variable "namespace" {
   type        = string
   description = "Namespace to apply goldpinger in"
   default     = "monitoring"
+  validation {
+    condition     = can(regex("[a-z]+", var.string))
+    error_message = "Namespace must contain at least one letter."
+  }
 }
 
 variable "priority_class" {
@@ -16,7 +20,7 @@ variable "priority_class" {
 }
 
 variable "servicemonitor_enabled" {
-  type = bool
+  type        = bool
   description = "Deploy servicemonitor to enable metrics scraping"
-  default = false
+  default     = false
 }

--- a/_sub/compute/helm-kube-prometheus-stack/main.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/main.tf
@@ -1,5 +1,5 @@
 resource "random_password" "grafana_password" {
-  length = 16
+  length  = 16
   special = true
 }
 
@@ -7,7 +7,7 @@ resource "helm_release" "kube_prometheus_stack" {
   name          = "monitoring"
   chart         = "kube-prometheus-stack"
   repository    = "https://prometheus-community.github.io/helm-charts"
-  version       = var.chart_version != null ? var.chart_version : null
+  version       = var.chart_version
   namespace     = var.namespace
   recreate_pods = true
   force_update  = false
@@ -39,10 +39,10 @@ resource "helm_release" "kube_prometheus_stack" {
     }),
 
     length(var.slack_webhook) > 0 ? templatefile("${path.module}/values/alertmanager-slack.yaml", {
-      alertmanager_priorityclass      = var.priority_class
-      alertmanager_slack_channel      = var.slack_channel
-      alertmanager_slack_webhook      = var.slack_webhook
-      target_namespaces = var.target_namespaces
+      alertmanager_priorityclass = var.priority_class
+      alertmanager_slack_channel = var.slack_channel
+      alertmanager_slack_webhook = var.slack_webhook
+      target_namespaces          = var.target_namespaces
     }) : file("${path.module}/values/alertmanager-disabled.yaml"),
 
     templatefile("${path.module}/values/rules.yaml", {

--- a/_sub/compute/helm-kube-prometheus-stack/vars.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/vars.tf
@@ -13,6 +13,11 @@ variable "namespace" {
   type        = string
   description = "Namespace to apply Kube-prometheus-stack in"
   default     = "monitoring"
+  validation {
+    condition     = can(regex("[a-z]+", var.string))
+    error_message = "Namespace must contain at least one letter."
+  }
+
 }
 
 variable "priority_class" {

--- a/_sub/compute/helm-metrics-server/main.tf
+++ b/_sub/compute/helm-metrics-server/main.tf
@@ -2,8 +2,8 @@ resource "helm_release" "metrics_server" {
   name          = "metrics-server"
   repository    = "https://charts.helm.sh/stable"
   chart         = "metrics-server"
-  version       = var.chart_version != null ? var.chart_version : null
-  namespace     = var.namespace != null ? var.namespace : null
+  version       = var.chart_version
+  namespace     = var.namespace
   recreate_pods = true
 
   values = [

--- a/_sub/compute/helm-metrics-server/vars.tf
+++ b/_sub/compute/helm-metrics-server/vars.tf
@@ -8,4 +8,8 @@ variable "namespace" {
   type        = string
   description = "Namespace to apply metrics-server in"
   default     = "monitoring"
+  validation {
+    condition     = can(regex("[a-z]+", var.string))
+    error_message = "Namespace must contain at least one letter."
+  }
 }


### PR DESCRIPTION
When applying Helm charts, we have both been setting the `chart_version` variable to `null` by default, and using this redundant logic:

```hcl
version          = var.chart_version != null ? var.chart_version : null
```

This PR cleans up the redundancy, making for more readable code.