### PR TITLE
Use intended variable for iam policy rather than having it hardcoded

### DIFF
--- a/_sub/compute/k8s-blaster-namespace/dependencies.tf
+++ b/_sub/compute/k8s-blaster-namespace/dependencies.tf
@@ -29,7 +29,7 @@ data "aws_iam_policy_document" "k8s_janitor" {
       "s3:PutObjectTagging"
     ]
 
-    resources = ["arn:aws:s3:::dfds-oxygen-k8s-hellman/*"]
+    resources = ["arn:aws:s3:::${var.blaster_configmap_bucket}/*"]
   }
 
   statement {
@@ -39,7 +39,7 @@ data "aws_iam_policy_document" "k8s_janitor" {
       "s3:ListBucket"
     ]
 
-    resources = ["arn:aws:s3:::dfds-oxygen-k8s-hellman"]
+    resources = ["arn:aws:s3:::${var.blaster_configmap_bucket}"]
   }
 }
 


### PR DESCRIPTION
Doesn't change anything for Hellman. Does make our life a whole lot easier for any cluster not named Hellman (sandbox clusters 😄 )

The variable for Hellman is set at: https://github.com/dfds/eks-pipeline/blob/75e9ed7c9bb25666fae5f6734a54b283aa7a555e/oxygen-account/eu-west-1/k8s-hellman/cluster/terragrunt.hcl#L38