### PR TITLE
replace deprecated policy arg in aws_s3_bucket

### DIFF
--- a/_sub/storage/s3-bucket-lifecycle/main.tf
+++ b/_sub/storage/s3-bucket-lifecycle/main.tf
@@ -6,7 +6,11 @@ resource "aws_s3_bucket" "bucket" {
   tags = {
     "Managed by" = "Terraform"
   }
+ 
+}
 
+resource "aws_s3_bucket_policy" "bucketpolicy" {
+  bucket = aws_s3_bucket.bucket.id
   policy = var.policy
 }
 


### PR DESCRIPTION
This PR replaces the deprecated `policy` argument in the `aws_s3_bucket` resource with its replacement `aws_s3_bucket_policy` resource