### PR TITLE
mark grafana_admin_password var as sensitive

### DIFF
--- a/_sub/compute/helm-kube-prometheus-stack/vars.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/vars.tf
@@ -29,6 +29,7 @@ variable "grafana_admin_password" {
   type        = string
   description = "Grafana admin password"
   default     = "" #tfsec:ignore:general-secrets-sensitive-in-variable
+  sensitive = true
 }
 
 variable "grafana_ingress_path" {

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -221,6 +221,7 @@ variable "monitoring_kube_prometheus_stack_grafana_admin_password" {
   type        = string
   description = "Grafana admin password"
   default     = "" #tfsec:ignore:general-secrets-sensitive-in-variable
+  sensitive = true
 }
 
 variable "monitoring_kube_prometheus_stack_grafana_ingress_path" {


### PR DESCRIPTION
This PR further improves the kube-prometheus-stack module by marking the optional password variable as sensitive to ensure it is not output on a terragrunt plan if a value is provided