### PR TITLE
remove crossplane-deploy role from org acc ctxt

### DIFF
--- a/security/org-account-context/dependencies.tf
+++ b/security/org-account-context/dependencies.tf
@@ -32,14 +32,3 @@ data "aws_iam_policy_document" "assume_role_adfs_shared" {
   }
 
 }
-
-data "aws_iam_policy_document" "assume_role_policy_crossplane_provider_aws" {
-  statement {
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.shared_account_id}:role/provider-aws"]
-    }
-  }
-}

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -145,20 +145,6 @@ module "iam_role_ecr_push" {
   }
 }
 
-module "iam_role_crossplane" {
-  source               = "../../_sub/security/iam-role"
-  role_name            = "crossplane-deploy"
-  role_description     = "This role is managed by CloudEngineering and used by the account's AWS providerconfig to deploy AWS resources from Kubernetes via Crossplane"
-  max_session_duration = 3600
-  assume_role_policy   = data.aws_iam_policy_document.assume_role_policy_crossplane_provider_aws.json
-  role_policy_name     = "crossplane-provider-aws"
-  role_policy_document = module.iam_policies.admin
-
-  providers = {
-    aws = aws.workload
-  }
-}
-
 # --------------------------------------------------
 # IAM deployment user
 # --------------------------------------------------


### PR DESCRIPTION
This PR will remove the crossplane-deploy role from org-account-context in infrastructure-modules