### PR TITLE
Clarify that the route table created, is attached to the subnets

### DIFF
--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -54,7 +54,7 @@ module "eks_internet_gateway" {
 
 module "eks_route_table" {
   source     = "../../_sub/network/route-table"
-  name       = "eks-${var.eks_cluster_name}"
+  name       = "eks-${var.eks_cluster_name}-subnet"
   vpc_id     = module.eks_cluster.vpc_id
   gateway_id = module.eks_internet_gateway.id
 }
@@ -211,8 +211,8 @@ module "eks_heptio" {
 }
 
 module "eks_addons" {
-  source = "../../_sub/compute/eks-addons"
-  depends_on = [module.eks_cluster]
+  source                     = "../../_sub/compute/eks-addons"
+  depends_on                 = [module.eks_cluster]
   cluster_name               = var.eks_cluster_name
   kubeproxy_version_override = var.eks_addon_kubeproxy_version_override
   coredns_version_override   = var.eks_addon_coredns_version_override


### PR DESCRIPTION
The EKS modules create two route tables:

- The main (/default) route table for the Kubernetes VPC. This is currently created implicitly, and thus does not have a name tag
- The route table directly associated with the subnets used by Kubernetes

Previously this was named `eks-hellman` which is ambiguous due to the above, which has caused confusion.

For now, this clarifies that this route table is used by the subnets.

Some other time we can create the main route table explicitly, before creating the VPC, and thus be able to assign a name (tag).