### PR TITLE
FluentD bumped to latest docker image v1.16

### DIFF
--- a/_sub/monitoring/fluentd-cloudwatch/dependencies.tf
+++ b/_sub/monitoring/fluentd-cloudwatch/dependencies.tf
@@ -52,7 +52,7 @@ locals {
     "images" = [
       {
         "name"   = "fluent/fluentd-kubernetes-daemonset",
-        "newTag" = "v1.11-debian-cloudwatch-1"
+        "newTag" = "v1.16-debian-cloudwatch-1"
       }
     ]
     "patchesStrategicMerge" = [


### PR DESCRIPTION
Do not merge this until Monday 01.06.2023 - be able to test more in sandbox.