### PR TITLE
Enable WAL for Grafana

### DIFF
--- a/_sub/compute/helm-kube-prometheus-stack/values/grafana.yaml
+++ b/_sub/compute/helm-kube-prometheus-stack/values/grafana.yaml
@@ -1,6 +1,6 @@
 grafana:
   image:
-    tag: 9.4.0-beta1
+    tag: 9.4.0-beta1 # TODO: Remove when Grafana 9.4.0 is released AND becomes part of kube-prometheus-stack
   resources:
     requests:
       cpu: 50m

--- a/_sub/compute/helm-kube-prometheus-stack/values/grafana.yaml
+++ b/_sub/compute/helm-kube-prometheus-stack/values/grafana.yaml
@@ -1,4 +1,6 @@
 grafana:
+  image:
+    tag: 9.4.0-beta1
   resources:
     requests:
       cpu: 50m
@@ -6,6 +8,8 @@ grafana:
   adminPassword: "${grafana_admin_password}"
   priorityClassName: ${grafana_priorityclass}
   grafana.ini:
+    database:
+      wal: true
     auth.anonymous:
       enabled: true
     metrics:


### PR DESCRIPTION
- Use write-ahead logging (WAL) with Grafana's embedded sqllite3 database; a feature not available until Grafana 9.4.0, which is yet to be released
- Add a TODO clause for remembering to remove using a beta image for Grafana
