### PR TITLE
added toggle for s3 bucket encryption

### DIFF
--- a/_sub/storage/s3-bucket/main.tf
+++ b/_sub/storage/s3-bucket/main.tf
@@ -11,7 +11,7 @@ resource "aws_s3_bucket" "bucket" {
 
 # tfsec:ignore:aws-s3-encryption-customer-key
 resource "aws_s3_bucket_server_side_encryption_configuration" "bucket_encryption" {
-  count  = var.deploy ? 1 : 0
+  count  = var.deploy && var.enable_server_side_encryption ? 1 : 0
   bucket = aws_s3_bucket.bucket[count.index].id
 
   rule {

--- a/_sub/storage/s3-bucket/vars.tf
+++ b/_sub/storage/s3-bucket/vars.tf
@@ -12,3 +12,8 @@ variable "acl" {
   default     = "private"
 }
 
+variable "enable_server_side_encryption" {
+  description = "Enable server side encryption (SSE) on the S3 bucket"
+  type = bool
+  default = true
+}

--- a/storage/s3-eks-public/main.tf
+++ b/storage/s3-eks-public/main.tf
@@ -20,4 +20,5 @@ module "s3_bucket" {
   deploy    = length(var.eks_public_s3_bucket) >= 1 ? true : false
   s3_bucket = var.eks_public_s3_bucket
   acl       = "public-read"
+  enable_server_side_encryption = var.enable_server_side_encryption
 }

--- a/storage/s3-eks-public/vars.tf
+++ b/storage/s3-eks-public/vars.tf
@@ -16,6 +16,12 @@ variable "eks_public_s3_bucket" {
   default     = ""
 }
 
+variable "enable_server_side_encryption" {
+  description = "Enable server side encryption (SSE) on the S3 bucket"
+  type = bool
+  default = true
+}
+
 # --------------------------------------------------
 # Unused variables - to provent TF warning/error:
 # Using a variables file to set an undeclared variable is deprecated and will


### PR DESCRIPTION
This PR adds a toggle feature to enable/disable server side encryption on an SSE bucket. It defaults to enabled to match the current behaviour, meaning no changes to any inputs are required for existing deployments. You can now, however, optionally disable it by providing `enable_server_side_encryption = false`