### PR TITLE
Ability to enable query logging on Prometheus.

### DIFF
--- a/_sub/compute/helm-kube-prometheus-stack/main.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/main.tf
@@ -65,6 +65,7 @@ resource "helm_release" "kube_prometheus_stack" {
       prometheus_request_cpu    = var.prometheus_request_cpu
       prometheus_limit_memory   = var.prometheus_limit_memory
       prometheus_limit_cpu      = var.prometheus_limit_cpu
+      query_log_file_enabled    = var.query_log_file_enabled
       enable_features           = var.enable_features
       tolerations               = var.tolerations,
       affinity                  = var.affinity,

--- a/_sub/compute/helm-kube-prometheus-stack/values/prometheus.yaml
+++ b/_sub/compute/helm-kube-prometheus-stack/values/prometheus.yaml
@@ -18,6 +18,9 @@ prometheus:
           port: http
   prometheusSpec:
     enableAdminAPI: false
+%{ if query_log_file_enabled ~}
+    queryLogFile: "/dev/stdout"
+%{ endif ~}
 %{ if length(enable_features) > 0 ~}
     enableFeatures:
 %{ for f in enable_features ~}

--- a/_sub/compute/helm-kube-prometheus-stack/vars.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/vars.tf
@@ -12,11 +12,11 @@ variable "chart_version" {
 variable "namespace" {
   type        = string
   description = "Namespace to apply Kube-prometheus-stack in"
+
   validation {
     condition     = can(regex("[a-z]+", var.namespace))
     error_message = "Namespace must contain at least one letter."
   }
-
 }
 
 variable "priority_class" {
@@ -153,6 +153,12 @@ variable "overwrite_on_create" {
   type        = bool
   default     = true
   description = "Enable overwriting existing files"
+}
+
+variable "query_log_file_enabled" {
+  type        = bool
+  default     = false
+  description = "Whether to to enable the Prometheus query loggging."
 }
 
 variable "enable_features" {

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -443,6 +443,7 @@ module "monitoring_kube_prometheus_stack" {
   prometheus_request_cpu      = var.monitoring_kube_prometheus_stack_prometheus_request_cpu
   prometheus_limit_memory     = var.monitoring_kube_prometheus_stack_prometheus_limit_memory
   prometheus_limit_cpu        = var.monitoring_kube_prometheus_stack_prometheus_limit_cpu
+  query_log_file_enabled      = var.monitoring_kube_prometheus_stack_prometheus_query_log_file_enabled
   enable_features             = var.monitoring_kube_prometheus_stack_prometheus_enable_features
   overwrite_on_create         = var.platform_fluxcd_overwrite_on_create
   tolerations                 = var.monitoring_tolerations

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -336,6 +336,12 @@ variable "monitoring_kube_prometheus_stack_prometheus_limit_cpu" {
   default     = "1000m"
 }
 
+variable "monitoring_kube_prometheus_stack_prometheus_query_log_file_enabled" {
+  type        = bool
+  description = "Whether to enable the query logging in Prometheus."
+  default     = false
+}
+
 variable "monitoring_kube_prometheus_stack_prometheus_enable_features" {
   type        = list(string)
   description = "Prometheus feature flags to enable."

--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -117,25 +117,26 @@ inputs = {
   # Kube-prometheus-stack
   # --------------------------------------------------
 
-  monitoring_kube_prometheus_stack_deploy                     = true
-  monitoring_kube_prometheus_stack_chart_version              = "44.3.0"
-  monitoring_kube_prometheus_stack_target_namespaces          = "kube-system|monitoring"
-  monitoring_kube_prometheus_stack_prometheus_storage_size    = "5Gi"
-  monitoring_kube_prometheus_stack_prometheus_storageclass    = "gp2"
-  monitoring_kube_prometheus_stack_prometheus_retention       = "1d"
-  monitoring_kube_prometheus_stack_slack_webhook              = "https://dummy.slack.webhook"
-  monitoring_kube_prometheus_stack_slack_channel              = "#hellman-alerting"
-  monitoring_kube_prometheus_stack_github_owner               = "dfds"
-  monitoring_kube_prometheus_stack_repo_name                  = "platform-manifests-qa"
-  monitoring_kube_prometheus_stack_repo_branch                = "main"
-  monitoring_kube_prometheus_stack_prometheus_request_memory  = "500Mi"
-  monitoring_kube_prometheus_stack_prometheus_request_cpu     = "500m"
-  monitoring_kube_prometheus_stack_prometheus_limit_memory    = "2Gi"
-  monitoring_kube_prometheus_stack_prometheus_limit_cpu       = "1000m"
-  monitoring_kube_prometheus_stack_grafana_storage_enabled    = true
-  monitoring_kube_prometheus_stack_grafana_storage_size       = "5Gi"
-  monitoring_kube_prometheus_stack_grafana_storageclass       = "gp2"
-  monitoring_kube_prometheus_stack_prometheus_enable_features = ["memory-snapshot-on-shutdown"]
+  monitoring_kube_prometheus_stack_deploy                            = true
+  monitoring_kube_prometheus_stack_chart_version                     = "44.3.0"
+  monitoring_kube_prometheus_stack_target_namespaces                 = "kube-system|monitoring"
+  monitoring_kube_prometheus_stack_prometheus_storage_size           = "5Gi"
+  monitoring_kube_prometheus_stack_prometheus_storageclass           = "gp2"
+  monitoring_kube_prometheus_stack_prometheus_retention              = "1d"
+  monitoring_kube_prometheus_stack_slack_webhook                     = "https://dummy.slack.webhook"
+  monitoring_kube_prometheus_stack_slack_channel                     = "#hellman-alerting"
+  monitoring_kube_prometheus_stack_github_owner                      = "dfds"
+  monitoring_kube_prometheus_stack_repo_name                         = "platform-manifests-qa"
+  monitoring_kube_prometheus_stack_repo_branch                       = "main"
+  monitoring_kube_prometheus_stack_prometheus_request_memory         = "500Mi"
+  monitoring_kube_prometheus_stack_prometheus_request_cpu            = "500m"
+  monitoring_kube_prometheus_stack_prometheus_limit_memory           = "2Gi"
+  monitoring_kube_prometheus_stack_prometheus_limit_cpu              = "1000m"
+  monitoring_kube_prometheus_stack_grafana_storage_enabled           = true
+  monitoring_kube_prometheus_stack_grafana_storage_size              = "5Gi"
+  monitoring_kube_prometheus_stack_grafana_storageclass              = "gp2"
+  monitoring_kube_prometheus_stack_prometheus_query_log_file_enabled = true
+  monitoring_kube_prometheus_stack_prometheus_enable_features        = ["memory-snapshot-on-shutdown"]
   # monitoring_kube_prometheus_stack_azure_tenant_id is set as ARM_TENANT_ID in
   # Azure DevOps Pipeline Library "Infrastructure-Modules QA" in and mapped in the
   # Azure DevOps pipeline file as TF_VAR_monitoring_kube_prometheus_stack_azure_tenant_id


### PR DESCRIPTION
Example CloudWatch Query: 

```
fields @timestamp, params.query, stats.samples.peakSamples, stats.samples.totalQueryableSamples, stats.timings.execTotalTime
| filter stream_name == "prometheus-monitoring-kube-prometheus-prometheus-0"
| filter stream == "stdout"
| sort stats.timings.execTotalTime desc
| limit 20
```