### PR TITLE
Bump from version 44 to 45

### DIFF
--- a/_sub/compute/helm-kube-prometheus-stack/values/grafana.yaml
+++ b/_sub/compute/helm-kube-prometheus-stack/values/grafana.yaml
@@ -1,8 +1,6 @@
 etcd:
   enabled: true
 grafana:
-  image:
-    tag: 9.4.3 # TODO: Remove when Grafana 9.4.0 or higher is part of kube-prometheus-stack
   resources:
     requests:
       cpu: 50m

--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -118,7 +118,7 @@ inputs = {
   # --------------------------------------------------
 
   monitoring_kube_prometheus_stack_deploy                            = true
-  monitoring_kube_prometheus_stack_chart_version                     = "44.3.0"
+  monitoring_kube_prometheus_stack_chart_version                     = "45.20.0"
   monitoring_kube_prometheus_stack_target_namespaces                 = "kube-system|monitoring"
   monitoring_kube_prometheus_stack_prometheus_storage_size           = "5Gi"
   monitoring_kube_prometheus_stack_prometheus_storageclass           = "gp2"


### PR DESCRIPTION
### Upgrade kube-prometheus-stack to kube-prometheus-stack-45.20.0 or higher

What: 
Grafana 9.4.0 or higher is now available in kube-prometheus-stack, so it can be upgraded to kube-prometheus-stack-45.20.0 or higher

- [x] Upgrade from version 44.3.0 to version` 45.20.0` by following the instructions at https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack (add --force-conflicts to all the commands that upgrades the CRDs).
- [x] Remove custom Grafana image in https://github.com/dfds/infrastructure-modules/blob/master/_sub/compute/helm-kube-prometheus-stack/values/grafana.yaml#L2
- [x] Verify that you still can see a list of alerts in Grafana
- [x] Test in sandbox
- [x] Test in QA
- [ ] Release to production.

Why:
We are currently running kube-prometheus-stack 44.3.0, and it has been tweaked to run Grafana 9.4.0-beta1 in order to use a feature called Write-Ahead Logging, which became available in Grafana 9.4.0.
