### PR TITLE
Enable postgres storage autoscaling

### DIFF
--- a/_sub/database/postgres-restore/main.tf
+++ b/_sub/database/postgres-restore/main.tf
@@ -51,14 +51,15 @@ resource "aws_db_instance" "postgres" {
   final_snapshot_identifier = "${var.db_snapshot}-final-${var.environment}"
 
   # configurable
-  storage_type        = var.db_storage_type
-  instance_class      = var.db_instance_class
-  allocated_storage   = var.db_allocated_storage
-  port                = var.db_port
-  db_name             = var.db_name
-  username            = var.db_master_username
-  password            = var.db_master_password
-  skip_final_snapshot = var.skip_final_snapshot
+  storage_type          = var.db_storage_type
+  instance_class        = var.db_instance_class
+  allocated_storage     = var.db_allocated_storage
+  max_allocated_storage = var.db_max_allocated_storage
+  port                  = var.db_port
+  db_name               = var.db_name
+  username              = var.db_master_username
+  password              = var.db_master_password
+  skip_final_snapshot   = var.skip_final_snapshot
 
   timeouts {
     create = "2h"

--- a/_sub/database/postgres-restore/vars.tf
+++ b/_sub/database/postgres-restore/vars.tf
@@ -48,6 +48,12 @@ variable "db_allocated_storage" {
   default     = 20
 }
 
+variable "db_max_allocated_storage" {
+  type        = number
+  description = "The space limit, in GB, which autoscaling can scale up to"
+  default     = 0 # Autoscaling disabled
+}
+
 variable "db_snapshot" {
   type        = string
   description = "Name of the snapshot to restore from"

--- a/_sub/database/postgres/main.tf
+++ b/_sub/database/postgres/main.tf
@@ -65,6 +65,7 @@ resource "aws_db_instance" "postgres" {
   storage_type                = var.db_storage_type
   instance_class              = var.db_instance_class
   allocated_storage           = var.db_allocated_storage
+  max_allocated_storage       = var.db_max_allocated_storage
   port                        = var.db_port
   db_name                     = var.db_name
   username                    = var.db_master_username

--- a/_sub/database/postgres/vars.tf
+++ b/_sub/database/postgres/vars.tf
@@ -48,6 +48,12 @@ variable "db_allocated_storage" {
   default     = 20
 }
 
+variable "db_max_allocated_storage" {
+  type        = number
+  description = "The space limit, in GB, which autoscaling can scale up to"
+  default     = 0 # Autoscaling disabled
+}
+
 variable "skip_final_snapshot" {
   type        = bool
   description = "Define if the default of creating a backup upon deletion should be skipped. Default is false"

--- a/database/postgres/README.md
+++ b/database/postgres/README.md
@@ -15,4 +15,5 @@ The connection strings, passwords etc can be found in parameter store in the sam
 - engine_version = 14 (Must be major version. Cannot be downgraded. Optional, but defaults to 14)
 - db_instance_class - "db.t3.nano" RDS (database instance class. Optional, but defaults to "db.t3.micro")
 - db_allocated_storage - 10 (The amount of space, in GB, to allocate for the database. Optional, but defaults to 20)
+- db_max_allocated_storage - 30 (The space limit, in GB, which autoscaling can scale up to. Optional, default to 0 - autoscaling disabled)
 - allow_major_version_upgrade = true (Define if major version upgrades to the Postgres engine are allowed. Optional, but defaults to true)

--- a/database/postgres/main.tf
+++ b/database/postgres/main.tf
@@ -26,6 +26,7 @@ module "postgres" {
   engine_version              = var.engine_version
   db_instance_class           = var.db_instance_class
   db_allocated_storage        = var.db_allocated_storage
+  db_max_allocated_storage    = var.db_max_allocated_storage
   allow_major_version_upgrade = var.allow_major_version_upgrade
   ssl_mode                    = var.ssl_mode
 }

--- a/database/postgres/vars.tf
+++ b/database/postgres/vars.tf
@@ -53,6 +53,12 @@ variable "db_allocated_storage" {
   description = "The amount of space, in GB, to allocate for the database"
 }
 
+variable "db_max_allocated_storage" {
+  type        = number
+  description = "The space limit, in GB, which autoscaling can scale up to"
+  default     = 0 # Autoscaling disabled
+}
+
 variable "allow_major_version_upgrade" {
   type        = bool
   description = "Define if major version upgrades to the Postgres engine are allowed"


### PR DESCRIPTION
Enable Postgres storage autoscaling by defining the optional `max_allocated_storage` variable, as per: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#max_allocated_storage

By default, it is set to 0, which disables autoscaling.