### PR TITLE
Automated inactivity triggered EKS/ELB clean up for sandboxes.

### DIFF
--- a/_sub/compute/eks-alb-auth/outputs.tf
+++ b/_sub/compute/eks-alb-auth/outputs.tf
@@ -2,6 +2,14 @@ output "alb_fqdn" {
   value = element(concat(aws_lb.traefik_auth[*].dns_name, [""]), 0)
 }
 
+output "alb_name" {
+  value = (var.deploy_blue_variant || var.deploy_green_variant) ? aws_lb.traefik_auth[0].name : ""
+}
+
+output "alb_arn" {
+  value = (var.deploy_blue_variant || var.deploy_green_variant) ? aws_lb.traefik_auth[0].arn : ""
+}
+
 output "alb_arn_suffix" {
   value = (var.deploy_blue_variant || var.deploy_green_variant) ? aws_lb.traefik_auth[0].arn_suffix : ""
 }

--- a/_sub/compute/eks-alb/outputs.tf
+++ b/_sub/compute/eks-alb/outputs.tf
@@ -2,6 +2,14 @@ output "alb_fqdn" {
   value = element(concat(aws_lb.traefik[*].dns_name, [""]), 0)
 }
 
+output "alb_name" {
+  value = (var.deploy_blue_variant || var.deploy_green_variant) ? aws_lb.traefik[0].name : ""
+}
+
+output "alb_arn" {
+  value = (var.deploy_blue_variant || var.deploy_green_variant) ? aws_lb.traefik[0].arn : ""
+}
+
 output "alb_arn_suffix" {
   value = (var.deploy_blue_variant || var.deploy_green_variant) ? aws_lb.traefik[0].arn_suffix : ""
 }

--- a/_sub/compute/eks-cluster/outputs.tf
+++ b/_sub/compute/eks-cluster/outputs.tf
@@ -10,6 +10,10 @@ output "subnet_ids" {
   value = aws_subnet.eks[*].id
 }
 
+output "eks_cluster_arn" {
+  value = aws_eks_cluster.eks.arn
+}
+
 output "eks_endpoint" {
   value = aws_eks_cluster.eks.endpoint
 }

--- a/_sub/compute/eks-inactivity-cleanup/documents/delete-eks.yaml
+++ b/_sub/compute/eks-inactivity-cleanup/documents/delete-eks.yaml
@@ -120,7 +120,7 @@ mainSteps:
     isCritical: true
     timeoutSeconds: 600
     description: |
-      ##DeleteEKSCluster
+      ## DeleteEKSCluster
       Delete EKS Cluster
       ## Outputs
       * EKSClusterStatus

--- a/_sub/compute/eks-inactivity-cleanup/documents/delete-eks.yaml
+++ b/_sub/compute/eks-inactivity-cleanup/documents/delete-eks.yaml
@@ -1,0 +1,193 @@
+---
+description: |
+  ### Delete EKS cluster
+
+  This document is based on the AWS-managed document `AWS-DeleteEKSCluster`, but has been modified somewhat.
+
+schemaVersion: "0.3"
+assumeRole: "{{AutomationAssumeRole}}"
+parameters:
+  EKSClusterName:
+    type: String
+    description: (Required) The name of the Amazon EKS Cluster to be deleted.
+    allowedPattern: "^[A-Za-z0-9_-]*$"
+  AutomationAssumeRole:
+    type: String
+    description: (Optional) The ARN of the role that allows Automation to perform the actions on your behalf.
+    default: ""
+    allowedPattern: "^arn:aws(-cn|-us-gov)?:iam::\\d{12}:role/[\\w+=,.@-]+|^$"
+
+outputs:
+  - DeleteEKSCluster.output
+  - DeleteNodeGroups.output
+mainSteps:
+  - name: DeleteNodeGroups
+    action: aws:executeScript
+    onFailure: Abort
+    isCritical: true
+    timeoutSeconds: 600
+    description: |
+      ## DeleteNodeGroups
+      Find and delete all node groups in the EKS cluster.
+      ## Outputs
+      * DeletedNodeGroups
+      * RemainingNodeGroups
+    inputs:
+      Runtime: python3.7
+      Handler: delete_node_groups_handler
+      InputPayload:
+        EKSClusterName: "{{EKSClusterName}}"
+      Script: |
+        import json
+        import boto3
+        import time
+
+        eks = boto3.client('eks')
+        DEFAULT_SLEEP_TIME=10
+
+        def delete_nodegroups(eks_cluster_name):
+            nodegroups = []
+            remaining_nodegroups = []
+            temp_remaining_nodegroups = []
+            nodegroups_response = eks.list_nodegroups(
+                clusterName=eks_cluster_name,
+                maxResults=100
+            )
+            nodegroups = nodegroups_response['nodegroups']
+            if "nextToken" in nodegroups_response:
+                while "nextToken" in nodegroups_response:
+                    nodegroups_response = eks.list_nodegroups(
+                    clusterName=eks_cluster_name,
+                    maxResults=100,
+                    nextToken=nodegroups_response['nextToken']
+                    )
+                    nodegroups += nodegroups_response['nodegroups']
+
+            for count,node in enumerate(nodegroups):
+                delete_nodegroup_response = eks.delete_nodegroup(
+                clusterName=eks_cluster_name,
+                nodegroupName=node
+                )
+                if delete_nodegroup_response['nodegroup']['status'] != "DELETING":
+                    remaining_nodegroups.append(node)
+
+            for x in range(2):
+                if not remaining_nodegroups:
+                    break
+                time.sleep(DEFAULT_SLEEP_TIME)
+                for count,node in enumerate(remaining_nodegroups):
+                    delete_nodegroup_response = eks.delete_nodegroup(
+                    clusterName=eks_cluster_name,
+                    nodegroupName=node
+                    )
+                    if delete_nodegroup_response['nodegroup']['status'] == "DELETING":
+                        temp_remaining_nodegroups.append(node)
+                remaining_nodegroups = temp_remaining_nodegroups
+                temp_remaining_nodegroups  =[]
+            return nodegroups,remaining_nodegroups
+
+        def delete_node_groups_handler(event, context):
+                eks_cluster_name = event['EKSClusterName']
+                successful = True
+                deleted_nodegroups = []
+                remaining_nodegroups =[]
+                msg= ''
+                try:
+                    deleted_nodegroups,remaining_nodegroups = delete_nodegroups(eks_cluster_name)
+                except Exception as e:
+                    successful= False
+                    msg= str(e)
+
+                out ={
+                    "DeletedNodeGroups": deleted_nodegroups,
+                    "RemainingNodeGroups": remaining_nodegroups
+                    }
+
+                if not successful:
+                    raise Exception(msg,out)
+
+                return {
+                'output': json.dumps(out)
+                }
+    outputs:
+      - Name: output
+        Selector: $.Payload.output
+        Type: String
+
+  - name: DeleteEKSCluster
+    action: aws:executeScript
+    onFailure: Abort
+    isCritical: true
+    timeoutSeconds: 600
+    description: |
+      ##DeleteEKSCluster
+      Delete EKS Cluster
+      ## Outputs
+      * EKSClusterStatus
+          * EKSClusterName: Deleted EKS Cluster name.
+          * DeleteStatus: 'DELETING'
+    inputs:
+      Runtime: python3.7
+      Handler: delete_eks_cluster_handler
+      InputPayload:
+        EKSClusterName: "{{EKSClusterName}}"
+      Script: |
+        import json
+        import boto3
+        import time
+        eks = boto3.client('eks')
+
+        delete_eks_cluster_retrials = 0
+        eks_delete_status = "Failed"
+        MAX_RETRIALS_NUM= 10
+        DEFAULT_SLEEP_TIME=30
+
+        def delete_eks_cluster(eks_cluster_name):
+            global delete_eks_cluster_retrials
+            global eks_delete_status
+            try:
+                response = eks.delete_cluster(
+                    name=eks_cluster_name
+                )
+                eks_delete_status = response['cluster']['status']
+            except Exception as e:
+                time.sleep(DEFAULT_SLEEP_TIME)
+                if delete_eks_cluster_retrials < MAX_RETRIALS_NUM:
+                    delete_eks_cluster_retrials += 1
+                    delete_eks_cluster(eks_cluster_name)
+                else:
+                    raise e
+
+        def delete_eks_cluster_handler(event, context):
+                eks_cluster_name = event['EKSClusterName']
+                error_msg=''
+
+                eks_cluster_status ={
+                    "Name":eks_cluster_name,
+                    "DeleteStatus" : "Undefined"
+                }
+                successful = True
+
+                try:
+                    delete_eks_cluster(eks_cluster_name)
+                    eks_cluster_status["DeleteStatus"] = eks_delete_status
+                except Exception as e:
+                    successful= False
+                    eks_cluster_status["DeleteStatus"] = "Failed"
+                    error_msg= str(e)
+
+
+                out ={
+                    "EKSClusterStatus": eks_cluster_status
+                    }
+
+                if not successful:
+                    raise Exception(error_msg,out)
+
+                return {
+                'output': json.dumps(out)
+                }
+    outputs:
+      - Name: output
+        Selector: $.Payload.output
+        Type: String

--- a/_sub/compute/eks-inactivity-cleanup/main.tf
+++ b/_sub/compute/eks-inactivity-cleanup/main.tf
@@ -1,0 +1,133 @@
+resource "aws_cloudwatch_event_rule" "inactivity" {
+  name        = "eks-inactivity-${var.eks_cluster_name}"
+  description = "Clean up EKS cluster due to inactivity"
+
+  event_pattern = jsonencode({
+    "source" : ["aws.cloudwatch"],
+    "detail-type" : ["CloudWatch Alarm State Change"],
+    "resources" : [var.inactivity_alarm_arn],
+    "detail" : {
+      "state" : {
+        "value" : ["ALARM"]
+      }
+    }
+  })
+}
+
+resource "aws_ssm_document" "clean_eks" {
+  name            = "clean-eks-${var.eks_cluster_name}"
+  document_format = "YAML"
+  document_type   = "Automation"
+
+  content = file("${path.module}/documents/delete-eks.yaml")
+}
+
+resource "aws_cloudwatch_event_target" "ssm" {
+  rule     = aws_cloudwatch_event_rule.inactivity.name
+  role_arn = aws_iam_role.issue_clean_eks.arn
+  # Work around bug where the API doesn't detect that this is an automation:
+  # https://github.com/hashicorp/terraform-provider-aws/issues/6461#issuecomment-510845647
+  arn = replace(aws_ssm_document.clean_eks.arn, "document/", "automation-definition/")
+
+  input = jsonencode({
+    "AutomationAssumeRole" : [aws_iam_role.exec_clean_eks.arn],
+    "EKSClusterName" : [var.eks_cluster_name]
+  })
+
+}
+
+data "aws_iam_policy_document" "exec_clean_eks_trust" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "ssm.amazonaws.com",
+      ]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "exec_clean_eks" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "eks:ListNodegroups",
+      "eks:DeleteCluster",
+    ]
+    resources = [var.eks_cluster_arn]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "eks:DeleteNodegroup",
+    ]
+    resources = [
+      "${join(":", slice(split(":", var.eks_cluster_arn), 0, 5))}:nodegroup/${var.eks_cluster_name}/*"
+    ]
+  }
+}
+
+resource "aws_iam_role" "exec_clean_eks" {
+  name               = "exec-clean-eks-${var.eks_cluster_name}"
+  assume_role_policy = data.aws_iam_policy_document.exec_clean_eks_trust.json
+}
+
+resource "aws_iam_policy" "exec_clean_eks" {
+  name   = "exec-clean-eks-${var.eks_cluster_name}"
+  policy = data.aws_iam_policy_document.exec_clean_eks.json
+}
+
+resource "aws_iam_role_policy_attachment" "exec_clean_eks" {
+  policy_arn = aws_iam_policy.exec_clean_eks.arn
+  role       = aws_iam_role.exec_clean_eks.name
+}
+
+data "aws_iam_policy_document" "issue_clean_eks_trust" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "events.amazonaws.com"
+      ]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "issue_clean_eks" {
+  statement {
+    effect    = "Allow"
+    actions   = ["iam:PassRole"]
+    resources = [aws_iam_role.exec_clean_eks.arn]
+  }
+
+  statement {
+    effect  = "Allow"
+    actions = ["ssm:StartAutomationExecution"]
+    resources = [
+      "${aws_ssm_document.clean_eks.arn}:*",
+      # Attempts to startu the execution on a resource with the "automation-definition" prefix
+      # instead of the "document" prefix:
+      "${replace(aws_ssm_document.clean_eks.arn, "document/", "automation-definition/")}:*",
+    ]
+  }
+}
+
+resource "aws_iam_role" "issue_clean_eks" {
+  name               = "issue-clean-eks-${var.eks_cluster_name}"
+  assume_role_policy = data.aws_iam_policy_document.issue_clean_eks_trust.json
+}
+
+resource "aws_iam_policy" "issue_clean_eks" {
+  name   = "issue-clean-eks-${var.eks_cluster_name}"
+  policy = data.aws_iam_policy_document.issue_clean_eks.json
+}
+
+resource "aws_iam_role_policy_attachment" "issue_clean_eks" {
+  policy_arn = aws_iam_policy.issue_clean_eks.arn
+  role       = aws_iam_role.issue_clean_eks.name
+}

--- a/_sub/compute/eks-inactivity-cleanup/vars.tf
+++ b/_sub/compute/eks-inactivity-cleanup/vars.tf
@@ -1,0 +1,11 @@
+variable "eks_cluster_name" {
+  type = string
+}
+
+variable "eks_cluster_arn" {
+  type = string
+}
+
+variable "inactivity_alarm_arn" {
+  type = string
+}

--- a/_sub/compute/eks-inactivity-cleanup/versions.tf
+++ b/_sub/compute/eks-inactivity-cleanup/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 1.3.0, < 2.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.60.0"
+    }
+  }
+
+}

--- a/_sub/compute/elb-inactivity-cleanup/main.tf
+++ b/_sub/compute/elb-inactivity-cleanup/main.tf
@@ -1,0 +1,149 @@
+resource "aws_cloudwatch_event_rule" "inactivity" {
+  name        = "elb-inactivity-${var.elb_name}"
+  description = "Clean up ELB load balancer due to inactivity"
+
+  event_pattern = jsonencode({
+    "source" : ["aws.cloudwatch"],
+    "detail-type" : ["CloudWatch Alarm State Change"],
+    "resources" : [var.inactivity_alarm_arn],
+    "detail" : {
+      "state" : {
+        "value" : ["ALARM"]
+      }
+    }
+  })
+}
+
+resource "aws_ssm_document" "clean_elb" {
+  name          = "clean_elb_${var.elb_name}"
+  document_type = "Automation"
+
+  content = jsonencode({
+    "description" : "Delete ELB load balancer",
+    "schemaVersion" : "0.3",
+    "assumeRole" : "{{ AutomationAssumeRole }}",
+    "parameters" : {
+      "AutomationAssumeRole" : {
+        "type" : "String",
+        "description" : "(Required) The ARN of the role that allows Automation to perform\nthe actions on your behalf. If no role is specified, Systems Manager Automation\nuses your IAM permissions to run this runbook.",
+        "allowedPattern" : "^arn:aws(-cn|-us-gov)?:iam::\\d{12}:role/[\\w+=,.@-]+|^$"
+      },
+      "LoadBalancerArn" : {
+        "type" : "String",
+        "description" : "(Required) The ARN of the load balancer.",
+      }
+    },
+    "mainSteps" : [
+      {
+        "name" : "deleteElb",
+        "action" : "aws:executeAwsApi",
+        "onFailure" : "Abort",
+        "inputs" : {
+          "Service" : "elbv2",
+          "Api" : "DeleteLoadBalancer",
+          "LoadBalancerArn" : "{{ LoadBalancerArn }}",
+        }
+      },
+    ],
+  })
+}
+
+resource "aws_cloudwatch_event_target" "ssm" {
+  rule     = aws_cloudwatch_event_rule.inactivity.name
+  role_arn = aws_iam_role.issue_clean_elb.arn
+  # Work around bug where the API doesn't detect that this is an automation:
+  # https://github.com/hashicorp/terraform-provider-aws/issues/6461#issuecomment-510845647
+  arn = replace(aws_ssm_document.clean_elb.arn, "document/", "automation-definition/")
+
+  input = jsonencode({
+    "AutomationAssumeRole" : [aws_iam_role.exec_clean_elb.arn],
+    "LoadBalancerArn" : [var.elb_arn]
+  })
+
+}
+
+data "aws_iam_policy_document" "exec_clean_elb_trust" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "ssm.amazonaws.com",
+      ]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "exec_clean_elb" {
+  statement {
+    effect  = "Allow"
+    actions = ["elasticloadbalancing:DeleteLoadBalancer"]
+    resources = [
+      var.elb_arn,
+      "${join("/", slice(split("/", var.elb_arn), 0, 1))}/${var.elb_name}"
+    ]
+  }
+}
+
+resource "aws_iam_role" "exec_clean_elb" {
+  name               = "exec-clean-elb-${var.elb_name}"
+  assume_role_policy = data.aws_iam_policy_document.exec_clean_elb_trust.json
+}
+
+resource "aws_iam_policy" "exec_clean_elb" {
+  name   = "exec-clean-elb-${var.elb_name}"
+  policy = data.aws_iam_policy_document.exec_clean_elb.json
+}
+
+resource "aws_iam_role_policy_attachment" "exec_clean_elb" {
+  policy_arn = aws_iam_policy.exec_clean_elb.arn
+  role       = aws_iam_role.exec_clean_elb.name
+}
+
+data "aws_iam_policy_document" "issue_clean_elb_trust" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "events.amazonaws.com"
+      ]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "issue_clean_elb" {
+  statement {
+    effect    = "Allow"
+    actions   = ["iam:PassRole"]
+    resources = [aws_iam_role.exec_clean_elb.arn]
+  }
+
+  statement {
+    effect  = "Allow"
+    actions = ["ssm:StartAutomationExecution"]
+    resources = [
+      "${aws_ssm_document.clean_elb.arn}:*",
+      # Attempts to start the execution on a resource with the "automation-definition" prefix
+      # instead of the "document" prefix:
+      "${replace(aws_ssm_document.clean_elb.arn, "document/", "automation-definition/")}:*",
+    ]
+  }
+}
+
+resource "aws_iam_role" "issue_clean_elb" {
+  name               = "issue-clean-elb-${var.elb_name}"
+  assume_role_policy = data.aws_iam_policy_document.issue_clean_elb_trust.json
+}
+
+resource "aws_iam_policy" "issue_clean_elb" {
+  name   = "issue-clean-elb-${var.elb_name}"
+  policy = data.aws_iam_policy_document.issue_clean_elb.json
+}
+
+resource "aws_iam_role_policy_attachment" "issue_clean_elb" {
+  policy_arn = aws_iam_policy.issue_clean_elb.arn
+  role       = aws_iam_role.issue_clean_elb.name
+}

--- a/_sub/compute/elb-inactivity-cleanup/vars.tf
+++ b/_sub/compute/elb-inactivity-cleanup/vars.tf
@@ -1,0 +1,11 @@
+variable "inactivity_alarm_arn" {
+  type = string
+}
+
+variable "elb_name" {
+  type = string
+}
+
+variable "elb_arn" {
+  type = string
+}

--- a/_sub/compute/elb-inactivity-cleanup/versions.tf
+++ b/_sub/compute/elb-inactivity-cleanup/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 1.3.0, < 2.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.60.0"
+    }
+  }
+
+}

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -307,7 +307,7 @@ module "aws_iam_oidc_provider" {
 # --------------------------------------------------
 
 resource "aws_cloudwatch_metric_alarm" "inactivity" {
-  count               = var.eks_is_sandbox && !var.disable_inactivity_cleanup ? 1 : 0
+  count               = var.eks_is_sandbox ? 1 : 0
   alarm_name          = "inactivity"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = 24

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -201,8 +201,7 @@ module "eks_heptio" {
 }
 
 module "eks_addons" {
-  source = "../../_sub/compute/eks-addons"
-  # TODO pass the kubeconfig_path
+  source                           = "../../_sub/compute/eks-addons"
   depends_on                       = [module.eks_cluster]
   cluster_name                     = var.eks_cluster_name
   kubeproxy_version_override       = var.eks_addon_kubeproxy_version_override

--- a/compute/eks-ec2/outputs.tf
+++ b/compute/eks-ec2/outputs.tf
@@ -16,9 +16,20 @@ output "kubeconfig_path" {
   value = local.kubeconfig_path
 }
 
-
 output "eks_openid_connect_provider_url" {
   value = module.eks_cluster.eks_openid_connect_provider_url
+}
+
+output "eks_cluster_arn" {
+  value = module.eks_cluster.eks_cluster_arn
+}
+
+output "eks_is_sandbox" {
+  value = var.eks_is_sandbox
+}
+
+output "eks_inactivity_alarm_arn" {
+  value = try(aws_cloudwatch_metric_alarm.inactivity[0].arn, null)
 }
 
 # --------------------------------------------------

--- a/compute/eks-ec2/vars.tf
+++ b/compute/eks-ec2/vars.tf
@@ -194,3 +194,13 @@ variable "eks_worker_cur_bucket_arn" {
   default     = null
   description = "S3 ARN for Billing Cost and Usage Report (CUR)"
 }
+
+# --------------------------------------------------
+# Inactivity based clean up for sandboxes
+# --------------------------------------------------
+
+variable "disable_inactivity_cleanup" {
+  type        = bool
+  default     = false
+  description = "Disables automated clean up of EKS resources based on inactivity. Only applicable to sandboxes."
+}

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -791,3 +791,23 @@ module "kyverno" {
   excluded_namespaces = ["traefik"]
   replicas            = var.kyverno_replicas
 }
+
+# --------------------------------------------------
+# Inactivity based clean up for sandboxes
+# --------------------------------------------------
+
+module "elb_inactivity_cleanup_anon" {
+  count                = data.terraform_remote_state.cluster.outputs.eks_is_sandbox && !var.disable_inactivity_cleanup && var.traefik_alb_anon_deploy && (var.traefik_blue_variant_flux_deploy || var.traefik_green_variant_flux_deploy) ? 1 : 0
+  source               = "../../_sub/compute/elb-inactivity-cleanup"
+  inactivity_alarm_arn = data.terraform_remote_state.cluster.outputs.eks_inactivity_alarm_arn
+  elb_name             = module.traefik_alb_anon.alb_name
+  elb_arn              = module.traefik_alb_anon.alb_arn
+}
+
+module "elb_inactivity_cleanup_auth" {
+  count                = data.terraform_remote_state.cluster.outputs.eks_is_sandbox && !var.disable_inactivity_cleanup && var.traefik_alb_auth_deploy && (var.traefik_blue_variant_flux_deploy || var.traefik_green_variant_flux_deploy) ? 1 : 0
+  source               = "../../_sub/compute/elb-inactivity-cleanup"
+  inactivity_alarm_arn = data.terraform_remote_state.cluster.outputs.eks_inactivity_alarm_arn
+  elb_name             = module.traefik_alb_auth.alb_name
+  elb_arn              = module.traefik_alb_auth.alb_arn
+}

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -1120,3 +1120,13 @@ variable "subnet_exporter_iam_role_name" {
   default     = null
   description = "The IAM role name used for the AWS Subnet Exporter"
 }
+
+# --------------------------------------------------
+# Inactivity based clean up for sandboxes
+# --------------------------------------------------
+
+variable "disable_inactivity_cleanup" {
+  type        = bool
+  default     = false
+  description = "Disables automated clean up of ELB resources based on inactivity. Only applicable to sandboxes."
+}

--- a/test/integration/eu-west-1/k8s-qa/cluster/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/cluster/terragrunt.hcl
@@ -32,7 +32,7 @@ inputs = {
   eks_is_sandbox = true
   # Since rebooting the cluster after inactivity at the moment requires first
   # running `terragrunt apply -target=module.eks_cluster` the QA cluster is
-  # exluded from the inactivity clean up on this step.
+  # excluded from the inactivity clean up on this step.
   disable_inactivity_cleanup = true
 
   # --------------------------------------------------

--- a/test/integration/eu-west-1/k8s-qa/cluster/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/cluster/terragrunt.hcl
@@ -20,7 +20,6 @@ inputs = {
   # EKS
   # --------------------------------------------------
 
-  eks_is_sandbox                             = true
   eks_cluster_name                           = "qa"
   eks_cluster_version                        = "1.25"
   eks_cluster_zones                          = 2
@@ -29,6 +28,12 @@ inputs = {
   eks_worker_ssh_ip_whitelist = ["193.9.230.100/32"]
   eks_worker_ssh_public_key   = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDS85QojLMO8eI5ArwburDpVthEZmW3IVs4/nmv7YnDMgs+ucJmW/etm7MlkRDvWphH4X/6mSGGmylJq7vUIn5rHMG0KTFxg06G2ZJ0zS6ryQ89tDLA9LXhD3q//TzXDFJ4ztjcSyxL1fSW44Lpmt7l7wWHdgrMaP3db2TRYOKY2/0iC22TwQKjTSGku59sFmv3XkLVBehO3fFOXcbLChZ4+maPMmgJDUyYMVSVZNJ2YsjFHHeaYClaN0az0Agcab2HIZMZh0Vv08ro0Se5ZBUjyfoPuDe3WjutkivePajG710k10vSOx6X5CHO3bZvQEBA8klCY58Xp2XrzSChNZhP eks-deploy-hellman"
   eks_k8s_auth_api_version    = "client.authentication.k8s.io/v1beta1"
+
+  eks_is_sandbox = true
+  # Since rebooting the cluster after inactivity at the moment requires first
+  # running `terragrunt apply -target=module.eks_cluster` the QA cluster is
+  # exluded from the inactivity clean up on this step.
+  disable_inactivity_cleanup = true
 
   # --------------------------------------------------
   # Managed nodes


### PR DESCRIPTION
Creates a CloudWatch alarm that aims to detect inactivity. The alarm will trigger the deletion of the EKS cluster and ELB load balancers. It will fire after a workday (excludes weekends) where sandbox ELB target groups have 0 targets. CloudWatch limits the evaluation period to 1 day so this was the best workaround to avoid triggering the inactivity clean-up due to normal activity during weekends.

To reboot the resources, one needs to first run `terragrunt apply -target=module.eks_cluster` to recreate the EKS control plane. Afterwards, run the normal `terragrunt apply`s to recreate the rest of the resources along with the ELBs.

To opt out of this clean up, use the variables
`disable_inactivity_cleanup`. Use this sparingly, not as a default.