### PR TITLE
Ignore changes to route table entries, to support capability peering

### DIFF
--- a/_sub/network/route-table/main.tf
+++ b/_sub/network/route-table/main.tf
@@ -6,6 +6,10 @@ resource "aws_route_table" "table" {
     gateway_id = var.gateway_id
   }
 
+  lifecycle {
+    ignore_changes = [route]
+  }
+
   tags = {
     Name = var.name
   }


### PR DESCRIPTION
Route table gets overwritten by pipeline, but we need to be able manage capability peering route entries.