### PR TITLE
Use drop_invalid_header_fields = true

### DIFF
--- a/_sub/compute/eks-alb-auth/main.tf
+++ b/_sub/compute/eks-alb-auth/main.tf
@@ -11,6 +11,8 @@ resource "aws_lb" "traefik_auth" {
     enabled = var.access_logs_enabled
     prefix  = var.name
   }
+
+  drop_invalid_header_fields = true
 }
 
 resource "aws_autoscaling_attachment" "traefik_auth" {

--- a/_sub/compute/eks-alb/main.tf
+++ b/_sub/compute/eks-alb/main.tf
@@ -11,6 +11,8 @@ resource "aws_lb" "traefik" {
     enabled = var.access_logs_enabled
     prefix  = var.name
   }
+
+  drop_invalid_header_fields = true
 }
 
 resource "aws_autoscaling_attachment" "traefik" {


### PR DESCRIPTION
Ref: https://aquasecurity.github.io/tfsec/v0.63.1/checks/aws/elb/drop-invalid-headers/

Signed-off-by: Audun Nes <aunes@dfds.com>

For planned maintenance on Tuesday January 18.

Successful in sandbox and QA: https://dev.azure.com/dfds/CloudEngineering/_build/results?buildId=430046&view=results