### PR TITLE
modify validation condition on velero variable to validate default

### DIFF
--- a/_sub/storage/velero-flux/vars.tf
+++ b/_sub/storage/velero-flux/vars.tf
@@ -98,7 +98,6 @@ variable "image_tag" {
 
 variable "plugin_for_aws_version" {
   type        = string
-  default     = "v1.4.1"
   description = "The version of velero-plugin-for-aws to use as initContainer"
   validation {
     condition     = can(regex("^v[[:digit:]].[[:digit:]].[[:digit:]]+", var.plugin_for_aws_version))
@@ -108,7 +107,6 @@ variable "plugin_for_aws_version" {
 
 variable "plugin_for_csi_version" {
   type        = string
-  default     = "v0.2.0"
   description = "The version of velero-plugin-for-csi to use as initContainer"
   validation {
     condition     = can(regex("^v[[:digit:]].[[:digit:]].[[:digit:]]+", var.plugin_for_csi_version))

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -1048,20 +1048,20 @@ variable "velero_image_tag" {
 
 variable "velero_plugin_for_aws_version" {
   type        = string
-  default     = ""
+  default     = "v1.4.1"
   description = "The version of velero-plugin-for-aws to use as initContainer"
   validation {
-    condition     = can(regex("^v[[:digit:]].[[:digit:]].[[:digit:]]+", var.velero_plugin_for_aws_version))
+    condition     = can(regex("^v[[:digit:]].[[:digit:]].[[:digit:]]+", var.velero_plugin_for_aws_version)) || var.velero_plugin_for_aws_version == ""
     error_message = "Velero plugin for AWS must specify a version. The version must start with the letter v and followed by a semantic version number."
   }
 }
 
 variable "velero_plugin_for_csi_version" {
   type        = string
-  default     = ""
+  default     = "v0.2.0"
   description = "The version of velero-plugin-for-csi to use as initContainer"
   validation {
-    condition     = can(regex("^v[[:digit:]].[[:digit:]].[[:digit:]]+", var.velero_plugin_for_csi_version))
+    condition     = can(regex("^v[[:digit:]].[[:digit:]].[[:digit:]]+", var.velero_plugin_for_csi_version)) || var.velero_plugin_for_csi_version == ""
     error_message = "Velero plugin for CSI must specify a version. The version must start with the letter v and followed by a semantic version number."
   }
 }


### PR DESCRIPTION
This PR allows the `velero_plugin_for_aws_version` and `velero_plugin_for_csi_version` variables to pass validation if no value is specified and successfully use the default values defined. Typically useful for sandbox deployments but is general good practice

This PR allows the following:

- prevent unnecessary prompts for input values for these variables if `velero_flux_deploy` is set to false by fixing the validation rule at k8s-services level to allow no value
- set default values at k8s-services level rather than an empty string which meant that the default values that were set in the velero module were always overridden