### PR TITLE
store random grafana password in param store

### DIFF
--- a/_sub/compute/helm-kube-prometheus-stack/main.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/main.tf
@@ -1,6 +1,14 @@
 resource "random_password" "grafana_password" {
-  length  = 16
+  length  = 32
   special = true
+}
+
+resource "aws_ssm_parameter" "param_grafana_password" {
+  name        = "/eks/${var.cluster_name}/${helm_release.kube_prometheus_stack.name}-grafana-password"
+  description = "Password for accessing the Grafana dashboard"
+  type        = "SecureString"
+  value       = var.grafana_admin_password != "" ? var.grafana_admin_password : random_password.grafana_password.result
+  overwrite   = true
 }
 
 resource "helm_release" "kube_prometheus_stack" {

--- a/_sub/compute/helm-kube-prometheus-stack/outputs.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/outputs.tf
@@ -1,4 +1,3 @@
 output "grafana_admin_password" {
-  value     = var.grafana_admin_password != "" ? "<as supplied in terragrunt.hcl>" : random_password.grafana_password.result
-  sensitive = true
+  value     = "This value is stored in the AWS SSM Parameter Store at ${aws_ssm_parameter.param_grafana_password.name}"
 }

--- a/compute/k8s-services/outputs.tf
+++ b/compute/k8s-services/outputs.tf
@@ -4,7 +4,6 @@
 
 output "prometheus_grafana_admin_password" {
   value     = try(module.monitoring_kube_prometheus_stack[0].grafana_admin_password, "")
-  sensitive = true
 }
 
 # --------------------------------------------------


### PR DESCRIPTION
This PR modifies the kube-prometheus-stack module to store the password in the AWS SSM Parameter store. It also increases the length of the randomly generated password