### PR TITLE
Added region to k8s auth exec command

### DIFF
--- a/_sub/compute/eks-heptio/dependencies.tf
+++ b/_sub/compute/eks-heptio/dependencies.tf
@@ -19,6 +19,7 @@ data "template_file" "kubeconfig_admin" {
     endpoint     = var.eks_endpoint
     ca           = var.eks_certificate_authority
     role_arn     = var.aws_assume_role_arn
+    aws_region   = data.aws_region.current.name
   }
 }
 

--- a/_sub/compute/eks-heptio/kubeconfig-admin.yaml
+++ b/_sub/compute/eks-heptio/kubeconfig-admin.yaml
@@ -23,5 +23,7 @@ users:
         - "get-token"
         - "--cluster-name"
         - "${cluster_name}"
+        - "--region"
+        - "${aws_region}"
         - "--role-arn"
         - "${role_arn}"

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -27,6 +27,8 @@ provider "kubernetes" {
       "get-token",
       "--cluster-name",
       var.eks_cluster_name,
+      "--region",
+      var.aws_region,
       "--role-arn",
       var.aws_assume_role_arn,
     ]


### PR DESCRIPTION
After looking at various online sources & usage of "aws eks get-token", it looks like adding the AWS region explictly may fix the issue we see in QA.

For QA logs, see run "442679" in ADO.

Sources:
https://florian.ec/blog/github-actions-awscli-errors/
https://github.com/terraform-aws-modules/terraform-aws-eks/pull/1699/files