### PR TITLE
Refactored to remove need to kill pods.

### DIFF
--- a/_sub/compute/helm-ebs-csi-driver/values/annotations.yaml
+++ b/_sub/compute/helm-ebs-csi-driver/values/annotations.yaml
@@ -1,2 +1,0 @@
-podAnnotations:
-  iam.amazonaws.com/role: "${role_arn}"


### PR DESCRIPTION
Previous designed used a null resource to annotate a service account and then kill the pods (to ensure the annotation was honoured).

After some discussion with Rasmus we figured out how to annotate as part of the helm deployment, thus killing off two null resources.