### PR TITLE
replace deprecated alb_target_group_arn param

### DIFF
--- a/_sub/compute/eks-alb-auth/main.tf
+++ b/_sub/compute/eks-alb-auth/main.tf
@@ -18,7 +18,7 @@ resource "aws_lb" "traefik_auth" {
 resource "aws_autoscaling_attachment" "traefik_auth" {
   count                  = var.deploy ? length(var.autoscaling_group_ids) : 0
   autoscaling_group_name = var.autoscaling_group_ids[count.index]
-  alb_target_group_arn   = aws_lb_target_group.traefik_auth[0].arn
+  lb_target_group_arn   = aws_lb_target_group.traefik_auth[0].arn
 }
 
 resource "aws_lb_target_group" "traefik_auth" {

--- a/_sub/compute/eks-alb/main.tf
+++ b/_sub/compute/eks-alb/main.tf
@@ -18,7 +18,7 @@ resource "aws_lb" "traefik" {
 resource "aws_autoscaling_attachment" "traefik" {
   count                  = var.deploy ? length(var.autoscaling_group_ids) : 0
   autoscaling_group_name = var.autoscaling_group_ids[count.index]
-  alb_target_group_arn   = aws_lb_target_group.traefik[0].arn
+  lb_target_group_arn   = aws_lb_target_group.traefik[0].arn
 }
 
 resource "aws_lb_target_group" "traefik" {

--- a/_sub/compute/eks-nlb/main.tf
+++ b/_sub/compute/eks-nlb/main.tf
@@ -9,7 +9,7 @@ resource "aws_lb" "nlb" {
 resource "aws_autoscaling_attachment" "nlb" {
   count                  = var.deploy ? length(var.autoscaling_group_ids) : 0
   autoscaling_group_name = var.autoscaling_group_ids[count.index]
-  alb_target_group_arn   = aws_lb_target_group.nlb[0].arn
+  lb_target_group_arn   = aws_lb_target_group.nlb[0].arn
 }
 
 resource "aws_lb_target_group" "nlb" {


### PR DESCRIPTION
This PR replaces the deprecated alb_target_group_arn with lb_target_group_arn in the aws_autoscaling_attachment resource