### PR TITLE
Allow tagging users

### DIFF
--- a/security/org-policies/policies/RestrictivePolicy.json
+++ b/security/org-policies/policies/RestrictivePolicy.json
@@ -8,9 +8,7 @@
                 "iam:AttachUserPolicy",
                 "iam:DeleteUserPolicy",
                 "iam:DetachUserPolicy",
-                "iam:PutUserPolicy",
-                "iam:TagUser",
-                "iam:UntagUser"
+                "iam:PutUserPolicy"
             ],
             "Resource": [
                 "arn:aws:iam::*:user/Deploy",


### PR DESCRIPTION
What: When creating an IAM key for a capability "Deploy" user with the attached steps while signed in as Capability, users are warned that they do not have required permission to add a tag. It does not prevent the creation of the key but a description is added and the error message might suggest to the user that they can't continue. I assume this is because AWS have changed the IAM credentials interface recently. We should stop the error from appearing

Why: So that capability users can add a description to their key(s) and are not confused about creating credentials

Log into your capability account
Browse to IAM
Select Users
Click on the user Deploy
Click on the Security Credentials tab
Under Access keys click Create access key
Select Application running outside AWS. Note the best practices info dialog
Enter a description tag value. I.e Pipeline
Click Create access key
Observe attached error

[#1371](https://github.com/dfds/cloudplatform/issues/1371)