### PR TITLE
Drop high cardinality labels i.e. id and name from container metrics

### DIFF
--- a/_sub/compute/helm-kube-prometheus-stack/values/prometheus.yaml
+++ b/_sub/compute/helm-kube-prometheus-stack/values/prometheus.yaml
@@ -17,6 +17,7 @@ prometheus:
         - path: /metrics
           port: http
   prometheusSpec:
+    enableAdminAPI: false
     resources:
       requests:
         memory: ${prometheus_request_memory}
@@ -42,3 +43,10 @@ grafana:
     enabled: true
     labels:
       release: monitoring
+kubelet:
+  serviceMonitor:
+    cAdvisorMetricRelabelings:
+      - regex: id
+        action: labeldrop
+      - regex: name
+        action: labeldrop


### PR DESCRIPTION
See this article https://source.coveo.com/2021/03/03/prometheus-memory/