### PR TITLE
Bump required Terraform version to 1.0 for all modules

### DIFF
--- a/_sub/compute/ec2-instance/versions.tf
+++ b/_sub/compute/ec2-instance/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/compute/ec2-keypair/versions.tf
+++ b/_sub/compute/ec2-keypair/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/compute/ec2-securitygroup/versions.tf
+++ b/_sub/compute/ec2-securitygroup/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/compute/ec2-sgrule-cidr/versions.tf
+++ b/_sub/compute/ec2-sgrule-cidr/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/compute/ec2-sgrule-sg/versions.tf
+++ b/_sub/compute/ec2-sgrule-sg/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/compute/ecr-repo/versions.tf
+++ b/_sub/compute/ecr-repo/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/compute/eks-addons/versions.tf
+++ b/_sub/compute/eks-addons/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/compute/eks-alb-auth/versions.tf
+++ b/_sub/compute/eks-alb-auth/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/compute/eks-alb/versions.tf
+++ b/_sub/compute/eks-alb/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/compute/eks-cluster/versions.tf
+++ b/_sub/compute/eks-cluster/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/compute/eks-heptio/versions.tf
+++ b/_sub/compute/eks-heptio/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/compute/eks-nlb/versions.tf
+++ b/_sub/compute/eks-nlb/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/compute/eks-nodegroup-unmanaged/versions.tf
+++ b/_sub/compute/eks-nodegroup-unmanaged/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/compute/eks-workers/versions.tf
+++ b/_sub/compute/eks-workers/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/compute/helm-atlantis/versions.tf
+++ b/_sub/compute/helm-atlantis/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 
   /*
   Hashicorp-managed providers can be loaded implicitly

--- a/_sub/compute/helm-crossplane/versions.tf
+++ b/_sub/compute/helm-crossplane/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 
   required_providers {
 
     kubectl = {
-      source  = "gavinbunney/kubectl"
+      source = "gavinbunney/kubectl"
     }
   }
 }

--- a/_sub/compute/helm-ebs-csi-driver/versions.tf
+++ b/_sub/compute/helm-ebs-csi-driver/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/compute/helm-goldpinger/versions.tf
+++ b/_sub/compute/helm-goldpinger/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/compute/helm-kube-prometheus-stack/version.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/version.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/compute/helm-metrics-server/versions.tf
+++ b/_sub/compute/helm-metrics-server/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/compute/k8s-atlantis-flux-config/versions.tf
+++ b/_sub/compute/k8s-atlantis-flux-config/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 
   /*
   Hashicorp-managed providers can be loaded implicitly

--- a/_sub/compute/k8s-blaster-namespace/versions.tf
+++ b/_sub/compute/k8s-blaster-namespace/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/compute/k8s-clusterrole/versions.tf
+++ b/_sub/compute/k8s-clusterrole/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/compute/k8s-fluxcd/versions.tf
+++ b/_sub/compute/k8s-fluxcd/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 1.0"
 
   /*
   Hashicorp-managed providers can be loaded implicitly
@@ -11,15 +11,15 @@ terraform {
   required_providers {
 
     kubectl = {
-      source  = "gavinbunney/kubectl"
+      source = "gavinbunney/kubectl"
     }
 
     github = {
-      source  = "integrations/github"
+      source = "integrations/github"
     }
 
     flux = {
-      source  = "fluxcd/flux"
+      source = "fluxcd/flux"
     }
 
   }

--- a/_sub/compute/k8s-kiam/versions.tf
+++ b/_sub/compute/k8s-kiam/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/compute/k8s-namespace/version.tf
+++ b/_sub/compute/k8s-namespace/version.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/compute/k8s-service-account/versions.tf
+++ b/_sub/compute/k8s-service-account/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/compute/k8s-traefik-flux/versions.tf
+++ b/_sub/compute/k8s-traefik-flux/versions.tf
@@ -1,18 +1,18 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 1.0"
 
   required_providers {
     github = {
-      source  = "integrations/github"
+      source = "integrations/github"
     }
 
     kubectl = {
-      source  = "gavinbunney/kubectl"
+      source = "gavinbunney/kubectl"
     }
 
     htpasswd = {
-        source  = "loafoe/htpasswd"
-        version = "~> 0.9.0"
-      }
+      source  = "loafoe/htpasswd"
+      version = "~> 0.9.0"
+    }
   }
 }

--- a/_sub/compute/k8s-traefik/versions.tf
+++ b/_sub/compute/k8s-traefik/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 
-    required_providers {
-      htpasswd = {
-        source  = "loafoe/htpasswd"
-        version = "~> 0.9.0"
-      }
+  required_providers {
+    htpasswd = {
+      source  = "loafoe/htpasswd"
+      version = "~> 0.9.0"
+    }
   }
 }

--- a/_sub/database/postgres-restore/versions.tf
+++ b/_sub/database/postgres-restore/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/database/postgres/versions.tf
+++ b/_sub/database/postgres/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/database/rds-postgres-harbor/versions.tf
+++ b/_sub/database/rds-postgres-harbor/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/examples/route53-zone/versions.tf
+++ b/_sub/examples/route53-zone/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/misc/budget-monthly/versions.tf
+++ b/_sub/misc/budget-monthly/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/misc/kafka-message/versions.tf
+++ b/_sub/misc/kafka-message/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/monitoring/alarm-notifier/versions.tf
+++ b/_sub/monitoring/alarm-notifier/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/monitoring/blackbox-exporter/versions.tf
+++ b/_sub/monitoring/blackbox-exporter/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 1.0"
 
   required_providers {
     github = {
-      source  = "integrations/github"
+      source = "integrations/github"
     }
   }
 }

--- a/_sub/network/acm-certificate-san/versions.tf
+++ b/_sub/network/acm-certificate-san/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/network/elastic-ip/versions.tf
+++ b/_sub/network/elastic-ip/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/network/internet-gateway/versions.tf
+++ b/_sub/network/internet-gateway/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/network/route-table-assoc/versions.tf
+++ b/_sub/network/route-table-assoc/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/network/route-table/versions.tf
+++ b/_sub/network/route-table/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/network/route53-delegate-zone/versions.tf
+++ b/_sub/network/route53-delegate-zone/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/network/route53-record/versions.tf
+++ b/_sub/network/route53-record/versions.tf
@@ -1,10 +1,10 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 
   required_providers {
     aws = {
-        source = "hashicorp/aws"
+      source = "hashicorp/aws"
     }
   }
 }

--- a/_sub/network/route53-zone/versions.tf
+++ b/_sub/network/route53-zone/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/network/security-group-eks-node/versions.tf
+++ b/_sub/network/security-group-eks-node/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/network/vpc-subnet-eks/versions.tf
+++ b/_sub/network/vpc-subnet-eks/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/network/vpc-subnet/versions.tf
+++ b/_sub/network/vpc-subnet/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/network/vpc/versions.tf
+++ b/_sub/network/vpc/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/security/active-directory/versions.tf
+++ b/_sub/security/active-directory/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/security/azure-app-registration/versions.tf
+++ b/_sub/security/azure-app-registration/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/security/cloudtrail-config/versions.tf
+++ b/_sub/security/cloudtrail-config/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/security/iam-account-alias/versions.tf
+++ b/_sub/security/iam-account-alias/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/security/iam-idp/versions.tf
+++ b/_sub/security/iam-idp/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/security/iam-policies/versions.tf
+++ b/_sub/security/iam-policies/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/security/iam-role/versions.tf
+++ b/_sub/security/iam-role/versions.tf
@@ -1,10 +1,10 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 
   required_providers {
     aws = {
-        source = "hashicorp/aws"
+      source = "hashicorp/aws"
     }
   }
 }

--- a/_sub/security/iam-user/versions.tf
+++ b/_sub/security/iam-user/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/security/org-account/versions.tf
+++ b/_sub/security/org-account/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/security/org-ou/versions.tf
+++ b/_sub/security/org-ou/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/security/org-policy/versions.tf
+++ b/_sub/security/org-policy/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/security/preprime-iam/versions.tf
+++ b/_sub/security/preprime-iam/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/security/random-string-generate/versions.tf
+++ b/_sub/security/random-string-generate/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/security/ssm-parameter-store/versions.tf
+++ b/_sub/security/ssm-parameter-store/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/storage/s3-bucket-lifecycle/versions.tf
+++ b/_sub/storage/s3-bucket-lifecycle/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 1.0"
 }

--- a/_sub/storage/s3-bucket-object/versions.tf
+++ b/_sub/storage/s3-bucket-object/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/storage/s3-bucket/versions.tf
+++ b/_sub/storage/s3-bucket/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/_sub/storage/s3-cloudtrail-bucket/versions.tf
+++ b/_sub/storage/s3-cloudtrail-bucket/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/compute/ecr-repo/versions.tf
+++ b/compute/ecr-repo/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/compute/eks-ec2/versions.tf
+++ b/compute/eks-ec2/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 1.0"
 
   required_providers {
     aws = {

--- a/compute/k8s-services/versions.tf
+++ b/compute/k8s-services/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 1.0"
 
   required_providers {
     aws = {

--- a/database/postgres-restore/versions.tf
+++ b/database/postgres-restore/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 1.0"
 
   required_providers {
     aws = {

--- a/database/postgres/versions.tf
+++ b/database/postgres/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 1.0"
 
   required_providers {
     aws = {

--- a/network/route53-sub-zone/versions.tf
+++ b/network/route53-sub-zone/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 1.0"
 
   required_providers {
     aws = {

--- a/security/adsync-qa-env/versions.tf
+++ b/security/adsync-qa-env/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 1.0"
 
   required_providers {
     aws = {

--- a/security/cloudtrail-master/versions.tf
+++ b/security/cloudtrail-master/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 1.0"
 
   required_providers {
     aws = {

--- a/security/iam-roles-master/versions.tf
+++ b/security/iam-roles-master/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 1.0"
 
   required_providers {
     aws = {

--- a/security/iam-roles-qa/versions.tf
+++ b/security/iam-roles-qa/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 1.0"
 
   required_providers {
     aws = {

--- a/security/iam-users-master/versions.tf
+++ b/security/iam-users-master/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 1.0"
 
   required_providers {
     aws = {

--- a/security/org-account-assume/versions.tf
+++ b/security/org-account-assume/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 1.0"
 
   required_providers {
     aws = {

--- a/security/org-account-context/versions.tf
+++ b/security/org-account-context/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 1.0"
 
   required_providers {
     aws = {

--- a/security/org-account/versions.tf
+++ b/security/org-account/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/security/org-capability-root/versions.tf
+++ b/security/org-capability-root/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 1.0"
 
   required_providers {
     aws = {

--- a/security/ssh-keypair/versions.tf
+++ b/security/ssh-keypair/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 1.0"
 
   required_providers {
     aws = {

--- a/storage/s3-eks-public/versions.tf
+++ b/storage/s3-eks-public/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }

--- a/storage/s3-velero-backup/versions.tf
+++ b/storage/s3-velero-backup/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 1.0"
 
   required_providers {
     aws = {

--- a/test/fixtures/terraform-backend/versions.tf
+++ b/test/fixtures/terraform-backend/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 }


### PR DESCRIPTION
We no longer validate any of our modules with Terraform versions older than 1.0, and thus the required Terraform version is now effectively 1.0.