### PR TITLE
Fluentd with containerd

### DIFF
--- a/_sub/compute/eks-nodegroup-unmanaged/outputs.tf
+++ b/_sub/compute/eks-nodegroup-unmanaged/outputs.tf
@@ -2,3 +2,7 @@ output "autoscaling_group_id" {
   value = try(aws_autoscaling_group.eks[*].id, [])
 }
 
+output "container_runtime" {
+  value = var.container_runtime
+}
+

--- a/_sub/compute/eks-nodegroup-unmanaged/vars.tf
+++ b/_sub/compute/eks-nodegroup-unmanaged/vars.tf
@@ -63,6 +63,11 @@ variable "eks_endpoint" {
 variable "container_runtime" {
   type    = string
   default = "containerd"
+
+  validation {
+    condition     = contains(["dockerd", "containerd"], var.container_runtime)
+    error_message = "Valid values for var.container_runtime are dockerd and containerd."
+  }
 }
 
 variable "eks_certificate_authority" {

--- a/_sub/monitoring/fluentd-cloudwatch/dependencies.tf
+++ b/_sub/monitoring/fluentd-cloudwatch/dependencies.tf
@@ -60,7 +60,61 @@ locals {
     ]
   }
 
-  config_patch_yaml = <<YAML
+  # TODO(emil): remove once dockershim is removed with move to 1.24
+  config_patch_yaml_dockerd = <<YAML
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${local.fluentd_namespace}
+
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ${local.fluentd_name}
+  namespace: ${local.fluentd_namespace}
+spec:
+  template:
+    spec:
+      serviceAccountName: ${local.fluentd_name}
+      containers:
+        - name: ${local.fluentd_name}
+          env:
+            - name: AWS_REGION
+              value: "${var.aws_region}"
+            - name: RETENTION_IN_DAYS
+              value: "${var.retention_in_days}"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${local.fluentd_name}
+  namespace: ${local.fluentd_namespace}
+data:
+  02-tag.conf: |-
+    # Tag with namespace and prefix with clustername
+    <match kubernetes.**>
+      @type rewrite_tag_filter
+      <rule>
+        key $.kubernetes.namespace_name
+        pattern ^(.+)$
+        tag /k8s/${var.cluster_name}/$1
+      </rule>
+    </match>
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${local.fluentd_name}
+  namespace: ${local.fluentd_namespace}
+  annotations:
+    eks.amazonaws.com/role-arn: ${aws_iam_role.this.arn}
+    eks.amazonaws.com/sts-regional-endpoints: "true"
+YAML
+
+  config_patch_yaml_containerd = <<YAML
 ---
 apiVersion: v1
 kind: Namespace

--- a/_sub/monitoring/fluentd-cloudwatch/main.tf
+++ b/_sub/monitoring/fluentd-cloudwatch/main.tf
@@ -13,7 +13,7 @@ resource "github_repository_file" "fluentd-cloudwatch_config_patch_yaml" {
   repository = var.repo_name
   branch     = data.github_branch.flux_branch.branch
   file       = "${local.config_repo_path}/patch.yaml"
-  content    = local.config_patch_yaml
+  content    = var.container_runtime == "containerd" ? local.config_patch_yaml_containerd : local.config_patch_yaml_dockerd
 }
 
 resource "github_repository_file" "fluentd-cloudwatch_config_path" {

--- a/_sub/monitoring/fluentd-cloudwatch/vars.tf
+++ b/_sub/monitoring/fluentd-cloudwatch/vars.tf
@@ -3,6 +3,16 @@ variable "cluster_name" {
   description = "The name of the EKS cluster."
 }
 
+variable "container_runtime" {
+  type        = string
+  description = "The container runtime utilized within the EKS cluster."
+
+  validation {
+    condition     = contains(["dockerd", "containerd"], var.container_runtime)
+    error_message = "Valid values for var.container_runtime are dockerd and containerd."
+  }
+}
+
 variable "deploy_name" {
   type        = string
   description = "Unique identifier of the deployment, only needs override if deploying multiple instances"

--- a/compute/eks-ec2/outputs.tf
+++ b/compute/eks-ec2/outputs.tf
@@ -49,6 +49,12 @@ output "eks_cluster_nodes_sg_id" {
   value = module.eks_workers_security_group.id
 }
 
+output "eks_worker_autoscaling_group_container_runtimes" {
+  value = flatten([
+    module.eks_nodegroup1_workers.container_runtime,
+    module.eks_nodegroup2_workers.container_runtime,
+  ])
+}
 
 # --------------------------------------------------
 # Misc

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -647,6 +647,7 @@ module "fluentd_cloudwatch_flux_manifests" {
   source                          = "../../_sub/monitoring/fluentd-cloudwatch"
   count                           = var.fluentd_cloudwatch_flux_deploy ? 1 : 0
   cluster_name                    = var.eks_cluster_name
+  container_runtime               = contains(data.terraform_remote_state.cluster.outputs.eks_worker_autoscaling_group_container_runtimes, "containerd") ? "containerd" : "dockerd"
   aws_region                      = var.aws_region
   retention_in_days               = var.fluentd_cloudwatch_retention_in_days
   repo_name                       = var.fluentd_cloudwatch_flux_repo_name != null ? var.fluentd_cloudwatch_flux_repo_name : var.platform_fluxcd_repo_name

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -647,7 +647,7 @@ module "fluentd_cloudwatch_flux_manifests" {
   source                          = "../../_sub/monitoring/fluentd-cloudwatch"
   count                           = var.fluentd_cloudwatch_flux_deploy ? 1 : 0
   cluster_name                    = var.eks_cluster_name
-  container_runtime               = contains(data.terraform_remote_state.cluster.outputs.eks_worker_autoscaling_group_container_runtimes, "containerd") ? "containerd" : "dockerd"
+  container_runtime               = contains(data.terraform_remote_state.cluster.outputs.eks_worker_autoscaling_group_container_runtimes, "dockerd") ? "dockerd" : "containerd"
   aws_region                      = var.aws_region
   retention_in_days               = var.fluentd_cloudwatch_retention_in_days
   repo_name                       = var.fluentd_cloudwatch_flux_repo_name != null ? var.fluentd_cloudwatch_flux_repo_name : var.platform_fluxcd_repo_name


### PR DESCRIPTION
- Configure fluentd based on runtime
- Concatenates partial logs emitted by containerd using the fluent-plugin-concat plugin
- Validation for container runtime values
- If either of the node groups in the EKS cluster has a `dockerd` container runtime it will configure fluentd to collect from `dockerd` otherwise it will be configured to collect from `containerd`