### PR TITLE
Avoid recreating autoscaling group attachments.

### DIFF
--- a/_sub/compute/eks-alb-auth/main.tf
+++ b/_sub/compute/eks-alb-auth/main.tf
@@ -45,8 +45,8 @@ resource "aws_lb_target_group" "traefik_auth_blue_variant" {
 }
 
 resource "aws_autoscaling_attachment" "traefik_auth_blue_variant" {
-  count                  = var.deploy_blue_variant ? length(var.autoscaling_group_ids) : 0
-  autoscaling_group_name = var.autoscaling_group_ids[count.index]
+  for_each               = var.deploy_blue_variant ? var.autoscaling_group_ids : []
+  autoscaling_group_name = each.key
   lb_target_group_arn    = aws_lb_target_group.traefik_auth_blue_variant[0].arn
 }
 
@@ -71,8 +71,8 @@ resource "aws_lb_target_group" "traefik_auth_green_variant" {
 }
 
 resource "aws_autoscaling_attachment" "traefik_auth_green_variant" {
-  count                  = var.deploy_green_variant ? length(var.autoscaling_group_ids) : 0
-  autoscaling_group_name = var.autoscaling_group_ids[count.index]
+  for_each               = var.deploy_green_variant ? var.autoscaling_group_ids : []
+  autoscaling_group_name = each.key
   lb_target_group_arn    = aws_lb_target_group.traefik_auth_green_variant[0].arn
 }
 

--- a/_sub/compute/eks-alb-auth/vars.tf
+++ b/_sub/compute/eks-alb-auth/vars.tf
@@ -15,7 +15,7 @@ variable "vpc_id" {
 }
 
 variable "autoscaling_group_ids" {
-  type = list(string)
+  type = set(string)
 }
 
 # variable "traefik_k8s_name" {}

--- a/_sub/compute/eks-alb/main.tf
+++ b/_sub/compute/eks-alb/main.tf
@@ -45,8 +45,8 @@ resource "aws_lb_target_group" "traefik_blue_variant" {
 }
 
 resource "aws_autoscaling_attachment" "traefik_blue_variant" {
-  count                  = var.deploy_blue_variant ? length(var.autoscaling_group_ids) : 0
-  autoscaling_group_name = var.autoscaling_group_ids[count.index]
+  for_each               = var.deploy_blue_variant ? var.autoscaling_group_ids : []
+  autoscaling_group_name = each.key
   lb_target_group_arn    = aws_lb_target_group.traefik_blue_variant[0].arn
 }
 
@@ -71,8 +71,8 @@ resource "aws_lb_target_group" "traefik_green_variant" {
 }
 
 resource "aws_autoscaling_attachment" "traefik_green_variant" {
-  count                  = var.deploy_green_variant ? length(var.autoscaling_group_ids) : 0
-  autoscaling_group_name = var.autoscaling_group_ids[count.index]
+  for_each               = var.deploy_green_variant ? var.autoscaling_group_ids : []
+  autoscaling_group_name = each.key
   lb_target_group_arn    = aws_lb_target_group.traefik_green_variant[0].arn
 }
 

--- a/_sub/compute/eks-alb/vars.tf
+++ b/_sub/compute/eks-alb/vars.tf
@@ -15,7 +15,7 @@ variable "vpc_id" {
 }
 
 variable "autoscaling_group_ids" {
-  type = list(string)
+  type = set(string)
 }
 
 # variable "traefik_k8s_name" {}


### PR DESCRIPTION
Use `for_each` to remove dependence on the order of the list of auto scaling groups.