### PR TITLE
Revert "Bumping fluentd container to v1.15 after testing. (#792)"

### DIFF
--- a/_sub/monitoring/fluentd-cloudwatch/dependencies.tf
+++ b/_sub/monitoring/fluentd-cloudwatch/dependencies.tf
@@ -52,7 +52,7 @@ locals {
     "images" = [
       {
         "name"   = "fluent/fluentd-kubernetes-daemonset",
-        "newTag" = "v1.15-debian-cloudwatch-1"
+        "newTag" = "v1.11-debian-cloudwatch-1"
       }
     ]
     "patchesStrategicMerge" = [


### PR DESCRIPTION
This reverts commit d2471b32ac1bbc1557d76ff2e8bb0e9d4aaf3d90.