### PR TITLE
Update to tagging logic

### DIFF
--- a/_sub/compute/k8s-traefik-flux/main.tf
+++ b/_sub/compute/k8s-traefik-flux/main.tf
@@ -93,10 +93,13 @@ resource "htpasswd_password" "hash" {
 # Save password in AWS Parameter Store
 # --------------------------------------------------
 resource "aws_ssm_parameter" "param_traefik_dashboard" {
-  count       = var.dashboard_deploy ? 1 : 0
-  name        = "/eks/${var.cluster_name}/traefik-dashboard"
-  description = "Password for accessing the Traefik dashboard"
-  type        = "SecureString"
-  value       = random_password.password[0].result
-  overwrite   = true
+  count           = var.dashboard_deploy ? 1 : 0
+  name            = "/eks/${var.cluster_name}/traefik-dashboard"
+  description     = "Password for accessing the Traefik dashboard"
+  type            = "SecureString"
+  value           = random_password.password[0].result
+  overwrite       = true
+  tags = {
+    createdBy = var.ssm_param_createdby != null ? var.ssm_param_createdby : "k8s-traefik-flux"
+  }
 }

--- a/_sub/compute/k8s-traefik-flux/vars.tf
+++ b/_sub/compute/k8s-traefik-flux/vars.tf
@@ -117,3 +117,9 @@ variable "dashboard_ingress_host" {
   type        = string
   description = "The alb auth dns name for accessing Traefik."
 }
+
+variable "ssm_param_createdby" {
+  type        = string
+  description = "The value that will be used for the createdBy key when tagging any SSM parameters"
+  default     = null
+}

--- a/_sub/compute/k8s-traefik/main.tf
+++ b/_sub/compute/k8s-traefik/main.tf
@@ -242,6 +242,9 @@ resource "aws_ssm_parameter" "param_traefik_dashboard" {
   type        = "SecureString"
   value       = random_password.password[0].result
   overwrite   = true
+  tags = {
+    createdBy = var.ssm_param_createdby != null ? var.ssm_param_createdby : "k8s-traefik"
+  }
 }
 
 # --------------------------------------------------

--- a/_sub/compute/k8s-traefik/vars.tf
+++ b/_sub/compute/k8s-traefik/vars.tf
@@ -68,3 +68,9 @@ variable "dashboard_ingress_host" {
   type        = string
   description = "The alb auth dns name for accessing Traefik."
 }
+
+variable "ssm_param_createdby" {
+  type        = string
+  description = "The value that will be used for the createdBy key when tagging any SSM parameters"
+  default     = null
+}

--- a/_sub/security/ssm-parameter-store/main.tf
+++ b/_sub/security/ssm-parameter-store/main.tf
@@ -6,6 +6,6 @@ resource "aws_ssm_parameter" "putSecureString" {
   value       = var.key_value
   overwrite   = true
   tags = {
-    createdBy = var.tag_createdby
+    createdBy = var.tag_createdby != null ? var.tag_createdby : "ssm-parameter-store"
   }
 }

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -230,7 +230,7 @@ module "param_kubeconfig_admin" {
   key_name        = "/eks/${var.eks_cluster_name}/kubeconfig-admin"
   key_description = "Kube config file for initial admin"
   key_value       = module.eks_heptio.kubeconfig_admin
-  tag_createdby   = var.ssm_param_createdby
+  tag_createdby   = var.ssm_param_createdby != null ? var.ssm_param_createdby : "eks-ec2"
 }
 
 module "param_kubeconfig_saml" {
@@ -238,7 +238,7 @@ module "param_kubeconfig_saml" {
   key_name        = "/eks/${var.eks_cluster_name}/kubeconfig-saml"
   key_description = "Kube config file for SAML"
   key_value       = module.eks_heptio.kubeconfig_saml
-  tag_createdby   = var.ssm_param_createdby
+  tag_createdby   = var.ssm_param_createdby != null ? var.ssm_param_createdby : "eks-ec2"
 }
 
 module "eks_s3_public_kubeconfig" {
@@ -264,7 +264,7 @@ module "k8s_service_account_store_secret" {
   key_name        = "/eks/${var.eks_cluster_name}/deploy_user"
   key_description = "Kube config file for general deployment user"
   key_value       = module.k8s_service_account.deploy_user_config
-  tag_createdby   = var.ssm_param_createdby
+  tag_createdby   = var.ssm_param_createdby != null ? var.ssm_param_createdby : "eks-ec2"
 }
 
 module "cloudwatch_agent_config_bucket" {

--- a/compute/eks-ec2/vars.tf
+++ b/compute/eks-ec2/vars.tf
@@ -24,7 +24,7 @@ variable "aws_workload_account_id" {
 variable "ssm_param_createdby" {
   type        = string
   description = "The value that will be used for the createdBy key when tagging any SSM parameters"
-  default     = "not-specified"
+  default     = null
 }
 
 

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -122,6 +122,7 @@ module "traefik_deploy" {
   admin_nodeport         = var.traefik_admin_nodeport
   dashboard_ingress_host = local.traefik_dashboard_ingress_host
   dashboard_deploy       = var.traefik_dashboard_deploy
+  ssm_param_createdby    = var.ssm_param_createdby != null ? var.ssm_param_createdby : "k8s-services"
 }
 
 module "traefik_flux_manifests" {
@@ -143,6 +144,7 @@ module "traefik_flux_manifests" {
   dashboard_deploy       = var.traefik_flux_dashboard_deploy
   dashboard_ingress_host = local.traefik_flux_dashboard_ingress_host
   is_using_alb_auth      = local.traefik_flux_is_using_alb_auth
+  ssm_param_createdby    = var.ssm_param_createdby != null ? var.ssm_param_createdby : "k8s-services"
 
   providers = {
     github = github.fluxcd

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -27,6 +27,12 @@ variable "aws_assume_role_arn" {
 variable "workload_dns_zone_name" {
 }
 
+variable "ssm_param_createdby" {
+  type        = string
+  description = "The value that will be used for the createdBy key when tagging any SSM parameters"
+  default     = null
+}
+
 # --------------------------------------------------
 # EKS
 # --------------------------------------------------


### PR DESCRIPTION
Specifically a couple of things:

- I modified the logic so instead of assigning a default value to ssm_param_createdby we instead assign it null and then use some logic to determine what value to apply.  This now means that if a value isn't set then the createdBy tag will be set to 'ssm-parameter-store' which is the name of the module which actually creates the parameter.  The logic also means that we can set values further up the chain, so in most cases the tag will be set to either 'eks-ec2' or 'k8s-services', but this can be overridden to reflect the name of a pipeline should it be required (just set the name in the account.tfvars).
- Added createdBy tags for k8s-traefik and k8s-traefik-flux modules.
