### PR TITLE
Fixing one QA issue and attempting to fix a second QA issue. Thirdly disable app reg

### DIFF
--- a/src/qa-test-eks.sh
+++ b/src/qa-test-eks.sh
@@ -150,6 +150,10 @@ if [ "$ACTION" = "destroy-cluster" ]; then
     # Essential cleanup commands (set RETURN=1 if fails)
     terragrunt destroy-all --terragrunt-working-dir "$WORKDIR" --terragrunt-source-update --terragrunt-non-interactive -input=false -auto-approve || RETURN=1
 
+    # Workaround to ensure ENIs are no longer used: Sleep for 15 minutes.
+    # Bug: https://github.com/aws/amazon-vpc-cni-k8s/issues/1399
+    sleep 900
+
     # Remove specific resources that sometimes get left behind (always return true, as resource may have been successfully been cleaned up)
     cleanup_roles "eks-${CLUSTERNAME}-"
     cleanup_eni

--- a/test/integration/eu-west-1/k8s-qa21/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa21/services/terragrunt.hcl
@@ -26,7 +26,8 @@ inputs = {
   # Traefik
   # --------------------------------------------------
 
-  traefik_alb_auth_deploy = true # triggers Azure App registration
+  # TODO: traefik_alb_auth_deploy = false due to https://github.com/hashicorp/terraform-provider-azuread/issues/588
+  traefik_alb_auth_deploy = false # triggers Azure App registration
   traefik_alb_anon_deploy = true
   # traefik_alb_auth_core_alias = ["qa-alias1.dfds.cloud", "qa-alias2.dfds.cloud"]
   traefik_alb_auth_core_alias = []

--- a/test/integration/eu-west-1/k8s-qa21/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa21/services/terragrunt.hcl
@@ -103,8 +103,8 @@ inputs = {
   # --------------------------------------------------
 
   crossplane_deploy        = true
-  crossplane_chart_version = "1.2.1"
-  crossplane_providers     = ["crossplane/provider-aws:v0.18.1"]
+  crossplane_chart_version = "1.4.0"
+  crossplane_providers     = ["crossplane/provider-aws:v0.19.0"]
   crossplane_admin_service_accounts = [
     {
       serviceaccount = "default"


### PR DESCRIPTION
This PR contains to changes to QA:

1. Adding a 'sleep 900' before deleting ENI resources. This was mentioned as a workaround in a issue related to the AWS CLI when deleting ENI.
2. The QA pipeline was out of sync with the crossplane releases used in production. So this has now been aligned.
3. Due to a bug in AzureAD provider, I have disabled the app registration in QA for now.