### PR TITLE
Reset QA account and other QA changes

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -49,7 +49,6 @@ pool:
   vmImage: "ubuntu-latest"
 stages:
   - stage: nuke
-    lockBehavior: sequential
     displayName: "Nuke QA Account"
     condition: eq(variables['NUKE_QA'], 'true')
     jobs:
@@ -67,7 +66,6 @@ stages:
                   timeoutInMinutes: 60
 
   - stage: test
-    lockBehavior: sequential
     displayName: "Testing"
     condition: or(succeeded(), ne(variables['NUKE_QA'], 'true'))
     jobs:
@@ -131,14 +129,11 @@ stages:
                   displayName: "Run tests"
                   timeoutInMinutes: 15
 
-  - stage: destroy
-    lockBehavior: sequential
-    displayName: "Destruction"
-    condition: and(succeededOrFailed(), ne(variables['NO_DESTROY'], 'true'))
-    jobs:
       - deployment: destroy
         displayName: Destroy resources
         container: prime
+        dependsOn: apply
+        condition: and(succeededOrFailed(), ne(variables['NO_DESTROY'], 'true'))
         environment: QA
         strategy:
           runOnce:

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -134,7 +134,7 @@ stages:
   - stage: destroy
     lockBehavior: sequential
     displayName: "Destruction"
-    condition: ne(variables['NO_DESTROY'], 'true')
+    condition: and(succeededOrFailed(), ne(variables['NO_DESTROY'], 'true'))
     jobs:
       - deployment: destroy
         displayName: Destroy resources

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -92,7 +92,7 @@ stages:
   - stage: test
     displayName: "Testing"
     dependsOn: nuke
-    condition: or(succeeded('nuke'), ne(variables['NUKE_QA'], 'true'))
+    condition: or(succeededOrFailed('nuke'), ne(variables['NUKE_QA'], 'true'))
     jobs:
       - deployment: init
         displayName: Provision from master branch

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -127,9 +127,6 @@ stages:
         environment: QA
         strategy:
           runOnce:
-            preDeploy:
-              steps:
-                - checkout: self
             deploy:
               steps:
                 - checkout: self

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -67,11 +67,12 @@ stages:
                   displayName: "Nuke resources in QA account"
                   timeoutInMinutes: 60
 
-      - deployment: init_shared
-        displayName: Provision shared resources from master branch
+      - deployment: init
+        displayName: Provision from master branch
         container: prime
         dependsOn:
           - nuke_account
+        condition: or(succeeded(), ne(variables['NUKE_QA'], 'true'))
         environment: QA
         strategy:
           runOnce:
@@ -79,92 +80,68 @@ stages:
               steps:
                 - checkout: Origin
                 - bash: ./src/qa-test-eks.sh apply-shared _global/eks-public-s3-bucket
-                  displayName: "Provision public S3 bucket"
+                  displayName: "Provision shared resources"
                   timeoutInMinutes: 15
-
-      - deployment: init
-        displayName: Provision cluster & services from master branch
-        container: prime
-        dependsOn: init_shared
-        environment: QA
-        strategy:
-          runOnce:
-            preDeploy:
-              steps:
-                - checkout: Origin
                 - bash: ./src/qa-test-eks.sh cleanup-cluster eu-west-1 qa
                   displayName: "Pre-apply cleanup"
-                  condition: eq(variables['PRE_CLEANUP'], 'true')
-            deploy:
-              steps:
-                - checkout: Origin
+                  condition: and(succeeded(), eq(variables['PRE_CLEANUP'], 'true'))
+                  timeoutInMinutes: 15
                 - bash: ./src/qa-test-eks.sh apply-cluster eu-west-1 qa
                   displayName: "Terraform apply"
                   timeoutInMinutes: 60
                 - bash: ./src/qa-test-eks.sh test eu-west-1 qa
                   displayName: "Run tests"
-
-      - deployment: apply_shared
-        condition: ne(variables['Build.SourceBranchName'], 'master')
-        displayName: Apply shared resources from feature branch
-        container: prime
-        dependsOn: init
-        environment: QA
-        strategy:
-          runOnce:
-            deploy:
-              steps:
-                - checkout: self
-                - bash: ./src/qa-test-eks.sh apply-shared _global/eks-public-s3-bucket
-                  displayName: "Provision public S3 bucket"
                   timeoutInMinutes: 15
 
       - deployment: apply
-        condition: ne(variables['Build.SourceBranchName'], 'master')
-        displayName: Apply cluster & services from feature branch
+        displayName: Apply from feature branch
         container: prime
-        dependsOn: apply_shared
+        dependsOn: init
+        condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'master'))
         environment: QA
         strategy:
           runOnce:
-            preDeploy:
-              steps:
-                - checkout: self
-                - bash: ./src/qa-test-eks.sh cleanup-cluster eu-west-1 qa
-                  displayName: "Pre-apply cleanup"
-                  condition: eq(variables['PRE_CLEANUP'], 'true')
             deploy:
               steps:
                 - checkout: self
+                - bash: ./src/qa-test-eks.sh apply-shared _global/eks-public-s3-bucket
+                  displayName: "Provision public S3 bucket"
+                  timeoutInMinutes: 15
+                - bash: ./src/qa-test-eks.sh cleanup-cluster eu-west-1 qa
+                  displayName: "Pre-apply cleanup"
+                  condition: and(succeeded(), eq(variables['PRE_CLEANUP'], 'true'))
+                  timeoutInMinutes: 15
                 - bash: ./src/qa-test-eks.sh apply-cluster eu-west-1 qa
                   displayName: "Terraform apply"
                   timeoutInMinutes: 60
                 - bash: ./src/qa-test-eks.sh test eu-west-1 qa
                   displayName: "Run tests"
+                  timeoutInMinutes: 15
 
       - deployment: init_velero
         displayName: Init Velero S3 bucket
         container: prime
         dependsOn:
           - apply
+        condition: succeeded()
         environment: QA
         strategy:
           runOnce:
             preDeploy:
               steps:
                 - checkout: self
-                - bash: ./src/qa-test-eks.sh cleanup-shared eu-west-1
-                  displayName: "Pre-apply cleanup"
-                  condition: eq(variables['PRE_CLEANUP'], 'true')
             deploy:
               steps:
                 - checkout: self
+                - bash: ./src/qa-test-eks.sh cleanup-shared eu-west-1
+                  displayName: "Pre-apply cleanup"
+                  condition: eq(variables['PRE_CLEANUP'], 'true')
                 - bash: ./src/qa-test-eks.sh apply-shared _global/s3-bucket-velero
                   displayName: "Provision Velero S3 bucket"
                   timeoutInMinutes: 15
 
-      - deployment: destroy_velero
-        displayName: Destroy Velero S3 bucket
+      - deployment: destroy
+        displayName: Destroy resources
         container: prime
         dependsOn:
           - init_velero
@@ -176,37 +153,14 @@ stages:
               steps:
                 - checkout: self
                 - bash: ./src/qa-test-eks.sh destroy-velero-bucket eu-west-1 _global/s3-bucket-velero
-                  displayName: "Terraform destroy Velero S3 bucket (post)"
+                  displayName: "Terraform destroy Velero S3 bucket"
+                  condition: succeededOrFailed()
                   timeoutInMinutes: 30
-
-      - deployment: destroy
-        displayName: Destroy cluster & services
-        container: prime
-        dependsOn:
-          - destroy_velero
-        condition: ne(variables['NO_DESTROY'], 'true')
-        environment: QA
-        strategy:
-          runOnce:
-            deploy:
-              steps:
-                - checkout: self
                 - bash: ./src/qa-test-eks.sh destroy-cluster eu-west-1 qa
-                  displayName: "Terraform destroy (post)"
+                  displayName: "Terraform destroy cluster & services"
+                  condition: succeededOrFailed()
                   timeoutInMinutes: 60
-
-      - deployment: destroy_shared
-        displayName: Destroy shared resources
-        container: prime
-        dependsOn:
-          - destroy
-        condition: ne(variables['NO_DESTROY'], 'true')
-        environment: QA
-        strategy:
-          runOnce:
-            deploy:
-              steps:
-                - checkout: self
                 - bash: ./src/qa-test-eks.sh destroy-public-bucket eu-west-1 _global/eks-public-s3-bucket
-                  displayName: "Terraform destroy public S3 bucket (post)"
+                  displayName: "Terraform destroy shared resources"
+                  condition: succeededOrFailed()
                   timeoutInMinutes: 30

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -46,12 +46,10 @@ variables:
 
 lockBehavior: sequential
 stages:
-  # Continuous Integration steps
-  - stage: CI
-    displayName: "Continuous Integration"
+  - stage: nuke
+    displayName: "Nuke QA Account"
     pool:
       vmImage: "ubuntu-latest"
-
     jobs:
       - deployment: nuke_account
         displayName: Nuke QA account
@@ -67,27 +65,35 @@ stages:
                   displayName: "Nuke resources in QA account"
                   timeoutInMinutes: 60
 
+  - stage: test
+    displayName: "Testing"
+    pool:
+      vmImage: "ubuntu-latest"
+    jobs:
       - deployment: init
         displayName: Provision from master branch
         container: prime
-        dependsOn:
-          - nuke_account
-        condition: or(succeeded(), ne(variables['NUKE_QA'], 'true'))
         environment: QA
         strategy:
           runOnce:
             deploy:
               steps:
                 - checkout: Origin
-                - bash: ./src/qa-test-eks.sh apply-shared _global/eks-public-s3-bucket
-                  displayName: "Provision shared resources"
-                  timeoutInMinutes: 15
                 - bash: ./src/qa-test-eks.sh cleanup-cluster eu-west-1 qa
                   displayName: "Pre-apply cleanup"
                   condition: and(succeeded(), eq(variables['PRE_CLEANUP'], 'true'))
                   timeoutInMinutes: 15
+                - bash: ./src/qa-test-eks.sh cleanup-shared eu-west-1
+                  displayName: "Pre-apply cleanup shared"
+                  condition: and(succeeded(), eq(variables['PRE_CLEANUP'], 'true'))
+                - bash: ./src/qa-test-eks.sh apply-shared _global/s3-bucket-velero
+                  displayName: "Provision Velero S3 bucket"
+                  timeoutInMinutes: 15
+                - bash: ./src/qa-test-eks.sh apply-shared _global/eks-public-s3-bucket
+                  displayName: "Provision shared EKS S3 bucket"
+                  timeoutInMinutes: 15
                 - bash: ./src/qa-test-eks.sh apply-cluster eu-west-1 qa
-                  displayName: "Terraform apply"
+                  displayName: "Provision cluster & services"
                   timeoutInMinutes: 60
                 - bash: ./src/qa-test-eks.sh test eu-west-1 qa
                   displayName: "Run tests"
@@ -104,44 +110,34 @@ stages:
             deploy:
               steps:
                 - checkout: self
-                - bash: ./src/qa-test-eks.sh apply-shared _global/eks-public-s3-bucket
-                  displayName: "Provision public S3 bucket"
-                  timeoutInMinutes: 15
                 - bash: ./src/qa-test-eks.sh cleanup-cluster eu-west-1 qa
                   displayName: "Pre-apply cleanup"
                   condition: and(succeeded(), eq(variables['PRE_CLEANUP'], 'true'))
                   timeoutInMinutes: 15
+                - bash: ./src/qa-test-eks.sh cleanup-shared eu-west-1
+                  displayName: "Pre-apply cleanup shared"
+                  condition: and(succeeded(), eq(variables['PRE_CLEANUP'], 'true'))
+                - bash: ./src/qa-test-eks.sh apply-shared _global/s3-bucket-velero
+                  displayName: "Provision Velero S3 bucket"
+                  timeoutInMinutes: 15
+                - bash: ./src/qa-test-eks.sh apply-shared _global/eks-public-s3-bucket
+                  displayName: "Provision shared EKS S3 bucket"
+                  timeoutInMinutes: 15
                 - bash: ./src/qa-test-eks.sh apply-cluster eu-west-1 qa
-                  displayName: "Terraform apply"
+                  displayName: "Provision cluster & services"
                   timeoutInMinutes: 60
                 - bash: ./src/qa-test-eks.sh test eu-west-1 qa
                   displayName: "Run tests"
                   timeoutInMinutes: 15
 
-      - deployment: init_velero
-        displayName: Init Velero S3 bucket
-        container: prime
-        dependsOn:
-          - apply
-        condition: succeeded()
-        environment: QA
-        strategy:
-          runOnce:
-            deploy:
-              steps:
-                - checkout: self
-                - bash: ./src/qa-test-eks.sh cleanup-shared eu-west-1
-                  displayName: "Pre-apply cleanup"
-                  condition: eq(variables['PRE_CLEANUP'], 'true')
-                - bash: ./src/qa-test-eks.sh apply-shared _global/s3-bucket-velero
-                  displayName: "Provision Velero S3 bucket"
-                  timeoutInMinutes: 15
-
+  - stage: destroy
+    displayName: "Destruction"
+    pool:
+      vmImage: "ubuntu-latest"
+    jobs:
       - deployment: destroy
         displayName: Destroy resources
         container: prime
-        dependsOn:
-          - init_velero
         condition: ne(variables['NO_DESTROY'], 'true')
         environment: QA
         strategy:

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -65,6 +65,7 @@ stages:
                 - checkout: Nuke
                 - bash: /usr/local/bin/aws-nuke -c ./nuke-config.yaml --force --force-sleep 0 --no-dry-run
                   displayName: "Nuke resources in QA account"
+                  timeoutInMinutes: 60
 
       - deployment: init_shared
         displayName: Provision shared resources from master branch
@@ -79,6 +80,7 @@ stages:
                 - checkout: Origin
                 - bash: ./src/qa-test-eks.sh apply-shared _global/eks-public-s3-bucket
                   displayName: "Provision public S3 bucket"
+                  timeoutInMinutes: 15
 
       - deployment: init
         displayName: Provision cluster & services from master branch
@@ -98,13 +100,9 @@ stages:
                 - checkout: Origin
                 - bash: ./src/qa-test-eks.sh apply-cluster eu-west-1 qa
                   displayName: "Terraform apply"
-                # TODO(emil): Move this to the Docker image after code freeze
-                - bash: sudo apt-get update && sudo apt-get --yes install golang
-                  displayName: "Install Go"
-                  condition: always()
+                  timeoutInMinutes: 60
                 - bash: ./src/qa-test-eks.sh test eu-west-1 qa
                   displayName: "Run tests"
-                  condition: always()
 
       - deployment: apply_shared
         condition: ne(variables['Build.SourceBranchName'], 'master')
@@ -119,6 +117,7 @@ stages:
                 - checkout: self
                 - bash: ./src/qa-test-eks.sh apply-shared _global/eks-public-s3-bucket
                   displayName: "Provision public S3 bucket"
+                  timeoutInMinutes: 15
 
       - deployment: apply
         condition: ne(variables['Build.SourceBranchName'], 'master')
@@ -139,13 +138,9 @@ stages:
                 - checkout: self
                 - bash: ./src/qa-test-eks.sh apply-cluster eu-west-1 qa
                   displayName: "Terraform apply"
-                # TODO(emil): Move this to the Docker image after code freeze
-                - bash: sudo apt-get update && sudo apt-get --yes install golang
-                  displayName: "Install Go"
-                  condition: always()
+                  timeoutInMinutes: 60
                 - bash: ./src/qa-test-eks.sh test eu-west-1 qa
                   displayName: "Run tests"
-                  condition: always()
 
       - deployment: init_velero
         displayName: Init Velero S3 bucket
@@ -166,6 +161,7 @@ stages:
                 - checkout: self
                 - bash: ./src/qa-test-eks.sh apply-shared _global/s3-bucket-velero
                   displayName: "Provision Velero S3 bucket"
+                  timeoutInMinutes: 15
 
       - deployment: destroy_velero
         displayName: Destroy Velero S3 bucket
@@ -181,6 +177,7 @@ stages:
                 - checkout: self
                 - bash: ./src/qa-test-eks.sh destroy-velero-bucket eu-west-1 _global/s3-bucket-velero
                   displayName: "Terraform destroy Velero S3 bucket (post)"
+                  timeoutInMinutes: 30
 
       - deployment: destroy
         displayName: Destroy cluster & services
@@ -196,6 +193,7 @@ stages:
                 - checkout: self
                 - bash: ./src/qa-test-eks.sh destroy-cluster eu-west-1 qa
                   displayName: "Terraform destroy (post)"
+                  timeoutInMinutes: 60
 
       - deployment: destroy_shared
         displayName: Destroy shared resources
@@ -211,3 +209,4 @@ stages:
                 - checkout: self
                 - bash: ./src/qa-test-eks.sh destroy-public-bucket eu-west-1 _global/eks-public-s3-bucket
                   displayName: "Terraform destroy public S3 bucket (post)"
+                  timeoutInMinutes: 30

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -99,13 +99,6 @@ stages:
             deploy:
               steps:
                 - checkout: Origin
-                - bash: ./src/qa-test-eks.sh cleanup-cluster eu-west-1 qa
-                  displayName: "Pre-apply cleanup"
-                  condition: and(succeeded(), eq(variables['PRE_CLEANUP'], 'true'))
-                  timeoutInMinutes: 15
-                - bash: ./src/qa-test-eks.sh cleanup-shared eu-west-1
-                  displayName: "Pre-apply cleanup shared"
-                  condition: and(succeeded(), eq(variables['PRE_CLEANUP'], 'true'))
                 - bash: ./src/qa-test-eks.sh apply-shared _global/eks-public-s3-bucket
                   displayName: "Provision shared EKS S3 bucket"
                   timeoutInMinutes: 15

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -78,6 +78,7 @@ stages:
         displayName: Nuke QA's AWS account
         container: aws-nuke
         dependsOn: destroy
+        condition: succeededOrFailed()
         environment: QA
         strategy:
           runOnce:
@@ -86,7 +87,6 @@ stages:
                 - checkout: Nuke
                 - bash: /usr/local/bin/aws-nuke -c ./nuke-config.yaml --force --force-sleep 5 --no-dry-run
                   displayName: "Nuke resources in QA account"
-                  condition: succeededOrFailed()
                   timeoutInMinutes: 60
 
   - stage: test

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -108,14 +108,6 @@ stages:
           runOnce:
             deploy:
               steps:
-                - checkout: self
-                - bash: ./src/qa-test-eks.sh cleanup-cluster eu-west-1 qa
-                  displayName: "Pre-apply cleanup"
-                  condition: and(succeeded(), eq(variables['PRE_CLEANUP'], 'true'))
-                  timeoutInMinutes: 15
-                - bash: ./src/qa-test-eks.sh cleanup-shared eu-west-1
-                  displayName: "Pre-apply cleanup shared"
-                  condition: and(succeeded(), eq(variables['PRE_CLEANUP'], 'true'))
                 - bash: ./src/qa-test-eks.sh apply-shared _global/eks-public-s3-bucket
                   displayName: "Provision shared EKS S3 bucket"
                   timeoutInMinutes: 15

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -45,11 +45,11 @@ variables:
   - group: "Infrastructure-Modules QA"
 
 lockBehavior: sequential
+pool:
+  vmImage: "ubuntu-latest"
 stages:
   - stage: nuke
     displayName: "Nuke QA Account"
-    pool:
-      vmImage: "ubuntu-latest"
     condition: eq(variables['NUKE_QA'], 'true')
     jobs:
       - deployment: nuke_account
@@ -67,8 +67,6 @@ stages:
 
   - stage: test
     displayName: "Testing"
-    pool:
-      vmImage: "ubuntu-latest"
     condition: or(succeeded(), ne(variables['NUKE_QA'], 'true'))
     jobs:
       - deployment: init
@@ -133,14 +131,11 @@ stages:
 
   - stage: destroy
     displayName: "Destruction"
-    pool:
-      vmImage: "ubuntu-latest"
-    condition: succeededOrFailed()
+    condition: ne(variables['NO_DESTROY'], 'true')
     jobs:
       - deployment: destroy
         displayName: Destroy resources
         container: prime
-        condition: ne(variables['NO_DESTROY'], 'true')
         environment: QA
         strategy:
           runOnce:

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -63,7 +63,7 @@ stages:
             deploy:
               steps:
                 - checkout: Nuke
-                - bash: /usr/local/bin/aws-nuke -c ./nuke-config.yaml --force --force-sleep 0 --no-dry-run
+                - bash: /usr/local/bin/aws-nuke -c ./nuke-config.yaml --force --force-sleep 5 --no-dry-run
                   displayName: "Nuke resources in QA account"
                   timeoutInMinutes: 60
 

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -87,7 +87,8 @@ stages:
 
   - stage: test
     displayName: "Testing"
-    condition: or(succeeded(), ne(variables['NUKE_QA'], 'true'))
+    dependsOn: nuke
+    condition: or(succeeded('nuke'), ne(variables['NUKE_QA'], 'true'))
     jobs:
       - deployment: init
         displayName: Provision from master branch

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -135,7 +135,7 @@ stages:
     displayName: "Destruction"
     pool:
       vmImage: "ubuntu-latest"
-    condition: succededOrFailed()
+    condition: succeededOrFailed()
     jobs:
       - deployment: destroy
         displayName: Destroy resources

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -63,12 +63,15 @@ stages:
                 - checkout: origin
                 - bash: ./src/qa-test-eks.sh destroy-velero-bucket eu-west-1 _global/s3-bucket-velero
                   displayName: "Terraform destroy Velero S3 bucket"
+                  condition: succeededOrFailed()
                   timeoutInMinutes: 30
                 - bash: ./src/qa-test-eks.sh destroy-cluster eu-west-1 qa
                   displayName: "Terraform destroy cluster & services"
+                  condition: succeededOrFailed()
                   timeoutInMinutes: 60
                 - bash: ./src/qa-test-eks.sh destroy-public-bucket eu-west-1 _global/eks-public-s3-bucket
                   displayName: "Terraform destroy shared resources"
+                  condition: succeededOrFailed()
                   timeoutInMinutes: 30
 
       - deployment: nuke_account
@@ -83,6 +86,7 @@ stages:
                 - checkout: Nuke
                 - bash: /usr/local/bin/aws-nuke -c ./nuke-config.yaml --force --force-sleep 5 --no-dry-run
                   displayName: "Nuke resources in QA account"
+                  condition: succeededOrFailed()
                   timeoutInMinutes: 60
 
   - stage: test

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -52,9 +52,29 @@ stages:
     displayName: "Nuke QA Account"
     condition: eq(variables['NUKE_QA'], 'true')
     jobs:
+      - deployment: destroy
+        displayName: Destroy resources
+        container: prime
+        environment: QA
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - checkout: origin
+                - bash: ./src/qa-test-eks.sh destroy-velero-bucket eu-west-1 _global/s3-bucket-velero
+                  displayName: "Terraform destroy Velero S3 bucket"
+                  timeoutInMinutes: 30
+                - bash: ./src/qa-test-eks.sh destroy-cluster eu-west-1 qa
+                  displayName: "Terraform destroy cluster & services"
+                  timeoutInMinutes: 60
+                - bash: ./src/qa-test-eks.sh destroy-public-bucket eu-west-1 _global/eks-public-s3-bucket
+                  displayName: "Terraform destroy shared resources"
+                  timeoutInMinutes: 30
+
       - deployment: nuke_account
-        displayName: Nuke QA account
+        displayName: Nuke QA's AWS account
         container: aws-nuke
+        dependsOn: destroy
         environment: QA
         strategy:
           runOnce:

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -50,11 +50,11 @@ stages:
     displayName: "Nuke QA Account"
     pool:
       vmImage: "ubuntu-latest"
+    condition: eq(variables['NUKE_QA'], 'true')
     jobs:
       - deployment: nuke_account
         displayName: Nuke QA account
         container: aws-nuke
-        condition: eq(variables['NUKE_QA'], 'true')
         environment: QA
         strategy:
           runOnce:
@@ -69,6 +69,7 @@ stages:
     displayName: "Testing"
     pool:
       vmImage: "ubuntu-latest"
+    condition: or(succeeded(), ne(variables['NUKE_QA'], 'true'))
     jobs:
       - deployment: init
         displayName: Provision from master branch
@@ -86,15 +87,15 @@ stages:
                 - bash: ./src/qa-test-eks.sh cleanup-shared eu-west-1
                   displayName: "Pre-apply cleanup shared"
                   condition: and(succeeded(), eq(variables['PRE_CLEANUP'], 'true'))
-                - bash: ./src/qa-test-eks.sh apply-shared _global/s3-bucket-velero
-                  displayName: "Provision Velero S3 bucket"
-                  timeoutInMinutes: 15
                 - bash: ./src/qa-test-eks.sh apply-shared _global/eks-public-s3-bucket
                   displayName: "Provision shared EKS S3 bucket"
                   timeoutInMinutes: 15
                 - bash: ./src/qa-test-eks.sh apply-cluster eu-west-1 qa
                   displayName: "Provision cluster & services"
                   timeoutInMinutes: 60
+                - bash: ./src/qa-test-eks.sh apply-shared _global/s3-bucket-velero
+                  displayName: "Provision Velero S3 bucket"
+                  timeoutInMinutes: 15
                 - bash: ./src/qa-test-eks.sh test eu-west-1 qa
                   displayName: "Run tests"
                   timeoutInMinutes: 15
@@ -117,15 +118,15 @@ stages:
                 - bash: ./src/qa-test-eks.sh cleanup-shared eu-west-1
                   displayName: "Pre-apply cleanup shared"
                   condition: and(succeeded(), eq(variables['PRE_CLEANUP'], 'true'))
-                - bash: ./src/qa-test-eks.sh apply-shared _global/s3-bucket-velero
-                  displayName: "Provision Velero S3 bucket"
-                  timeoutInMinutes: 15
                 - bash: ./src/qa-test-eks.sh apply-shared _global/eks-public-s3-bucket
                   displayName: "Provision shared EKS S3 bucket"
                   timeoutInMinutes: 15
                 - bash: ./src/qa-test-eks.sh apply-cluster eu-west-1 qa
                   displayName: "Provision cluster & services"
                   timeoutInMinutes: 60
+                - bash: ./src/qa-test-eks.sh apply-shared _global/s3-bucket-velero
+                  displayName: "Provision Velero S3 bucket"
+                  timeoutInMinutes: 15
                 - bash: ./src/qa-test-eks.sh test eu-west-1 qa
                   displayName: "Run tests"
                   timeoutInMinutes: 15
@@ -134,6 +135,7 @@ stages:
     displayName: "Destruction"
     pool:
       vmImage: "ubuntu-latest"
+    condition: succededOrFailed()
     jobs:
       - deployment: destroy
         displayName: Destroy resources

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -122,6 +122,7 @@ stages:
           runOnce:
             deploy:
               steps:
+                - checkout: self
                 - bash: ./src/qa-test-eks.sh apply-shared _global/eks-public-s3-bucket
                   displayName: "Provision shared EKS S3 bucket"
                   timeoutInMinutes: 15

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -49,6 +49,7 @@ pool:
   vmImage: "ubuntu-latest"
 stages:
   - stage: nuke
+    lockBehavior: sequential
     displayName: "Nuke QA Account"
     condition: eq(variables['NUKE_QA'], 'true')
     jobs:
@@ -66,6 +67,7 @@ stages:
                   timeoutInMinutes: 60
 
   - stage: test
+    lockBehavior: sequential
     displayName: "Testing"
     condition: or(succeeded(), ne(variables['NUKE_QA'], 'true'))
     jobs:
@@ -130,6 +132,7 @@ stages:
                   timeoutInMinutes: 15
 
   - stage: destroy
+    lockBehavior: sequential
     displayName: "Destruction"
     condition: ne(variables['NO_DESTROY'], 'true')
     jobs:

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -11,16 +11,6 @@ pr:
     include:
       - "*"
 
-# Run a daily test at midnight
-# TODO(emil): this can be removed later
-schedules:
-  - cron: "0 0 * * *"
-    displayName: Daily midnight test
-    branches:
-      include:
-        - master
-    always: true
-
 # Define resources for container to use.
 resources:
   containers:
@@ -33,12 +23,22 @@ resources:
         TF_VAR_atlantis_github_token: $(TF_VAR_atlantis_github_token)
         TF_VAR_crossplane_provider_confluent_email: $(CROSSPLANE_PROVIDER_CONFLUENT_EMAIL)
         TF_VAR_crossplane_provider_confluent_password: $(CROSSPLANE_PROVIDER_CONFLUENT_PASSWORD)
+    - container: aws-nuke
+      image: dfdsdk/aws-nuke:0.0.7
+      env:
+        AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
+        ARM_CLIENT_SECRET: $(ARM_CLIENT_SECRET)
   repositories:
     - repository: Origin
       type: github
       endpoint: "dfds (2)"
       name: dfds/infrastructure-modules
       ref: master
+    - repository: Nuke
+      type: github
+      endpoint: "dfds (2)"
+      name: dfds/qa-nuke-config
+      ref: main
 
 # Define variable group to use
 variables:
@@ -53,9 +53,24 @@ stages:
       vmImage: "ubuntu-latest"
 
     jobs:
+      - deployment: nuke_account
+        displayName: Nuke QA account
+        container: aws-nuke
+        condition: eq(variables['NUKE_QA'], 'true')
+        environment: QA
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - checkout: Nuke
+                - bash: /usr/local/bin/aws-nuke -c ./nuke-config.yaml --force --force-sleep 0 --no-dry-run
+                  displayName: "Nuke resources in QA account"
+
       - deployment: init_shared
         displayName: Provision shared resources from master branch
         container: prime
+        dependsOn:
+          - nuke_account
         environment: QA
         strategy:
           runOnce:

--- a/src/qa-test-eks.sh
+++ b/src/qa-test-eks.sh
@@ -3,63 +3,6 @@ set -eux #-o pipefail
 
 BASEPATH=./test/integration
 ACTION=$1
-# $AWS_DEFAULT_REGION
-
-function cleanup_roles {
-
-    ROLEPREFIX=$1
-
-    # Get roles
-    IFS=$'\n' roles=($(aws --no-cli-pager --region "$REGION" iam list-roles --output json | jq -r --arg ROLEPREFIX "$ROLEPREFIX" '.Roles[] | select( .RoleName | contains($ROLEPREFIX) ) | .RoleName'))
-
-    # Detach any policies and delete roles
-    for role in "${roles[@]}"; do
-        # Detach policies
-        aws --region "$REGION" iam list-attached-role-policies --role-name "$role" --output json | jq '.AttachedPolicies[].PolicyArn' | xargs -tr -L1 aws --no-cli-pager --region "$REGION" iam detach-role-policy --role-name "$role" --policy-arn || true
-
-        # Remove the role from an instance profile (if any)
-        IAM_PROFILE=$(aws --region "$REGION" iam list-instance-profiles-for-role --role-name "$role" --output json | jq -r '.InstanceProfiles[].InstanceProfileName')
-        [[ ! -z "$IAM_PROFILE" ]] && aws --region "$REGION" iam remove-role-from-instance-profile --instance-profile-name "$IAM_PROFILE" --role-name "$role" || true
-
-        # Delete role
-        aws --region "$REGION" --no-cli-pager iam delete-role --role-name "$role" || true
-
-        # Delete the instance profile
-        [[ ! -z "$IAM_PROFILE" ]] && aws --region "$REGION" iam delete-instance-profile --instance-profile-name "$IAM_PROFILE"
-    done
-
-}
-
-
-function cleanup_eni {
-    # Get all Network interfaces and treat it as an array instead of a space separated string
-    IFS=$'\n' nics=($(aws --no-cli-pager --region "$REGION" ec2 describe-network-interfaces --filters "Name=group-name,Values=eks-${CLUSTERNAME}-node" --query "NetworkInterfaces[].NetworkInterfaceId" --output json | jq -r '.[]'))
-
-    # Loop over network interfaces and delete them one by one
-    for nic in "${nics[@]}"; do
-        aws --no-cli-pager --region "$REGION" ec2 delete-network-interface --network-interface-id $nic || true
-    done
-
-}
-
-
-if [ "$ACTION" = "cleanup-cluster" ]; then
-    REGION=$2
-    CLUSTERNAME=$3
-
-    # Remove specific resources that sometimes get left behind (always return true, as resource may have been successfully been cleaned up)
-    cleanup_roles "eks-${CLUSTERNAME}-"
-    cleanup_roles "${CLUSTERNAME}-"
-    cleanup_eni
-fi
-
-
-if [ "$ACTION" = "cleanup-shared" ]; then
-    REGION=$2
-
-    # Remove specific resources that sometimes get left behind (always return true, as resource may have been successfully been cleaned up)
-    cleanup_roles "Velero"
-fi
 
 
 if [ "$ACTION" = "apply-shared" ]; then
@@ -82,10 +25,7 @@ fi
 
 
 if [ "$ACTION" = "test" ]; then
-    # --------------------------------------------------
     # Get kubeconfig path
-    # --------------------------------------------------
-
     REGION=$2
     CLUSTERNAME=$3
     WORKDIR="${BASEPATH}/${REGION}/k8s-${CLUSTERNAME}/cluster"
@@ -101,43 +41,22 @@ fi
 
 
 if [ "$ACTION" = "destroy-cluster" ]; then
-    RETURN=0
     REGION=$2
     CLUSTERNAME=$3
     WORKDIR="${BASEPATH}/${REGION}/k8s-${CLUSTERNAME}"
 
-    # Disable cluster logging
-    echo Disabling cluster logging
-    aws --region "$REGION" eks update-cluster-config --name "$CLUSTERNAME" --logging '{"clusterLogging":[{"types":["api","audit","authenticator","controllerManager","scheduler"],"enabled":false}]}' || true
-    sleep 60
-
-    # Essential cleanup commands (set RETURN=1 if fails)
-    terragrunt destroy-all --terragrunt-working-dir "$WORKDIR" --terragrunt-source-update --terragrunt-non-interactive -input=false -auto-approve || RETURN=1
-
-    # Remove specific resources that sometimes get left behind (always return true, as resource may have been successfully been cleaned up)
-    cleanup_roles "eks-${CLUSTERNAME}-"
-    cleanup_eni
-
-    # Return false, if any *eseential* commands failed
-    if [ $RETURN -ne 0 ]; then
-        false
-    fi
+    # Destroy resources
+    terragrunt destroy-all --terragrunt-working-dir "$WORKDIR" --terragrunt-source-update --terragrunt-non-interactive -input=false -auto-approve
 fi
 
 
 if [ "$ACTION" = "destroy-public-bucket" ]; then
-    RETURN=0
     REGION=$2
     SUBPATH=$3
     WORKDIR="${BASEPATH}/${SUBPATH}"
 
-    # Cleanup
-    terragrunt run-all destroy --terragrunt-working-dir "$WORKDIR" --terragrunt-source-update --terragrunt-non-interactive -input=false -auto-approve || RETURN=1
-
-    # Return false, if any *eseential* commands failed
-    if [ $RETURN -ne 0 ]; then
-        false
-    fi
+    # Destroy resources
+    terragrunt run-all destroy --terragrunt-working-dir "$WORKDIR" --terragrunt-source-update --terragrunt-non-interactive -input=false -auto-approve
 fi
 
 if [ "$ACTION" = "destroy-velero-bucket" ]; then
@@ -146,14 +65,6 @@ if [ "$ACTION" = "destroy-velero-bucket" ]; then
     SUBPATH=$3
     WORKDIR="${BASEPATH}/${SUBPATH}"
 
-    # Cleanup
-    terragrunt run-all destroy --terragrunt-working-dir "$WORKDIR" --terragrunt-source-update --terragrunt-non-interactive -input=false -auto-approve || RETURN=1
-
-    # Remove specific resources that sometimes get left behind (always return true, as resource may have been successfully been cleaned up)
-    cleanup_roles "Velero"
-
-    # Return false, if any *eseential* commands failed
-    if [ $RETURN -ne 0 ]; then
-        false
-    fi
+    # Destroy resources
+    terragrunt run-all destroy --terragrunt-working-dir "$WORKDIR" --terragrunt-source-update --terragrunt-non-interactive -input=false -auto-approve
 fi


### PR DESCRIPTION
- Optionally, allow one to reset the QA account with the `NUKE_QA` environment variable.
- Remove the now unnecessary Go install.
- Add some timeouts.
- Set explicit conditions on jobs/steps to better handle skips and cancellations.
- Combine some jobs and deploy stages for efficiency.
- Reorganize into stages