### PR TITLE
Replaced deprecated resource aws_s3_bucket_object

### DIFF
--- a/_sub/storage/s3-bucket-object/main.tf
+++ b/_sub/storage/s3-bucket-object/main.tf
@@ -1,4 +1,4 @@
-resource "aws_s3_bucket_object" "object" {
+resource "aws_s3_object" "object" {
   count   = var.deploy ? 1 : 0
   bucket  = var.bucket
   key     = var.key

--- a/_sub/storage/s3-bucket-object/outputs.tf
+++ b/_sub/storage/s3-bucket-object/outputs.tf
@@ -1,4 +1,4 @@
 output "id" {
-  value = element(concat(aws_s3_bucket_object.object.*.id, [""]), 0)
+  value = element(concat(aws_s3_object.object.*.id, [""]), 0)
 }
 


### PR DESCRIPTION
Replaced deprecated resource 'aws_s3_bucket_object' with 'aws_s3_object', as referenced in this Terragrunt warning:
```
╷
│ Warning: Argument is deprecated
│
│   with module.eks_s3_public_kubeconfig.aws_s3_bucket_object.object,
│   on ../../_sub/storage/s3-bucket-object/main.tf line 3, in resource "aws_s3_bucket_object" "object":
│    3:   bucket  = var.bucket
│
│ Use the aws_s3_object resource instead
│
│ (and 3 more similar warnings elsewhere)
╵
```