### PR TITLE
output id from ou in org-capability-root module

### DIFF
--- a/security/org-capability-root/outputs.tf
+++ b/security/org-capability-root/outputs.tf
@@ -1,0 +1,3 @@
+output "id" {
+  value = module.capability_ou.id
+}


### PR DESCRIPTION
This PR will allow the output of OU ID from the org-capability-root module. This allows the use of the ID from terragrunt/terraform calling the org-capability-root module so we can refer to OU's by reference rather than hard-coding strings