### PR TITLE
Remove creation of deploy user credentials to move responsibility to the team

### DIFF
--- a/_sub/security/iam-user/main.tf
+++ b/_sub/security/iam-user/main.tf
@@ -9,6 +9,6 @@ resource "aws_iam_user_policy" "policy" {
 }
 
 resource "aws_iam_access_key" "key" {
+  count = var.create_aws_iam_access_key ? 1 : 0
   user = aws_iam_user.user.name
 }
-

--- a/_sub/security/iam-user/outputs.tf
+++ b/_sub/security/iam-user/outputs.tf
@@ -3,11 +3,11 @@ output "arn" {
 }
 
 output "access_key" {
-  value = var.create_aws_iam_access_key ? aws_iam_access_key.key.id : ""
+  value = var.create_aws_iam_access_key ? aws_iam_access_key.key[0].id : ""
 }
 
 output "secret_key" {
-  value     = var.create_aws_iam_access_key ? aws_iam_access_key.key.secret : "" 
+  value     = var.create_aws_iam_access_key ? aws_iam_access_key.key[0].secret : "" 
   sensitive = true
 }
 

--- a/_sub/security/iam-user/outputs.tf
+++ b/_sub/security/iam-user/outputs.tf
@@ -3,11 +3,11 @@ output "arn" {
 }
 
 output "access_key" {
-  value = aws_iam_access_key.key.id
+  value = var.create_aws_iam_access_key ? aws_iam_access_key.key.id : ""
 }
 
 output "secret_key" {
-  value     = aws_iam_access_key.key.secret
+  value     = var.create_aws_iam_access_key ? aws_iam_access_key.key.secret : "" 
   sensitive = true
 }
 

--- a/_sub/security/iam-user/vars.tf
+++ b/_sub/security/iam-user/vars.tf
@@ -10,3 +10,7 @@ variable "user_policy_document" {
   type = string
 }
 
+variable "create_aws_iam_access_key" {
+  type = bool
+  default = true
+}

--- a/_sub/security/iam-user/vars.tf
+++ b/_sub/security/iam-user/vars.tf
@@ -12,5 +12,5 @@ variable "user_policy_document" {
 
 variable "create_aws_iam_access_key" {
   type = bool
-  default = true
+  default = false
 }

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -154,10 +154,25 @@ module "iam_user_deploy" {
   user_policy_name     = "Admin"
   user_policy_document = module.iam_policies.admin
   create_aws_iam_access_key = var.create_aws_iam_access_key
-
   providers = {
     aws = aws.workload
   }
+}
+
+# --------------------------------------------------
+# IAM Store deploy credentials
+# --------------------------------------------------
+
+module "iam_user_deploy_store_credentials" {
+  source          = "../../_sub/security/ssm-parameter-store"
+  key_name        = "/managed/deploy/aws-creds"
+  key_description = "AWS credentials for the IAM 'Deploy' user"
+  tag_createdby   = var.ssm_param_createdby
+  key_value = <<EOF
+AWS_ACCESS_KEY_ID=${module.iam_user_deploy.access_key}
+AWS_SECRET_ACCESS_KEY=${module.iam_user_deploy.secret_key}
+  EOF
+  count = var.create_aws_iam_access_key ? 1 : 0
 }
 
 # --------------------------------------------------

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -112,7 +112,6 @@ module "iam_role_shared" {
   }
 }
 
-
 # --------------------------------------------------
 # IAM roles - Workload (capability context)
 # --------------------------------------------------
@@ -168,23 +167,6 @@ module "iam_user_deploy" {
   user_name            = "Deploy"
   user_policy_name     = "Admin"
   user_policy_document = module.iam_policies.admin
-
-  providers = {
-    aws = aws.workload
-  }
-}
-
-module "iam_user_deploy_store_credentials" {
-  source          = "../../_sub/security/ssm-parameter-store"
-  key_name        = "/managed/deploy/aws-creds"
-  key_description = "AWS credentials for the IAM 'Deploy' user"
-  tag_createdby   = var.ssm_param_createdby
-
-  key_value = <<EOF
-AWS_ACCESS_KEY_ID=${module.iam_user_deploy.access_key}
-AWS_SECRET_ACCESS_KEY=${module.iam_user_deploy.secret_key}
-EOF
-
 
   providers = {
     aws = aws.workload

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -160,22 +160,6 @@ module "iam_user_deploy" {
 }
 
 # --------------------------------------------------
-# IAM Store deploy credentials
-# --------------------------------------------------
-
-module "iam_user_deploy_store_credentials" {
-  source          = "../../_sub/security/ssm-parameter-store"
-  key_name        = "/managed/deploy/aws-creds"
-  key_description = "AWS credentials for the IAM 'Deploy' user"
-  tag_createdby   = var.ssm_param_createdby
-  key_value = <<EOF
-AWS_ACCESS_KEY_ID=${module.iam_user_deploy.access_key}
-AWS_SECRET_ACCESS_KEY=${module.iam_user_deploy.secret_key}
-  EOF
-  count = var.create_aws_iam_access_key ? 1 : 0
-}
-
-# --------------------------------------------------
 # IAM OpenID Connect Provider
 # --------------------------------------------------
 

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -153,6 +153,7 @@ module "iam_user_deploy" {
   user_name            = "Deploy"
   user_policy_name     = "Admin"
   user_policy_document = module.iam_policies.admin
+  create_aws_iam_access_key = var.create_aws_iam_access_key
 
   providers = {
     aws = aws.workload

--- a/security/org-account-context/vars.tf
+++ b/security/org-account-context/vars.tf
@@ -132,5 +132,5 @@ variable "oidc_provider_tag" {
 
 variable "create_aws_iam_access_key" {
   type = bool
-  default = true
+  default = false
 }

--- a/security/org-account-context/vars.tf
+++ b/security/org-account-context/vars.tf
@@ -129,3 +129,8 @@ variable "oidc_provider_tag" {
   description = "Used for tagging the IAM OpenID Connect Provider for the capability account"
   default     = ""
 }
+
+variable "create_aws_iam_access_key" {
+  type = bool
+  default = true
+}

--- a/security/org-capability-root/dependencies.tf
+++ b/security/org-capability-root/dependencies.tf
@@ -68,11 +68,14 @@ POLICY
             "Effect": "Deny",
             "Action": [
                 "iam:AttachUserPolicy",
+				"iam:CreateAccessKey",
+                "iam:DeleteAccessKey",
                 "iam:DeleteUserPolicy",
                 "iam:DetachUserPolicy",
                 "iam:PutUserPolicy",
                 "iam:TagUser",
-                "iam:UntagUser"
+                "iam:UntagUser",
+				"iam:UpdateAccessKey"
             ],
             "Resource": [
                 "arn:aws:iam::*:user/Deploy",

--- a/security/org-capability-root/dependencies.tf
+++ b/security/org-capability-root/dependencies.tf
@@ -68,14 +68,11 @@ POLICY
             "Effect": "Deny",
             "Action": [
                 "iam:AttachUserPolicy",
-                "iam:CreateAccessKey",
-                "iam:DeleteAccessKey",
                 "iam:DeleteUserPolicy",
                 "iam:DetachUserPolicy",
                 "iam:PutUserPolicy",
                 "iam:TagUser",
-                "iam:UntagUser",
-                "iam:UpdateAccessKey"
+                "iam:UntagUser"
             ],
             "Resource": [
                 "arn:aws:iam::*:user/Deploy",

--- a/security/org-capability-root/dependencies.tf
+++ b/security/org-capability-root/dependencies.tf
@@ -67,14 +67,14 @@ POLICY
             "Sid": "DenyIAMUpdatesManagedUsers",
             "Effect": "Deny",
             "Action": [
-                "iam:AttachUserPolicy",
+				"iam:AttachUserPolicy",
 				"iam:CreateAccessKey",
-                "iam:DeleteAccessKey",
-                "iam:DeleteUserPolicy",
-                "iam:DetachUserPolicy",
-                "iam:PutUserPolicy",
-                "iam:TagUser",
-                "iam:UntagUser",
+				"iam:DeleteAccessKey",
+				"iam:DeleteUserPolicy",
+				"iam:DetachUserPolicy",
+				"iam:PutUserPolicy",
+				"iam:TagUser",
+				"iam:UntagUser",
 				"iam:UpdateAccessKey"
             ],
             "Resource": [

--- a/security/org-capability-root/dependencies.tf
+++ b/security/org-capability-root/dependencies.tf
@@ -68,14 +68,14 @@ POLICY
             "Effect": "Deny",
             "Action": [
 				"iam:AttachUserPolicy",
-				"iam:CreateAccessKey",
+                "iam:CreateAccessKey",
 				"iam:DeleteAccessKey",
 				"iam:DeleteUserPolicy",
 				"iam:DetachUserPolicy",
 				"iam:PutUserPolicy",
 				"iam:TagUser",
 				"iam:UntagUser",
-				"iam:UpdateAccessKey"
+                "iam:UpdateAccessKey"
             ],
             "Resource": [
                 "arn:aws:iam::*:user/Deploy",

--- a/security/org-capability-root/dependencies.tf
+++ b/security/org-capability-root/dependencies.tf
@@ -67,14 +67,14 @@ POLICY
             "Sid": "DenyIAMUpdatesManagedUsers",
             "Effect": "Deny",
             "Action": [
-				"iam:AttachUserPolicy",
+                "iam:AttachUserPolicy",
                 "iam:CreateAccessKey",
-				"iam:DeleteAccessKey",
-				"iam:DeleteUserPolicy",
-				"iam:DetachUserPolicy",
-				"iam:PutUserPolicy",
-				"iam:TagUser",
-				"iam:UntagUser",
+                "iam:DeleteAccessKey",
+                "iam:DeleteUserPolicy",
+                "iam:DetachUserPolicy",
+                "iam:PutUserPolicy",
+                "iam:TagUser",
+                "iam:UntagUser",
                 "iam:UpdateAccessKey"
             ],
             "Resource": [

--- a/security/org-capability-root/dependencies.tf
+++ b/security/org-capability-root/dependencies.tf
@@ -66,16 +66,13 @@ POLICY
         {
             "Sid": "DenyIAMUpdatesManagedUsers",
             "Effect": "Deny",
-            "Action": [
+ 			"Action": [
                 "iam:AttachUserPolicy",
-                "iam:CreateAccessKey",
-                "iam:DeleteAccessKey",
                 "iam:DeleteUserPolicy",
                 "iam:DetachUserPolicy",
                 "iam:PutUserPolicy",
                 "iam:TagUser",
-                "iam:UntagUser",
-                "iam:UpdateAccessKey"
+                "iam:UntagUser"
             ],
             "Resource": [
                 "arn:aws:iam::*:user/Deploy",
@@ -110,7 +107,7 @@ POLICY
                     ]
                 }
             }
-        },			
+        },
 		{
 			"Sid": "DenyIAM",
 			"Effect": "Deny",


### PR DESCRIPTION
Update IAM user module to allow for secret creds not to be automatically created when a IAM user is created, 
