### PR TITLE
Disable updates to indirect Go dependencies.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,11 +37,6 @@
             "automerge": false,
             "dependencyDashboard": true,
             "dependencyDashboardApproval": false
-        },
-        {
-            "matchManagers": ["gomod"],
-            "matchDepTypes": ["indirect"],
-            "enabled": true
         }
     ]
 }


### PR DESCRIPTION
It was producing too much noise and the PRs constantly conflict with each other on `go.mod` file.