### PR TITLE
Feature/add crossplane capability role

### DIFF
--- a/security/org-account-context/dependencies.tf
+++ b/security/org-account-context/dependencies.tf
@@ -32,3 +32,14 @@ data "aws_iam_policy_document" "assume_role_adfs_shared" {
   }
 
 }
+
+data "aws_iam_policy_document" "assume_role_policy_crossplane_provider_aws" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.shared_account_id}:role/provider-aws"]
+    }
+  }
+}

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -148,7 +148,7 @@ module "iam_role_ecr_push" {
 module "iam_role_crossplane" {
   source               = "../../_sub/security/iam-role"
   role_name            = "crossplane-deploy"
-  role_description     = "This role is used by a capability AWS providerconfig to deploy resources"
+  role_description     = "This role is managed by CloudEngineering and used by the account's AWS providerconfig to deploy AWS resources from Kubernetes via Crossplane"
   max_session_duration = 3600
   assume_role_policy   = data.aws_iam_policy_document.assume_role_policy_crossplane_provider_aws.json
   role_policy_name     = "crossplane-provider-aws"

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -145,6 +145,20 @@ module "iam_role_ecr_push" {
   }
 }
 
+module "iam_role_crossplane" {
+  source               = "../../_sub/security/iam-role"
+  role_name            = "crossplane-deploy"
+  role_description     = "This role is used by a capability AWS providerconfig to deploy resources"
+  max_session_duration = 3600
+  assume_role_policy   = data.aws_iam_policy_document.assume_role_policy_crossplane_provider_aws.json
+  role_policy_name     = "crossplane-provider-aws"
+  role_policy_document = module.iam_policies.admin
+
+  providers = {
+    aws = aws.workload
+  }
+}
+
 # --------------------------------------------------
 # IAM deployment user
 # --------------------------------------------------


### PR DESCRIPTION
This PR adds a crossplane-deploy role into capability AWS accounts that gives permission to the provider-aws role from the eks cluster account to assume it to deploy AWS resources into capability accounts