### PR TITLE
Exempt access-analyzer:ValidatePolicy action from non-EU SCP.

### DIFF
--- a/security/org-capability-root/dependencies.tf
+++ b/security/org-capability-root/dependencies.tf
@@ -10,6 +10,7 @@ locals {
             "Sid": "DenyAllOutsideEU",
             "Effect": "Deny",
             "NotAction": [
+                "access-analyzer:ValidatePolicy",
                 "acm:*",
                 "aws-marketplace:*",
                 "aws-portal:*",


### PR DESCRIPTION
Otherwise, a user receives permission warnings in the AWS console when inputting a new policy. This leads to confusion and support tickets.