### PR TITLE
Use local variable in main.tf

### DIFF
--- a/_sub/database/postgres/main.tf
+++ b/_sub/database/postgres/main.tf
@@ -27,9 +27,9 @@ resource "aws_security_group" "pgsg" {
 
 #Enable SSL on the database by default
 resource "aws_db_parameter_group" "dbparams" {
-  name        = "${var.application}-${var.engine_family}-force-ssl-${var.environment}"
-  description = "Force SSL encryption for ${var.engine_family}"
-  family      = var.engine_family
+  name        = "${var.application}-${local.engine_family}-force-ssl-${var.environment}"
+  description = "Force SSL encryption for ${local.engine_family}"
+  family      = local.engine_family
 
   parameter {
     name  = "rds.force_ssl"


### PR DESCRIPTION
The engine_family variable is declared locally, but it is used as an input variable so  the pipeline fails when it runs because it doesn't find a value. This PR fixes the bug.