### PR TITLE
Allow configuration of intervalDuration for helm-exporter; Sets default to 10 minutes

### DIFF
--- a/_sub/monitoring/helm-exporter/dependencies.tf
+++ b/_sub/monitoring/helm-exporter/dependencies.tf
@@ -60,6 +60,7 @@ locals {
         "deployment" = {
           "replicas" = var.replicas
         }
+        "intervalDuration" = var.interval_duration
       }
     }
   }

--- a/_sub/monitoring/helm-exporter/vars.tf
+++ b/_sub/monitoring/helm-exporter/vars.tf
@@ -41,3 +41,9 @@ variable "helm_chart_version" {
   description = "The version of the helm Exporter Helm Chart that should be used"
   default     = null
 }
+
+variable "interval_duration" {
+  type = string
+  description = "Interval between scrapes of Helm releases"
+  default = "10m"
+}


### PR DESCRIPTION
With the current configuration _helm-exporter_ will scrape the cluster for Helm releases every time the /metrics endpoint is hit.

Our Prometheus instance is configured to scrape all targets every 30 seconds.

![Screenshot 2023-03-05 at 8 44 55@2x](https://user-images.githubusercontent.com/1633308/222982184-8aec30fb-a268-4243-b1df-4de1795d90dc.png)

Throughout the last 6 days, this helm-exporter deployment has caused 4.39M logs lines from the kube apiserver out of a total 29.9M, or rather, 14.68%.

This PR changes the [intervalDuration setting for helm-exporter](https://github.com/sstarcher/helm-exporter/blob/b8eb96d7a2baca8f41aba1894b67c4825b392360/main.go#L55), so instead of the default value of 0, it is set to 10m. When the value of _intervalDuration_ is 0, nothing is cached and the cluster is scraped on every /metrics hit. If it's anything but 0, it will scrape the cluster, pause for the duration set, and then scrape again. Rinse and repeat. The resulting data is cached and served via /metrics.

----

![Screenshot 2023-03-05 at 8 56 51@2x](https://user-images.githubusercontent.com/1633308/222982818-bd65b9f5-b7b7-4bfc-a69c-317b5e415766.png)
![Screenshot 2023-03-05 at 8 58 18@2x](https://user-images.githubusercontent.com/1633308/222982827-49c2bb05-cf74-4c7c-abb7-5ef9ea890892.png)

After adding the intervalDuration manually to the deployment in Hellman, I'm seeing about 18.78X less log entries from the apiserver regarding helm-exporter.

Thanks to @emil2k for noticing the increase in traffic to the apiserver at https://github.com/dfds/cloudplatform/issues/1411#issuecomment-1455149333.

@Ranixa I've added you as reviewer since you [created the Terraform module for helm-exporter in infrastructure-modules](https://github.com/dfds/infrastructure-modules/pull/567). Not sure if 10 minutes is too high for the scrape interval. Feel free to suggest a different interval if it's too long.