### PR TITLE
Crossplane - Use UXP release

### DIFF
--- a/_sub/compute/helm-crossplane/main.tf
+++ b/_sub/compute/helm-crossplane/main.tf
@@ -1,12 +1,12 @@
 resource "helm_release" "crossplane" {
   name          = var.release_name
-  chart         = "crossplane"
-  repository    = "https://charts.crossplane.io/stable"
+  chart         = "universal-crossplane"
+  repository    = "https://charts.upbound.io/stable"
   version       = var.chart_version
   namespace     = var.namespace
   recreate_pods = var.recreate_pods
   force_update  = var.force_update
-
+  devel         = var.devel
   values = [
     templatefile("${path.module}/values/values.yaml", {
       crossplane_metrics_enabled = var.crossplane_metrics_enabled

--- a/_sub/compute/helm-crossplane/vars.tf
+++ b/_sub/compute/helm-crossplane/vars.tf
@@ -23,6 +23,11 @@ variable "force_update" {
   description = "Force resource updates through replacement"
 }
 
+variable "devel" {
+  type        = bool
+  description = "Allow use of development versions of Crossplane"
+}
+
 variable "crossplane_providers" {
   type        = list(string)
   description = "List of Crossplane providers to install"

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -521,6 +521,7 @@ module "crossplane" {
   chart_version                     = var.crossplane_chart_version
   recreate_pods                     = var.crossplane_recreate_pods
   force_update                      = var.crossplane_force_update
+  devel                             = var.crossplane_devel
   crossplane_providers              = var.crossplane_providers
   crossplane_admin_service_accounts = var.crossplane_admin_service_accounts
   crossplane_edit_service_accounts  = var.crossplane_edit_service_accounts

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -591,13 +591,13 @@ variable "crossplane_deploy" {
 variable "crossplane_namespace" {
   type        = string
   description = "Namespace in which to install Crossplane"
-  default     = "crossplane-system"
+  default     = "upbound-system"
 }
 
 variable "crossplane_release_name" {
   type        = string
   description = "Name of the chart release"
-  default     = "crossplane"
+  default     = "universal-crossplane"
 }
 
 variable "crossplane_chart_version" {
@@ -617,6 +617,14 @@ variable "crossplane_force_update" {
   description = "Force resource updates through replacement"
   default     = false
 }
+
+
+variable "crossplane_devel" {
+  type        = bool
+  description = "Allow use of development versions of Crossplane"
+  default     = true
+}
+
 
 variable "crossplane_providers" {
   type        = list(string)


### PR DESCRIPTION
Seems to work on a "fresh" cluster without any previous Crossplane installations.

Currently testing the following scenarios:
- [x] (Yes) Does it work on a fresh install
- [x] (Surprisingly yes?) Does it work if you go from the open-source version of Crossplane to this
  - [x] (Yes) Do you keep your resources?
  - [x] (Tested Bucket & RDSInstance, everything was kept intact) If not, are they orphaned at least?