### PR TITLE
Update to fix missing variable.

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -23,6 +23,8 @@ resources:
         ARM_CLIENT_SECRET: $(ARM_CLIENT_SECRET)
         TF_VAR_platform_fluxcd_github_token: $(TF_VAR_platform_fluxcd_github_token)
         TF_VAR_atlantis_github_token: $(TF_VAR_atlantis_github_token)
+        TF_VAR_crossplane_provider_confluent_email: $(CROSSPLANE_PROVIDER_CONFLUENT_EMAIL)
+        TF_VAR_crossplane_provider_confluent_password: $(CROSSPLANE_PROVIDER_CONFLUENT_PASSWORD)
 
 # Define variable group to use
 variables:


### PR DESCRIPTION
QA failed because the associated pipeline is now missing some variables which are required.  I wanted to get QA running so for now i've added the needed variables and  mapped them in by updating the pipeline YAML.  This might want changing at a later date to use a variable group.