### PR TITLE
Use kube-prometheus-stack 44.3.0 in QA

### DIFF
--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -76,7 +76,7 @@ inputs = {
   # --------------------------------------------------
 
   monitoring_kube_prometheus_stack_deploy                     = true
-  monitoring_kube_prometheus_stack_chart_version              = "31.0.0"
+  monitoring_kube_prometheus_stack_chart_version              = "44.3.0"
   monitoring_kube_prometheus_stack_target_namespaces          = "kube-system|monitoring"
   monitoring_kube_prometheus_stack_prometheus_storage_size    = "5Gi"
   monitoring_kube_prometheus_stack_prometheus_storageclass    = "gp2"


### PR DESCRIPTION
Signed-off-by: Audun Nes <audun.nes@gmail.com>

This is expected to fail in QA, since there are close to 100 manual steps to run through in order to update from 33.1.0 to 44.3.0, and trying to achive this by hacking QA has proved to be counter-productive.