### PR TITLE
Enable ACLs on buckets before setting ACLs.

### DIFF
--- a/_sub/storage/s3-bucket-lifecycle/main.tf
+++ b/_sub/storage/s3-bucket-lifecycle/main.tf
@@ -36,9 +36,21 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "bucket_encryption
   }
 }
 
+resource "aws_s3_bucket_ownership_controls" "bucket_ownership_controls" {
+  bucket = aws_s3_bucket.bucket.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "bucket_acl" {
   bucket = aws_s3_bucket.bucket.id
   acl    = var.acl
+
+  depends_on = [
+    aws_s3_bucket_public_access_block.block_public_access,
+    aws_s3_bucket_ownership_controls.bucket_ownership_controls,
+  ]
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "bucket_liftecycle" {

--- a/_sub/storage/s3-cloudtrail-bucket/main.tf
+++ b/_sub/storage/s3-cloudtrail-bucket/main.tf
@@ -14,10 +14,20 @@ resource "aws_s3_bucket_policy" "this" {
   policy = data.aws_iam_policy_document.this.json
 }
 
+resource "aws_s3_bucket_ownership_controls" "bucket_ownership_controls" {
+  count  = var.create_s3_bucket ? 1 : 0
+  bucket = aws_s3_bucket.bucket[count.index].id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "bucket_acl" {
   count  = var.create_s3_bucket ? 1 : 0
   bucket = aws_s3_bucket.bucket[count.index].id
   acl    = "private"
+
+  depends_on = [aws_s3_bucket_ownership_controls.bucket_ownership_controls]
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "bucket_liftecycle" {

--- a/storage/s3-velero-backup/main.tf
+++ b/storage/s3-velero-backup/main.tf
@@ -133,9 +133,21 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "bucket_encryption
   }
 }
 
+resource "aws_s3_bucket_ownership_controls" "bucket_ownership_controls" {
+  bucket = aws_s3_bucket.velero_storage.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "bucket_acl" {
   bucket = aws_s3_bucket.velero_storage.id
   acl    = "private"
+
+  depends_on = [
+    aws_s3_bucket_public_access_block.veloro_storage_block_public_access,
+    aws_s3_bucket_ownership_controls.bucket_ownership_controls,
+  ]
 }
 
 resource "aws_s3_bucket_versioning" "bucket_versioning" {


### PR DESCRIPTION
Applies to new S3 buckets, announced in April 2023: https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/