### PR TITLE
OIDC provider isolation

### DIFF
--- a/_sub/compute/helm-ebs-csi-driver/main.tf
+++ b/_sub/compute/helm-ebs-csi-driver/main.tf
@@ -159,21 +159,6 @@ EOF
 
 }
 
-# required TLS Certificate which is then used for the openid connect provider thumprint list
-data "tls_certificate" "eks" {
-  url = "${var.eks_openid_connect_provider_url}"
-}
-
-# define openid connect provider that is bound to the provider URL for the EKS cluster
-resource "aws_iam_openid_connect_provider" "default" {
-  url = var.eks_openid_connect_provider_url
-
-  client_id_list = [
-    "sts.amazonaws.com",
-  ]
-
-  thumbprint_list = [data.tls_certificate.eks.certificates.0.sha1_fingerprint]
-}
 
 # define IAM role for the CSI Driver to utilise, including a trust relationship for the KAIM Server role
 resource "aws_iam_role" "csi_driver_role" {
@@ -192,7 +177,7 @@ resource "aws_iam_role" "csi_driver_role" {
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
         "StringEquals": {
-          "${trim(var.eks_openid_connect_provider_url,"https://")}:sub": "system:serviceaccount:kube-system:ebs-csi-controller-sa"
+          "${trim(var.eks_openid_connect_provider_url,"https://")}:sub": "system:serviceaccount:${var.csi_ebs_serviceaccount_namespace}:${var.csi_ebs_serviceaccount_name}"
         }
       }
     }

--- a/_sub/compute/helm-ebs-csi-driver/main.tf
+++ b/_sub/compute/helm-ebs-csi-driver/main.tf
@@ -177,7 +177,7 @@ resource "aws_iam_role" "csi_driver_role" {
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
         "StringEquals": {
-          "${trim(var.eks_openid_connect_provider_url,"https://")}:sub": "system:serviceaccount:${var.csi_ebs_serviceaccount_namespace}:${var.csi_ebs_serviceaccount_name}"
+          "${trim(var.eks_openid_connect_provider_url,"https://")}:sub": "system:serviceaccount:kube-system:${var.csi_ebs_serviceaccount_name}"
         }
       }
     }
@@ -203,6 +203,10 @@ resource "helm_release" "aws-ebs-csi-driver" {
   namespace     = "kube-system"
   recreate_pods = true
   force_update  = false
+  values = [
+    templatefile("${path.module}/values/values.yaml", {
+      csi_ebs_serviceaccount_name = var.csi_ebs_serviceaccount_name
+  })]
 
   set {
     name = "controller.serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"

--- a/_sub/compute/helm-ebs-csi-driver/values/values.yaml
+++ b/_sub/compute/helm-ebs-csi-driver/values/values.yaml
@@ -1,0 +1,3 @@
+controller:
+  serviceAccount:
+    name: ${csi_ebs_serviceaccount_name}

--- a/_sub/compute/helm-ebs-csi-driver/vars.tf
+++ b/_sub/compute/helm-ebs-csi-driver/vars.tf
@@ -26,9 +26,3 @@ variable "csi_ebs_serviceaccount_name" {
   description = "The name of the Service Account used by the CSI EBS Driver."
   default     = "ebs-csi-controller-sa"
 }
-
-variable "csi_ebs_serviceaccount_namespace" {
-  type        = string
-  description = "The namespace  where the Service Account used by the CSI EBS Driver is located."
-  default     = "kube-system"
-}

--- a/_sub/compute/helm-ebs-csi-driver/vars.tf
+++ b/_sub/compute/helm-ebs-csi-driver/vars.tf
@@ -21,7 +21,14 @@ variable "cluster_name" {
   description = "The cluster name"
 }
 
-variable "kiam_server_role_arn" {
+variable "csi_ebs_serviceaccount_name" {
   type        = string
-  description = "The role or entity to provide trust for when creating roles to use with annotations in kubernetes"
+  description = "The name of the Service Account used by the CSI EBS Driver."
+  default     = "ebs-csi-controller-sa"
+}
+
+variable "csi_ebs_serviceaccount_namespace" {
+  type        = string
+  description = "The namespace  where the Service Account used by the CSI EBS Driver is located."
+  default     = "kube-system"
 }

--- a/_sub/security/iam-oidc-provider/main.tf
+++ b/_sub/security/iam-oidc-provider/main.tf
@@ -1,0 +1,15 @@
+# required TLS Certificate which is then used for the openid connect provider thumprint list
+data "tls_certificate" "eks" {
+  url = "${var.eks_openid_connect_provider_url}"
+}
+
+# define openid connect provider that is bound to the provider URL for the EKS cluster
+resource "aws_iam_openid_connect_provider" "default" {
+  url = var.eks_openid_connect_provider_url
+
+  client_id_list = [
+    "sts.amazonaws.com",
+  ]
+
+  thumbprint_list = [data.tls_certificate.eks.certificates.0.sha1_fingerprint]
+}

--- a/_sub/security/iam-oidc-provider/vars.tf
+++ b/_sub/security/iam-oidc-provider/vars.tf
@@ -1,0 +1,5 @@
+variable "eks_openid_connect_provider_url" {
+  type        = string
+  description = "The OpenID Connect provider URL for the EKS cluster"
+  default     = null
+}

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -81,6 +81,14 @@ provider "azuread" {
 
 }
 
+# --------------------------------------------------
+# AWS IAM Open ID Connect Provider
+# --------------------------------------------------
+
+module "aws_iam_oidc_provider" {
+  source                          = "../../_sub/security/iam-oidc-provider"
+  eks_openid_connect_provider_url = data.aws_eks_cluster.eks.identity[0].oidc[0].issuer
+}
 
 # --------------------------------------------------
 # AWS EBS CSI Driver (Helm Chart Installation)
@@ -91,9 +99,8 @@ module "ebs_csi_driver" {
   count                           = var.ebs_csi_driver_deploy ? 1 : 0
   chart_version                   = var.ebs_csi_driver_chart_version
   cluster_name                    = var.eks_cluster_name
-  kiam_server_role_arn            = module.kiam_deploy.server_role_arn
   kubeconfig_path                 = local.kubeconfig_path
-  eks_openid_connect_provider_url = data.terraform_remote_state.cluster.outputs.eks_openid_connect_provider_url
+  eks_openid_connect_provider_url = data.aws_eks_cluster.eks.identity[0].oidc[0].issuer
 }
 
 # --------------------------------------------------
@@ -523,7 +530,7 @@ module "crossplane" {
   crossplane_view_service_accounts  = var.crossplane_view_service_accounts
   crossplane_metrics_enabled        = var.crossplane_metrics_enabled
   crossplane_aws_iam_role_name      = var.crossplane_aws_iam_role_name
-  eks_openid_connect_provider_url   = var.eks_openid_connect_provider_url
+  eks_openid_connect_provider_url   = data.aws_eks_cluster.eks.identity[0].oidc[0].issuer
 }
 
 # --------------------------------------------------

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -678,12 +678,6 @@ variable "crossplane_aws_iam_role_name" {
   default = "provider-aws"
 }
 
-variable "eks_openid_connect_provider_url" {
-  type        = string
-  description = "The OpenID Connect provider URL for the EKS cluster"
-  default     = null
-}
-
 # -------------
 
 variable "kiam_strict_mode_disabled" {


### PR DESCRIPTION
Migrates the OIDC Provider into it's own module rather than having it included as part of the CSI EBS Driver module.
