### PR TITLE
Update TLS encryption for Flux to use a supported alorithme in

### DIFF
--- a/_sub/compute/k8s-fluxcd/main.tf
+++ b/_sub/compute/k8s-fluxcd/main.tf
@@ -49,8 +49,8 @@ resource "kubectl_manifest" "sync" {
 # --------------------------------------------------
 
 resource "tls_private_key" "main" {
-  algorithm = "RSA"
-  rsa_bits  = 4096
+  algorithm   = "ECDSA"
+  ecdsa_curve = "P256"
 }
 
 resource "kubernetes_secret" "main" {


### PR DESCRIPTION
order to avoid ERROR: You're using an RSA key with SHA-1, which is no longer allowed.
Please use a newer client or a different key type

Signed-off-by: Audun Nes <aunes@dfds.com>