### PR TITLE
Updated vpccni version to v1.11.4-eksbuild.1

### DIFF
--- a/_sub/compute/eks-addons/dependencies.tf
+++ b/_sub/compute/eks-addons/dependencies.tf
@@ -12,7 +12,7 @@ locals {
     "1.19" = "v1.11.2-eksbuild.1"
     "1.20" = "v1.11.2-eksbuild.1"
     "1.21" = "v1.11.2-eksbuild.1"
-    "1.22" = "v1.11.2-eksbuild.1"
+    "1.22" = "v1.11.4-eksbuild.1"
   }
 
   coredns_version_map = {


### PR DESCRIPTION
This PR will update the eksaddon for vpccni to the latest supported version of v1.11.2-eksbuild.1 to version v1.11.4-eksbuild.1