### PR TITLE
Atlantis refactor and prep for staging

### DIFF
--- a/_sub/compute/helm-atlantis/main.tf
+++ b/_sub/compute/helm-atlantis/main.tf
@@ -84,10 +84,6 @@ resource "helm_release" "atlantis" {
     value = random_password.webhook_password.result
   }
 
-  # TODO(emil): don't hard code environment variables just pass in a map of environment variables for atlantis
-  # TODO(emil): don't need multiple workflows
-  # TODO(emil): need to disable the other commands (i.e. import)
-  # TODO(emil): don't need to do run-all in the command
   values = [
     templatefile("${path.module}/values/values.yaml", {
       atlantis_ingress   = var.atlantis_ingress,

--- a/_sub/compute/helm-atlantis/main.tf
+++ b/_sub/compute/helm-atlantis/main.tf
@@ -103,7 +103,7 @@ resource "helm_release" "atlantis" {
     yamlencode({
       environmentSecrets = [
         for key, value in var.environment_variables : {
-          name : upper(key)
+          name : key
           secretKeyRef : {
             name : "env-secrets",
             key : key,

--- a/_sub/compute/helm-atlantis/values/values.yaml
+++ b/_sub/compute/helm-atlantis/values/values.yaml
@@ -26,96 +26,6 @@ github:
 extraArgs:
   - --disable-autoplan
 
-environmentSecrets:
-  - name: AWS_ACCESS_KEY_ID
-    secretKeyRef:
-      name: aws-credentials
-      key: aws_access_key
-  - name: AWS_SECRET_ACCESS_KEY
-    secretKeyRef:
-      name: aws-credentials
-      key: aws_secret
-  - name: access_key_master
-    secretKeyRef:
-      name: aws-credentials
-      key: access_key_master
-  - name: secret_key_master
-    secretKeyRef:
-      name: aws-credentials
-      key: secret_key_master
-  - name: ARM_TENANT_ID
-    secretKeyRef:
-      name: az-credentials
-      key: arm_tenant_id
-  - name: ARM_SUBSCRIPTION_ID
-    secretKeyRef:
-      name: az-credentials
-      key: arm_subscription_id
-  - name: ARM_CLIENT_ID
-    secretKeyRef:
-      name: az-credentials
-      key: arm_client_id
-  - name: ARM_CLIENT_SECRET
-    secretKeyRef:
-      name: az-credentials
-      key: arm_client_secret
-  - name: TF_VAR_platform_fluxcd_github_token
-    secretKeyRef:
-      name: gh-credentials
-      key: github_token_flux
-
-  - name: TF_VAR_atlantis_aws_access_key
-    secretKeyRef:
-      name: aws-credentials
-      key: aws_access_key
-  - name: TF_VAR_atlantis_aws_secret
-    secretKeyRef:
-      name: aws-credentials
-      key: aws_secret
-  - name: TF_VAR_atlantis_access_key_master
-    secretKeyRef:
-      name: aws-credentials
-      key: access_key_master
-  - name: TF_VAR_atlantis_secret_key_master
-    secretKeyRef:
-      name: aws-credentials
-      key: secret_key_master
-  - name: TF_VAR_atlantis_arm_tenant_id
-    secretKeyRef:
-      name: az-credentials
-      key: arm_tenant_id
-  - name: TF_VAR_atlantis_arm_subscription_id
-    secretKeyRef:
-      name: az-credentials
-      key: arm_subscription_id
-  - name: TF_VAR_atlantis_arm_client_id
-    secretKeyRef:
-      name: az-credentials
-      key: arm_client_id
-  - name: TF_VAR_atlantis_arm_client_secret
-    secretKeyRef:
-      name: az-credentials
-      key: arm_client_secret
-  - name: TF_VAR_atlantis_platform_fluxcd_github_token
-    secretKeyRef:
-      name: gh-credentials
-      key: github_token_flux
-
-  - name: TF_VAR_atlantis_github_token
-    secretKeyRef:
-      name: gh-credentials
-      key: github_token
-
-  - name: TF_VAR_slack_webhook_url
-    secretKeyRef:
-      name: cloudwatch-credentials
-      key: cloudwatch_webhook
-
-  - name: TF_VAR_monitoring_kube_prometheus_stack_slack_webhook
-    secretKeyRef:
-      name: monitoring-kube-prometheus-stack-credentials
-      key: slack_webhook
-
 ingress:
   host: ${atlantis_ingress}
   annotations:
@@ -136,6 +46,7 @@ repoConfig: |
     terragrunt:
       plan:
         steps:
+        - run: env | awk -F'=' '{print $1"="substr($2, 1, 3)"***"}'
         - run: terragrunt run-all plan -no-color --terragrunt-non-interactive -input=false
       apply:
         steps:

--- a/_sub/compute/helm-atlantis/values/values.yaml
+++ b/_sub/compute/helm-atlantis/values/values.yaml
@@ -11,7 +11,7 @@ resources:
     memory: 1536Mi
     cpu: null
 
-orgWhitelist: ${github_repos}
+orgAllowlist: ${github_repos}
 logLevel: "info"
 
 disableApply: true

--- a/_sub/compute/helm-atlantis/values/values.yaml
+++ b/_sub/compute/helm-atlantis/values/values.yaml
@@ -40,21 +40,5 @@ repoConfig: |
   ---
   repos:
   - id: "/.*/"
-    workflow: terragrunt
     allowed_overrides: [workflow]
-  workflows:
-    terragrunt:
-      plan:
-        steps:
-        - run: env | awk -F'=' '{print $1"="substr($2, 1, 3)"***"}'
-        - run: terragrunt run-all plan -no-color --terragrunt-non-interactive -input=false
-      apply:
-        steps:
-        - run: exit 1
-    eks-pipeline:
-      plan:
-        steps:
-        - run: terragrunt run-all plan -no-color --terragrunt-non-interactive -input=false
-      apply:
-        steps:
-        - run: exit 1
+    allow_custom_workflows: true

--- a/_sub/compute/helm-atlantis/vars.tf
+++ b/_sub/compute/helm-atlantis/vars.tf
@@ -40,24 +40,10 @@ variable "github_repositories" {
   default     = []
 }
 
-variable "arm_tenant_id" {
-  type        = string
-  description = ""
-}
-
-variable "arm_subscription_id" {
-  type        = string
-  description = ""
-}
-
-variable "arm_client_id" {
-  type        = string
-  description = ""
-}
-
-variable "arm_client_secret" {
-  type        = string
-  description = ""
+variable "environment_variables" {
+  description = "Map of environment variables that will be exported for the Atlantis process"
+  type        = map(string)
+  default     = {}
 }
 
 variable "storage_class" {
@@ -65,17 +51,17 @@ variable "storage_class" {
   description = "Storage class to use for the persistent volume"
 }
 
-## Github ##
-variable "github_token" {
-  type        = string
-  description = "Github token that the provider uses to perform Github operations. Leaving unset will fall back to GITHUB_TOKEN environment variable"
-}
-
+## Flux ##
 variable "platform_fluxcd_github_token" {
   type        = string
   description = "Github token that the provider uses to perform Github operations for Flux."
 }
 
+## Github ##
+variable "github_token" {
+  type        = string
+  description = "Github token that the provider uses to perform Github operations. Leaving unset will fall back to GITHUB_TOKEN environment variable"
+}
 
 variable "github_username" {
   type        = string
@@ -98,28 +84,7 @@ variable "webhook_events" {
   type        = list(string)
 }
 
-## Kubernetes ##
-
-variable "aws_access_key" {
-  type        = string
-  description = "AWS Access Key"
-}
-
-variable "aws_secret" {
-  type        = string
-  description = "AWS Secret"
-}
-
-variable "access_key_master" {
-  type        = string
-  description = "Access Key for Core account"
-}
-
-variable "secret_key_master" {
-  type        = string
-  description = "Secret for Core account"
-}
-
+## SSM ##
 variable "auth_username" {
   type        = string
   description = "Username used for basic authentication."
@@ -129,14 +94,4 @@ variable "auth_username" {
 variable "cluster_name" {
   type        = string
   description = "The name of the Kubernetes cluster"
-}
-
-variable "slack_webhook_url" {
-  type        = string
-  description = "Cloudwatch alarm notifier to Slack"
-}
-
-variable "monitoring_kube_prometheus_stack_slack_webhook" {
-  type        = string
-  description = "Kube-prometheus-stack alert slack webhook"
 }

--- a/_sub/compute/helm-atlantis/vars.tf
+++ b/_sub/compute/helm-atlantis/vars.tf
@@ -51,12 +51,6 @@ variable "storage_class" {
   description = "Storage class to use for the persistent volume"
 }
 
-## Flux ##
-variable "platform_fluxcd_github_token" {
-  type        = string
-  description = "Github token that the provider uses to perform Github operations for Flux."
-}
-
 ## Github ##
 variable "github_token" {
   type        = string

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -537,6 +537,7 @@ module "atlantis" {
     arm_client_id                                           = var.atlantis_arm_client_id
     arm_client_secret                                       = var.atlantis_arm_client_secret
     tf_var_monitoring_kube_prometheus_stack_azure_tenant_id = var.monitoring_kube_prometheus_stack_azure_tenant_id
+    tf_var_platform_fluxcd_github_token                     = var.atlantis_platform_fluxcd_github_token
     tf_var_atlantis_github_token                            = var.atlantis_github_token
     tf_var_atlantis_platform_fluxcd_github_token            = var.atlantis_platform_fluxcd_github_token
   }

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -502,37 +502,49 @@ module "platform_fluxcd" {
 # --------------------------------------------------
 
 module "atlantis" {
-  source                                         = "../../_sub/compute/helm-atlantis"
-  count                                          = var.atlantis_deploy ? 1 : 0
-  namespace                                      = var.atlantis_namespace
-  namespace_labels                               = var.atlantis_namespace_labels
-  chart_version                                  = var.atlantis_chart_version
-  atlantis_image                                 = var.atlantis_image
-  atlantis_image_tag                             = var.atlantis_image_tag
-  atlantis_ingress                               = var.atlantis_ingress
-  github_username                                = var.atlantis_github_username
-  github_token                                   = var.atlantis_github_token
-  github_repositories                            = var.atlantis_github_repositories
-  webhook_url                                    = var.atlantis_ingress
-  webhook_events                                 = var.atlantis_webhook_events
-  aws_access_key                                 = var.atlantis_aws_access_key
-  aws_secret                                     = var.atlantis_aws_secret
-  access_key_master                              = var.atlantis_access_key_master
-  secret_key_master                              = var.atlantis_secret_key_master
-  arm_tenant_id                                  = var.atlantis_arm_tenant_id
-  arm_subscription_id                            = var.atlantis_arm_subscription_id
-  arm_client_id                                  = var.atlantis_arm_client_id
-  arm_client_secret                              = var.atlantis_arm_client_secret
-  platform_fluxcd_github_token                   = var.atlantis_platform_fluxcd_github_token
-  storage_class                                  = var.atlantis_storage_class
-  cluster_name                                   = var.eks_cluster_name
-  slack_webhook_url                              = var.slack_webhook_url
-  monitoring_kube_prometheus_stack_slack_webhook = var.monitoring_kube_prometheus_stack_slack_webhook
+  source       = "../../_sub/compute/helm-atlantis"
+  count        = var.atlantis_deploy ? 1 : 0
+  cluster_name = var.eks_cluster_name
+  # TODO(emil): is this variable really necessary?
+  platform_fluxcd_github_token = var.atlantis_platform_fluxcd_github_token
+  namespace                    = var.atlantis_namespace
+  namespace_labels             = var.atlantis_namespace_labels
+  chart_version                = var.atlantis_chart_version
+  atlantis_image               = var.atlantis_image
+  atlantis_image_tag           = var.atlantis_image_tag
+  atlantis_ingress             = var.atlantis_ingress
+  storage_class                = var.atlantis_storage_class
+  github_username              = var.atlantis_github_username
+  github_token                 = var.atlantis_github_token
+  github_repositories          = var.atlantis_github_repositories
+  webhook_url                  = var.atlantis_ingress
+  webhook_events               = var.atlantis_webhook_events
 
-  providers = {
-    github = github.atlantis
+  # Environment variables
+  # TODO(emil): review naming of these variables
+  # TODO(emil): add variables for staging
+  environment_variables = {
+
+    # Production
+    aws_access_key_id                                     = var.atlantis_aws_access_key
+    aws_secret_access_key                                 = var.atlantis_aws_secret
+    tf_var_slack_webhook_url                              = var.slack_webhook_url
+    tf_var_monitoring_kube_prometheus_stack_slack_webhook = var.monitoring_kube_prometheus_stack_slack_webhook
+
+    # Common
+    arm_tenant_id                                           = var.atlantis_arm_tenant_id
+    arm_subscription_id                                     = var.atlantis_arm_subscription_id
+    arm_client_id                                           = var.atlantis_arm_client_id
+    arm_client_secret                                       = var.atlantis_arm_client_secret
+    tf_var_monitoring_kube_prometheus_stack_azure_tenant_id = var.monitoring_kube_prometheus_stack_azure_tenant_id
+    tf_var_atlantis_github_token                            = var.atlantis_github_token
+    tf_var_atlantis_platform_fluxcd_github_token            = var.atlantis_platform_fluxcd_github_token
   }
 
+  providers = {
+    # TODO(emil): why is there a different provider?
+    github = github.atlantis
+  }
 }
 
 module "atlantis_flux_manifests" {

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -502,28 +502,23 @@ module "platform_fluxcd" {
 # --------------------------------------------------
 
 module "atlantis" {
-  source       = "../../_sub/compute/helm-atlantis"
-  count        = var.atlantis_deploy ? 1 : 0
-  cluster_name = var.eks_cluster_name
-  # TODO(emil): is this variable really necessary?
-  platform_fluxcd_github_token = var.atlantis_platform_fluxcd_github_token
-  namespace                    = var.atlantis_namespace
-  namespace_labels             = var.atlantis_namespace_labels
-  chart_version                = var.atlantis_chart_version
-  atlantis_image               = var.atlantis_image
-  atlantis_image_tag           = var.atlantis_image_tag
-  atlantis_ingress             = var.atlantis_ingress
-  storage_class                = var.atlantis_storage_class
-  github_username              = var.atlantis_github_username
-  github_token                 = var.atlantis_github_token
-  github_repositories          = var.atlantis_github_repositories
-  webhook_url                  = var.atlantis_ingress
-  webhook_events               = var.atlantis_webhook_events
+  source              = "../../_sub/compute/helm-atlantis"
+  count               = var.atlantis_deploy ? 1 : 0
+  cluster_name        = var.eks_cluster_name
+  namespace           = var.atlantis_namespace
+  namespace_labels    = var.atlantis_namespace_labels
+  chart_version       = var.atlantis_chart_version
+  atlantis_image      = var.atlantis_image
+  atlantis_image_tag  = var.atlantis_image_tag
+  atlantis_ingress    = var.atlantis_ingress
+  storage_class       = var.atlantis_storage_class
+  github_username     = var.atlantis_github_username
+  github_token        = var.atlantis_github_token
+  github_repositories = var.atlantis_github_repositories
+  webhook_url         = var.atlantis_ingress
+  webhook_events      = var.atlantis_webhook_events
 
   # Environment variables
-  # TODO(emil): review naming of these variables
-  # TODO(emil): add variables for staging
-  # TODO(emil): what's with all the github tokens?
   environment_variables = {
     PRODUCTION_AWS_ACCESS_KEY_ID                                     = var.atlantis_aws_access_key
     PRODUCTION_AWS_SECRET_ACCESS_KEY                                 = var.atlantis_aws_secret
@@ -538,13 +533,11 @@ module "atlantis" {
     SHARED_ARM_CLIENT_ID                                             = var.atlantis_arm_client_id
     SHARED_ARM_CLIENT_SECRET                                         = var.atlantis_arm_client_secret
     SHARED_TF_VAR_monitoring_kube_prometheus_stack_azure_tenant_id   = var.monitoring_kube_prometheus_stack_azure_tenant_id
-    SHARED_TF_VAR_platform_fluxcd_github_token                       = var.atlantis_platform_fluxcd_github_token
+    SHARED_TF_VAR_platform_fluxcd_github_token                       = var.platform_fluxcd_github_token
     SHARED_TF_VAR_atlantis_github_token                              = var.atlantis_github_token
-    SHARED_TF_VAR_atlantis_platform_fluxcd_github_token              = var.atlantis_platform_fluxcd_github_token
   }
 
   providers = {
-    # TODO(emil): why is there a different provider?
     github = github.atlantis
   }
 }

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -523,23 +523,24 @@ module "atlantis" {
   # Environment variables
   # TODO(emil): review naming of these variables
   # TODO(emil): add variables for staging
+  # TODO(emil): what's with all the github tokens?
   environment_variables = {
-
-    # Production
-    aws_access_key_id                                     = var.atlantis_aws_access_key
-    aws_secret_access_key                                 = var.atlantis_aws_secret
-    tf_var_slack_webhook_url                              = var.slack_webhook_url
-    tf_var_monitoring_kube_prometheus_stack_slack_webhook = var.monitoring_kube_prometheus_stack_slack_webhook
-
-    # Common
-    arm_tenant_id                                           = var.atlantis_arm_tenant_id
-    arm_subscription_id                                     = var.atlantis_arm_subscription_id
-    arm_client_id                                           = var.atlantis_arm_client_id
-    arm_client_secret                                       = var.atlantis_arm_client_secret
-    tf_var_monitoring_kube_prometheus_stack_azure_tenant_id = var.monitoring_kube_prometheus_stack_azure_tenant_id
-    tf_var_platform_fluxcd_github_token                     = var.atlantis_platform_fluxcd_github_token
-    tf_var_atlantis_github_token                            = var.atlantis_github_token
-    tf_var_atlantis_platform_fluxcd_github_token            = var.atlantis_platform_fluxcd_github_token
+    PRODUCTION_AWS_ACCESS_KEY_ID                                     = var.atlantis_aws_access_key
+    PRODUCTION_AWS_SECRET_ACCESS_KEY                                 = var.atlantis_aws_secret
+    PRODUCTION_TF_VAR_slack_webhook_url                              = var.slack_webhook_url
+    PRODUCTION_TF_VAR_monitoring_kube_prometheus_stack_slack_webhook = var.monitoring_kube_prometheus_stack_slack_webhook
+    STAGING_AWS_ACCESS_KEY_ID                                        = var.atlantis_staging_aws_access_key
+    STAGING_AWS_SECRET_ACCESS_KEY                                    = var.atlantis_staging_aws_secret
+    STAGING_TF_VAR_slack_webhook_url                                 = var.staging_slack_webhook_url
+    STAGING_TF_VAR_monitoring_kube_prometheus_stack_slack_webhook    = var.monitoring_kube_prometheus_stack_staging_slack_webhook
+    SHARED_ARM_TENANT_ID                                             = var.atlantis_arm_tenant_id
+    SHARED_ARM_SUBSCRIPTION_ID                                       = var.atlantis_arm_subscription_id
+    SHARED_ARM_CLIENT_ID                                             = var.atlantis_arm_client_id
+    SHARED_ARM_CLIENT_SECRET                                         = var.atlantis_arm_client_secret
+    SHARED_TF_VAR_monitoring_kube_prometheus_stack_azure_tenant_id   = var.monitoring_kube_prometheus_stack_azure_tenant_id
+    SHARED_TF_VAR_platform_fluxcd_github_token                       = var.atlantis_platform_fluxcd_github_token
+    SHARED_TF_VAR_atlantis_github_token                              = var.atlantis_github_token
+    SHARED_TF_VAR_atlantis_platform_fluxcd_github_token              = var.atlantis_platform_fluxcd_github_token
   }
 
   providers = {

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -518,7 +518,6 @@ module "atlantis" {
   webhook_url         = var.atlantis_ingress
   webhook_events      = var.atlantis_webhook_events
 
-  # Environment variables
   environment_variables = {
     PRODUCTION_AWS_ACCESS_KEY_ID                                     = var.atlantis_aws_access_key
     PRODUCTION_AWS_SECRET_ACCESS_KEY                                 = var.atlantis_aws_secret

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -454,6 +454,8 @@ variable "atlantis_deploy" {
   default     = false
 }
 
+# TODO(emil): can remove all these extra variables, just passing variables around
+
 variable "atlantis_github_token" {
   type        = string
   default     = null

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -533,7 +533,7 @@ variable "atlantis_image_tag" {
 variable "atlantis_storage_class" {
   type        = string
   description = "Storage class to use for persistent volume"
-  default     = "csi-gp2"
+  default     = "csi-gp3"
 }
 
 variable "atlantis_flux_repo_name" {

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -471,12 +471,6 @@ variable "atlantis_github_token" {
   description = "Github token that the provider uses to perform Github operations. Leaving unset will fall back to GITHUB_TOKEN environment variable"
 }
 
-variable "atlantis_platform_fluxcd_github_token" {
-  type        = string
-  default     = "" #tfsec:ignore:general-secrets-sensitive-in-variable
-  description = "Github token that the provider uses to perform Github operations for Flux."
-}
-
 variable "atlantis_github_owner" {
   type        = string
   default     = null

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -118,6 +118,11 @@ variable "slack_webhook_url" {
   default = ""
 }
 
+variable "staging_slack_webhook_url" {
+  type    = string
+  default = ""
+}
+
 variable "alarm_notifier_deploy" {
   type    = bool
   default = false
@@ -271,6 +276,12 @@ variable "monitoring_kube_prometheus_stack_azure_tenant_id" {
 variable "monitoring_kube_prometheus_stack_slack_webhook" {
   type        = string
   description = "Kube-prometheus-stack alert slack webhook"
+  default     = ""
+}
+
+variable "monitoring_kube_prometheus_stack_staging_slack_webhook" {
+  type        = string
+  description = "Kube-prometheus-stack alert slack webhook for the staging environment"
   default     = ""
 }
 
@@ -454,8 +465,6 @@ variable "atlantis_deploy" {
   default     = false
 }
 
-# TODO(emil): can remove all these extra variables, just passing variables around
-
 variable "atlantis_github_token" {
   type        = string
   default     = null
@@ -527,6 +536,36 @@ variable "atlantis_image_tag" {
   default     = "latest"
 }
 
+variable "atlantis_storage_class" {
+  type        = string
+  description = "Storage class to use for persistent volume"
+  default     = "csi-gp2"
+}
+
+variable "atlantis_flux_repo_name" {
+  type        = string
+  description = "Name of the Github repo to store the Atlantis Flux manifests in"
+  default     = null
+}
+
+variable "atlantis_flux_repo_owner" {
+  type        = string
+  description = "Github username or organization that owns the repo to store the Atlantis Flux manifests in"
+  default     = null
+}
+
+variable "atlantis_flux_repo_branch" {
+  type        = string
+  description = "Override the default branch of the Atlantis Flux repo (optional)"
+  default     = "main"
+}
+
+
+# --------------------------------------------------
+# Atlantis variables
+# --------------------------------------------------
+# Used as env variables within the Atlantis process.
+
 variable "atlantis_arm_tenant_id" {
   type        = string
   description = "Used to set environment variable for ARM tenant ID"
@@ -563,41 +602,18 @@ variable "atlantis_aws_secret" {
   description = "AWS Secret"
 }
 
-variable "atlantis_access_key_master" {
+variable "atlantis_staging_aws_access_key" {
   type        = string
-  description = "Access Key for Core account"
   default     = "" #tfsec:ignore:general-secrets-sensitive-in-variable
+  description = "AWS Access Key for staging environment"
 }
 
-variable "atlantis_secret_key_master" {
+variable "atlantis_staging_aws_secret" {
   type        = string
-  description = "Secret for Core account"
   default     = "" #tfsec:ignore:general-secrets-sensitive-in-variable
+  description = "AWS Secret for staging environment"
 }
 
-variable "atlantis_storage_class" {
-  type        = string
-  description = "Storage class to use for persistent volume"
-  default     = "csi-gp2"
-}
-
-variable "atlantis_flux_repo_name" {
-  type        = string
-  description = "Name of the Github repo to store the Atlantis Flux manifests in"
-  default     = null
-}
-
-variable "atlantis_flux_repo_owner" {
-  type        = string
-  description = "Github username or organization that owns the repo to store the Atlantis Flux manifests in"
-  default     = null
-}
-
-variable "atlantis_flux_repo_branch" {
-  type        = string
-  description = "Override the default branch of the Atlantis Flux repo (optional)"
-  default     = "main"
-}
 
 # --------------------------------------------------
 # Crossplane


### PR DESCRIPTION
- Move to [repo level `atlantis.yaml` config](https://www.runatlantis.io/docs/repo-level-atlantis-yaml.html)
- Make the `helm-atlantis` module more reusable by not blindly passing through variables from services
- Enable staging environment with new variables passed into services
- Removed unused variables:  `atlantis_platform_fluxcd_github_token`, `atlantis_access_key_master`, `atlantis_secret_key_master`
- Split storage of Atlantis credentials in SSM into two parts to avoid `jsonencode` (one then has to decode to use the credential)
- Switch the default storage class for Atlantis from `csi-gp2` to `csi-gp3`.
- Move away from using deprecated `orgWhitelist` in the Atlantis Helm chart

--- 

Note that one will need to remap the environment variables like so in the `atlantis.yaml` in different workflows depending on the usage, like so:

```yaml
        - env:
            name: AWS_ACCESS_KEY_ID
            command: "echo $STAGING_AWS_ACCESS_KEY_ID"
``` 