### PR TITLE
Replace null_resource and kubectl dep. with native provider resource

### DIFF
--- a/_sub/compute/helm-ebs-csi-driver/main.tf
+++ b/_sub/compute/helm-ebs-csi-driver/main.tf
@@ -250,20 +250,16 @@ resource "kubernetes_storage_class" "csi-gp2" {
 }
 
 # change gp2 so it's no longer the default storageclass
-locals {
-  gp2_is_default = false
+resource "kubernetes_annotations" "gp2-default" {
+  api_version = "storage.k8s.io/v1"
+  kind        = "StorageClass"
+  force       = "true"
+
+  metadata {
+    name = "gp2"
+  }
+  annotations = {
+    "storageclass.kubernetes.io/is-default-class" = "false"
+  }
 }
 
-
-resource "null_resource" "gp2_removedefault_patch" {
-
-  depends_on = [kubernetes_storage_class.csi-gp2]
-  triggers = {
-    is_default = local.gp2_is_default
-  }
-
-  provisioner "local-exec" {
-    command = "kubectl --kubeconfig ${var.kubeconfig_path} patch storageclass gp2 -p '{\"metadata\": {\"annotations\":{\"storageclass.kubernetes.io/is-default-class\":\"${local.gp2_is_default}\"}}}'"
-  }
-
-}


### PR DESCRIPTION
As of version 2.10, Kubernetes provider [now supports](https://github.com/hashicorp/terraform-provider-kubernetes/releases/tag/v2.10.0) annotations as a separate Terraform resource, enabling the mangement of annotations that are otherwise not managed by Terraform.

This change removes a `null_resource` and dependency on the `kubectl` binary, in favour of a native provider resource.

Note: I have not been able to test this myself, as I don't currently have an environment where I can do that.