### PR TITLE
Removed unused variables

### DIFF
--- a/compute/eks-ec2/vars.tf
+++ b/compute/eks-ec2/vars.tf
@@ -1,12 +1,4 @@
 # --------------------------------------------------
-# Terraform
-# --------------------------------------------------
-
-variable "terraform_state_s3_bucket" {
-  type = string
-}
-
-# --------------------------------------------------
 # AWS
 # --------------------------------------------------
 
@@ -18,8 +10,8 @@ variable "aws_assume_role_arn" {
   type = string
 }
 
-variable "aws_workload_account_id" {
-}
+# Optional
+# --------------------------------------------------
 
 variable "ssm_param_createdby" {
   type        = string
@@ -39,6 +31,17 @@ variable "eks_cluster_name" {
 variable "eks_cluster_version" {
   type = string
 }
+
+variable "eks_worker_ssh_public_key" {
+  type = string
+}
+
+variable "eks_worker_ssh_ip_whitelist" {
+  type = list(string)
+}
+
+# Optional
+# --------------------------------------------------
 
 variable "eks_is_sandbox" {
   type        = bool
@@ -62,10 +65,6 @@ variable "eks_cluster_log_retention_days" {
   default     = 90
 }
 
-variable "eks_worker_ssh_public_key" {
-  type = string
-}
-
 variable "eks_worker_inotify_max_user_watches" {
   default = 131072 # default t3.large is 8192 which is too low
 }
@@ -73,10 +72,6 @@ variable "eks_worker_inotify_max_user_watches" {
 variable "eks_worker_subnets" {
   type    = list(string)
   default = []
-}
-
-variable "eks_worker_ssh_ip_whitelist" {
-  type = list(string)
 }
 
 variable "eks_worker_scale_to_zero_cron" {
@@ -213,23 +208,4 @@ variable "eks_worker_cloudwatch_agent_config_deploy" {
 variable "eks_worker_cloudwatch_agent_config_file" {
   type    = string
   default = "aws-cloudwatch-agent-conf.json"
-}
-
-
-# --------------------------------------------------
-# Unused variables - to provent TF warning/error:
-# Using a variables file to set an undeclared variable is deprecated and will
-# become an error in a future release. If you wish to provide certain "global"
-# settings to all configurations in your organization, use TF_VAR_...
-# environment variables to set these instead.
-# --------------------------------------------------
-
-variable "workload_dns_zone_name" {
-  type    = string
-  default = ""
-}
-
-variable "terraform_state_region" {
-  type    = string
-  default = ""
 }

--- a/compute/k8s-services/dependencies.tf
+++ b/compute/k8s-services/dependencies.tf
@@ -183,13 +183,6 @@ data "aws_iam_policy_document" "cloudwatch_metrics_trust" {
 # ---------------------------------------------------------------------
 
 locals {
-  traefik_dashboard_ingress_prod_host = "traefik-legacy.${local.core_dns_zone_name}"
-  traefik_alb_auth_dns_name           = try(module.traefik_alb_auth_dns.record_name["0"], "traefik-legacy.${var.eks_cluster_name}")
-  traefik_dashboard_ingress_host = contains(
-    var.traefik_alb_auth_core_alias,
-    local.traefik_dashboard_ingress_prod_host
-  ) ? local.traefik_dashboard_ingress_prod_host : "${local.traefik_alb_auth_dns_name}.${var.workload_dns_zone_name}"
-
   traefik_flux_dashboard_ingress_prod_host = "traefik.${local.core_dns_zone_name}"
   traefik_flux_alb_auth_dns_name           = try(module.traefik_alb_auth_dns.record_name["0"], "traefik.${var.eks_cluster_name}")
   traefik_flux_dashboard_ingress_host = contains(

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -36,6 +36,12 @@ variable "ssm_param_createdby" {
   default     = null
 }
 
+variable "s3_bucket_additional_tags" {
+  description = "Add additional tags to s3 bucket"
+  type        = map(any)
+  default     = {}
+}
+
 # --------------------------------------------------
 # EKS
 # --------------------------------------------------

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -27,6 +27,9 @@ variable "aws_assume_role_arn" {
 variable "workload_dns_zone_name" {
 }
 
+# Optional
+# --------------------------------------------------
+
 variable "ssm_param_createdby" {
   type        = string
   description = "The value that will be used for the createdBy key when tagging any SSM parameters"

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -107,11 +107,6 @@ variable "traefik_nlb_deploy" {
   default = false
 }
 
-variable "traefik_nlb_cidr_blocks" {
-  type    = list(string)
-  default = []
-}
-
 # --------------------------------------------------
 # Blaster
 # --------------------------------------------------
@@ -230,12 +225,6 @@ variable "monitoring_kube_prometheus_stack_grafana_ingress_path" {
   default     = "/infrastructure"
 }
 
-variable "monitoring_kube_prometheus_stack_grafana_notifier_name" {
-  type        = string
-  description = "Grafana alert notifier name"
-  default     = "notifier1"
-}
-
 variable "monitoring_kube_prometheus_stack_grafana_serviceaccount_name" {
   type        = string
   description = "Grafana serviceaccount to be used for pod"
@@ -344,30 +333,6 @@ variable "monitoring_metrics_server_repo_url" {
 }
 
 # --------------------------------------------------
-# Unused variables - to provent TF warning/error:
-# Using a variables file to set an undeclared variable is deprecated and will
-# become an error in a future release. If you wish to provide certain "global"
-# settings to all configurations in your organization, use TF_VAR_...
-# environment variables to set these instead.
-# --------------------------------------------------
-
-variable "eks_public_s3_bucket" {
-  type    = string
-  default = ""
-}
-
-variable "eks_is_sandbox" {
-  type    = bool
-  default = false
-}
-
-variable "s3_bucket_additional_tags" {
-  description = "Add additional tags to s3 bucket"
-  type        = map(any)
-  default     = {}
-}
-
-# --------------------------------------------------
 # Platform Flux CD
 # --------------------------------------------------
 
@@ -383,19 +348,7 @@ variable "platform_fluxcd_release_tag" {
   description = "The release tag of Flux CD to use."
 }
 
-variable "platform_fluxcd_namespace" {
-  type        = string
-  default     = "platform-flux"
-  description = ""
-}
-
 variable "platform_fluxcd_repo_name" {
-  type        = string
-  default     = ""
-  description = ""
-}
-
-variable "platform_fluxcd_repo_path" {
   type        = string
   default     = ""
   description = ""
@@ -464,14 +417,6 @@ variable "atlantis_github_repositories" {
   description = "List of repositories to whitelist for Atlantis"
   type        = list(string)
   default     = []
-}
-
-variable "atlantis_webhook_content_type" {
-  default = "application/json"
-}
-
-variable "atlantis_webhook_insecure_ssl" {
-  default = false
 }
 
 variable "atlantis_webhook_events" {
@@ -824,12 +769,6 @@ variable "traefik_flux_admin_nodeport" {
   default     = 31001
 }
 
-variable "traefik_flux_health_check_path" {
-  description = "Which path should the LB call when checking if Traefik v2 service is healthy"
-  type        = string
-  default     = "/ping/"
-}
-
 variable "traefik_flux_additional_args" {
   type        = list(any)
   description = "Pass arguments to the additionalArguments node in the Traefik Helm chart"
@@ -964,12 +903,6 @@ variable "velero_flux_deploy" {
   description = "Should Velero Helm chart be deployed?"
 }
 
-variable "velero_flux_deploy_name" {
-  type        = string
-  description = "Unique identifier of the deployment, only needs override if deploying multiple instances"
-  default     = "velero"
-}
-
 variable "velero_flux_role_arn" {
   type        = string
   description = "The ARN for the role that is permitted to use Velero backup storage."
@@ -982,13 +915,6 @@ variable "velero_flux_bucket_name" {
   description = "The name of the S3 bucket that contains the Velero backup"
 }
 
-variable "velero_flux_snapshots_enabled" {
-  type        = bool
-  default     = false
-  description = "Should Velero use snapshot backups?"
-
-}
-
 variable "velero_flux_log_level" {
   type        = string
   default     = "info"
@@ -997,30 +923,6 @@ variable "velero_flux_log_level" {
     condition     = contains(["info", "debug", "warning", "error", "fatal", "panic"], var.velero_flux_log_level)
     error_message = "Invalid value for log_level. Valid values: info, debug, warning, error, fatal, panic."
   }
-}
-
-variable "velero_flux_cron_schedule" {
-  type        = string
-  default     = "0 0 * * *"
-  description = "Cron format scheuled time."
-}
-
-variable "velero_flux_schedules_template_ttl" {
-  type        = string
-  default     = "336h"
-  description = "Time to live for the scheduled backup."
-}
-
-variable "velero_flux_schedules_template_snapshot_volumes" {
-  type        = bool
-  default     = false
-  description = "Should Velero use snapshot volumes?"
-}
-
-variable "velero_flux_schedules_template_include_cluster_resources" {
-  type        = bool
-  default     = false
-  description = "Should Velero also backup cluster resources?"
 }
 
 variable "velero_flux_github_owner" {

--- a/storage/s3-eks-public/vars.tf
+++ b/storage/s3-eks-public/vars.tf
@@ -13,7 +13,11 @@ variable "aws_assume_role_arn" {
 variable "eks_public_s3_bucket" {
   description = "The name of the public S3 bucket, where non-sensitive Kubeconfig will be copied to."
   type        = string
-  default     = ""
+
+  validation {
+    condition     = length(var.eks_public_s3_bucket) > 0
+    error_message = "Bucket name must be a non-empty string"
+  }
 }
 
 variable "enable_server_side_encryption" {
@@ -26,32 +30,4 @@ variable "additional_tags" {
   description = "Add additional tags to s3 bucket"
   type        = map(string)
   default     = {}
-}
-
-# --------------------------------------------------
-# Unused variables - to provent TF warning/error:
-# Using a variables file to set an undeclared variable is deprecated and will
-# become an error in a future release. If you wish to provide certain "global"
-# settings to all configurations in your organization, use TF_VAR_...
-# environment variables to set these instead.
-# --------------------------------------------------
-
-variable "terraform_state_region" {
-  type    = string
-  default = ""
-}
-
-variable "aws_workload_account_id" {
-  type    = string
-  default = ""
-}
-
-variable "workload_dns_zone_name" {
-  type    = string
-  default = ""
-}
-
-variable "terraform_state_s3_bucket" {
-  type    = string
-  default = ""
 }


### PR DESCRIPTION
Related to https://github.com/dfds/cloudplatform/issues/1152

- Removed unused variables in the EKS pipeline modules, used `tflint` to detect unused variables (related https://github.com/dfds/cloudplatform/issues/1182).
- Some unused variables were introduced intentionally to avoid getting warnings about the setting of undeclared variables. To avoid these warnings I think it is better to refactor the HCLs instead of introducing such unused variables into the modules which were done in a separate PR on the eks-pipeline repo.
- Introduced a validation for a variable, we should probably utilize this more.