### PR TITLE
Specify Flux dependencies to destroy resources in the proper order

### DIFF
--- a/_sub/compute/helm-goldpinger/vars.tf
+++ b/_sub/compute/helm-goldpinger/vars.tf
@@ -7,7 +7,6 @@ variable "chart_version" {
 variable "namespace" {
   type        = string
   description = "Namespace to apply goldpinger in"
-  default     = "monitoring"
   validation {
     condition     = can(regex("[a-z]+", var.namespace))
     error_message = "Namespace must contain at least one letter."

--- a/_sub/compute/helm-kube-prometheus-stack/vars.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/vars.tf
@@ -12,7 +12,6 @@ variable "chart_version" {
 variable "namespace" {
   type        = string
   description = "Namespace to apply Kube-prometheus-stack in"
-  default     = "monitoring"
   validation {
     condition     = can(regex("[a-z]+", var.namespace))
     error_message = "Namespace must contain at least one letter."
@@ -29,7 +28,7 @@ variable "grafana_admin_password" {
   type        = string
   description = "Grafana admin password"
   default     = "" #tfsec:ignore:general-secrets-sensitive-in-variable
-  sensitive = true
+  sensitive   = true
 }
 
 variable "grafana_ingress_path" {

--- a/_sub/compute/helm-metrics-server/vars.tf
+++ b/_sub/compute/helm-metrics-server/vars.tf
@@ -7,7 +7,6 @@ variable "helm_chart_version" {
 variable "namespace" {
   type        = string
   description = "Namespace to apply metrics-server in"
-  default     = "monitoring"
   validation {
     condition     = can(regex("[a-z]+", var.namespace))
     error_message = "Namespace must contain at least one letter."

--- a/_sub/monitoring/blackbox-exporter/vars.tf
+++ b/_sub/monitoring/blackbox-exporter/vars.tf
@@ -11,7 +11,6 @@ variable "deploy_name" {
 variable "namespace" {
   type        = string
   description = "The namespace in which to deploy Helm resources"
-  default     = "monitoring"
 }
 
 variable "replicas" {
@@ -43,7 +42,7 @@ variable "helm_chart_version" {
 }
 
 variable "monitoring_targets" {
-  type = list(object({ name=string, url=string, module=string }))
+  type        = list(object({ name = string, url = string, module = string }))
   description = "Complex object of what to monitor with Blackbox Exporter"
-  default = []
+  default     = []
 }

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -129,6 +129,8 @@ module "traefik_flux_manifests" {
   providers = {
     github = github.fluxcd
   }
+
+  depends_on = [module.platform_fluxcd]
 }
 
 module "traefik_alb_cert" {
@@ -484,7 +486,7 @@ module "atlantis_flux_manifests" {
   flux_repo_name        = var.atlantis_flux_repo_name
   flux_repo_branch      = var.atlantis_flux_repo_branch
 
-  depends_on = [module.atlantis, module.traefik_flux_manifests, ]
+  depends_on = [module.atlantis, module.traefik_flux_manifests, module.platform_fluxcd]
 
   providers = {
     github = github.fluxcd
@@ -528,7 +530,7 @@ module "crossplane_operator" {
     github = github.fluxcd
   }
 
-  depends_on = [module.crossplane]
+  depends_on = [module.crossplane, module.platform_fluxcd]
 }
 
 module "crossplane_configuration_package" {
@@ -545,7 +547,7 @@ module "crossplane_configuration_package" {
     github = github.fluxcd
   }
 
-  depends_on = [module.crossplane]
+  depends_on = [module.crossplane, module.platform_fluxcd]
 }
 
 locals {
@@ -571,7 +573,7 @@ module "crossplane_provider_confluent_prereqs" {
     github = github.fluxcd
   }
 
-  depends_on = [module.crossplane]
+  depends_on = [module.crossplane, module.platform_fluxcd]
 }
 
 # --------------------------------------------------
@@ -592,7 +594,7 @@ module "blackbox_exporter_flux_manifests" {
     github = github.fluxcd
   }
 
-  depends_on = [module.monitoring_kube_prometheus_stack]
+  depends_on = [module.monitoring_kube_prometheus_stack, module.platform_fluxcd]
 }
 
 # --------------------------------------------------
@@ -613,6 +615,8 @@ module "podinfo_flux_manifests" {
   providers = {
     github = github.fluxcd
   }
+
+  depends_on = [module.platform_fluxcd]
 }
 
 # --------------------------------------------------
@@ -637,6 +641,7 @@ module "fluentd_cloudwatch_flux_manifests" {
     aws    = aws.logs
   }
 
+  depends_on = [module.platform_fluxcd]
 }
 
 # --------------------------------------------------
@@ -662,6 +667,8 @@ module "velero_flux_manifests" {
   providers = {
     github = github.fluxcd
   }
+
+  depends_on = [module.platform_fluxcd]
 }
 
 

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -241,7 +241,7 @@ module "traefik_alb_anon_dns_core_alias" {
 
 module "kiam_deploy" {
   source                  = "../../_sub/compute/k8s-kiam"
-  count                  = var.kiam_deploy ? 1 : 0
+  count                   = var.kiam_deploy ? 1 : 0
   chart_version           = var.kiam_chart_version
   cluster_name            = var.eks_cluster_name
   priority_class          = "service-critical"
@@ -444,30 +444,30 @@ module "platform_fluxcd" {
 # --------------------------------------------------
 
 module "atlantis" {
-  source                       = "../../_sub/compute/helm-atlantis"
-  count                        = var.atlantis_deploy ? 1 : 0
-  namespace                    = var.atlantis_namespace
-  chart_version                = var.atlantis_chart_version
-  atlantis_image               = var.atlantis_image
-  atlantis_image_tag           = var.atlantis_image_tag
-  atlantis_ingress             = var.atlantis_ingress
-  github_username              = var.atlantis_github_username
-  github_token                 = var.atlantis_github_token
-  github_repositories          = var.atlantis_github_repositories
-  webhook_url                  = var.atlantis_ingress
-  webhook_events               = var.atlantis_webhook_events
-  aws_access_key               = var.atlantis_aws_access_key
-  aws_secret                   = var.atlantis_aws_secret
-  access_key_master            = var.atlantis_access_key_master
-  secret_key_master            = var.atlantis_secret_key_master
-  arm_tenant_id                = var.atlantis_arm_tenant_id
-  arm_subscription_id          = var.atlantis_arm_subscription_id
-  arm_client_id                = var.atlantis_arm_client_id
-  arm_client_secret            = var.atlantis_arm_client_secret
-  platform_fluxcd_github_token = var.atlantis_platform_fluxcd_github_token
-  storage_class                = var.atlantis_storage_class
-  cluster_name                 = var.eks_cluster_name
-  slack_webhook_url = var.slack_webhook_url
+  source                                         = "../../_sub/compute/helm-atlantis"
+  count                                          = var.atlantis_deploy ? 1 : 0
+  namespace                                      = var.atlantis_namespace
+  chart_version                                  = var.atlantis_chart_version
+  atlantis_image                                 = var.atlantis_image
+  atlantis_image_tag                             = var.atlantis_image_tag
+  atlantis_ingress                               = var.atlantis_ingress
+  github_username                                = var.atlantis_github_username
+  github_token                                   = var.atlantis_github_token
+  github_repositories                            = var.atlantis_github_repositories
+  webhook_url                                    = var.atlantis_ingress
+  webhook_events                                 = var.atlantis_webhook_events
+  aws_access_key                                 = var.atlantis_aws_access_key
+  aws_secret                                     = var.atlantis_aws_secret
+  access_key_master                              = var.atlantis_access_key_master
+  secret_key_master                              = var.atlantis_secret_key_master
+  arm_tenant_id                                  = var.atlantis_arm_tenant_id
+  arm_subscription_id                            = var.atlantis_arm_subscription_id
+  arm_client_id                                  = var.atlantis_arm_client_id
+  arm_client_secret                              = var.atlantis_arm_client_secret
+  platform_fluxcd_github_token                   = var.atlantis_platform_fluxcd_github_token
+  storage_class                                  = var.atlantis_storage_class
+  cluster_name                                   = var.eks_cluster_name
+  slack_webhook_url                              = var.slack_webhook_url
   monitoring_kube_prometheus_stack_slack_webhook = var.monitoring_kube_prometheus_stack_slack_webhook
 
   providers = {
@@ -589,6 +589,7 @@ module "blackbox_exporter_flux_manifests" {
   repo_name          = var.blackbox_exporter_repo_name
   repo_branch        = var.blackbox_exporter_repo_branch
   monitoring_targets = local.blackbox_exporter_monitoring_targets
+  namespace          = module.monitoring_namespace[0].name
 
   providers = {
     github = github.fluxcd

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -347,6 +347,12 @@ module "monitoring_namespace" {
   source = "../../_sub/compute/k8s-namespace"
   count  = var.monitoring_namespace_deploy ? 1 : 0
   name   = local.monitoring_namespace_name
+
+  # The monitoring namespace has resources that are provisioned and
+  # deprovisioned from it via Flux. If Flux is removed before the monitoring
+  # namespace, the monitoring namespace may be unable to terminated as it will
+  # have resources left in it with Flux finalizers which cannot be finalized.
+  depends_on = [module.platform_fluxcd]
 }
 
 

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -221,7 +221,7 @@ variable "monitoring_kube_prometheus_stack_grafana_admin_password" {
   type        = string
   description = "Grafana admin password"
   default     = "" #tfsec:ignore:general-secrets-sensitive-in-variable
-  sensitive = true
+  sensitive   = true
 }
 
 variable "monitoring_kube_prometheus_stack_grafana_ingress_path" {
@@ -335,12 +335,6 @@ variable "monitoring_metrics_server_chart_version" {
   type        = string
   description = "metrics-server helm chart version"
   default     = null
-}
-
-variable "monitoring_metrics_server_chart_namespace" {
-  type        = string
-  description = "Namespace to apply metrics-server in"
-  default     = "monitoring"
 }
 
 variable "monitoring_metrics_server_repo_url" {


### PR DESCRIPTION
I tried running the master version of the QA pipeline before this and it failed 2 out of 3 times by getting stuck on terminating the `monitoring` namespace because of flux finalizers not being cleared up.

Ran this branch 3 times and it succeeded each time, so I'm assuming this has improved on the flakiness:
- https://dev.azure.com/dfds/CloudEngineering/_build/results?buildId=517374&view=results 
- https://dfds.visualstudio.com/CloudEngineering/_build/results?buildId=517343&view=results 
- https://dfds.visualstudio.com/CloudEngineering/_build/results?buildId=517327&view=results 

Note the `flux-system` namespace is still not properly cleaned up on services destroy, if one wants to be able to cleanly destroy and reapply solely the service phase this still doesn't work properly and will require further investigation. However, since the lack of clean up in the `flux-system` doesn't fail the destroy step on services and the QA pipeline proceeds to destroy the cluster this does not interfere with the QA pipeline.