### PR TITLE
Allow the manage users to be rotated by teams

### DIFF
--- a/security/org-capability-root/dependencies.tf
+++ b/security/org-capability-root/dependencies.tf
@@ -68,14 +68,11 @@ POLICY
             "Effect": "Deny",
             "Action": [
                 "iam:AttachUserPolicy",
-                "iam:CreateAccessKey",
-                "iam:DeleteAccessKey",
                 "iam:DeleteUserPolicy",
                 "iam:DetachUserPolicy",
                 "iam:PutUserPolicy",
                 "iam:TagUser",
-                "iam:UntagUser",
-                "iam:UpdateAccessKey"
+                "iam:UntagUser"
             ],
             "Resource": [
                 "arn:aws:iam::*:user/Deploy",


### PR DESCRIPTION
Update IAM SCP to allow the development team to create, remove and rotate the deploy IAM creds,