### PR TITLE
postgres.output.connection_string: flag as sensitive

### DIFF
--- a/database/postgres/outputs.tf
+++ b/database/postgres/outputs.tf
@@ -4,6 +4,7 @@ output "host" {
 
 output "connection_string" {
   value = module.postgres.connection_string
+  sensitive = true
 }
 
 output "port" {


### PR DESCRIPTION
if the password is sensitive, `connection_string` should be protected as well - to prevent password leak