### PR TITLE
remove the storage of the deploy creds

### DIFF
--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -160,23 +160,6 @@ module "iam_user_deploy" {
   }
 }
 
-module "iam_user_deploy_store_credentials" {
-  source          = "../../_sub/security/ssm-parameter-store"
-  key_name        = "/managed/deploy/aws-creds"
-  key_description = "AWS credentials for the IAM 'Deploy' user"
-  tag_createdby   = var.ssm_param_createdby
-
-  key_value = <<EOF
-AWS_ACCESS_KEY_ID=${module.iam_user_deploy.access_key}
-AWS_SECRET_ACCESS_KEY=${module.iam_user_deploy.secret_key}
-EOF
-
-
-  providers = {
-    aws = aws.workload
-  }
-}
-
 # --------------------------------------------------
 # IAM OpenID Connect Provider
 # --------------------------------------------------


### PR DESCRIPTION
Removes the storage of the deploy creds to limit privilege escalation 