### PR TITLE
Abillity to specify velero cron schedule.

### DIFF
--- a/_sub/storage/velero-flux/vars.tf
+++ b/_sub/storage/velero-flux/vars.tf
@@ -52,7 +52,7 @@ variable "log_level" {
 variable "cron_schedule" {
   type        = string
   default     = "0 0 * * *"
-  description = "Cron format scheuled time."
+  description = "Cron-formatted scheduled time."
 }
 
 variable "schedules_template_ttl" {

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -761,6 +761,7 @@ module "velero_flux_manifests" {
   cluster_name            = var.eks_cluster_name
   role_arn                = var.velero_role_arn
   bucket_name             = var.velero_bucket_name
+  cron_schedule           = var.velero_cron_schedule
   log_level               = var.velero_log_level
   repo_name               = var.fluxcd_bootstrap_repo_name
   repo_branch             = var.fluxcd_bootstrap_repo_branch

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -932,7 +932,7 @@ variable "velero_bucket_name" {
 
 variable "velero_cron_schedule" {
   type        = string
-  default     = null
+  default     = "0 0 * * *"
   description = "Cron-formatted scheduled time for the Velero backup."
 }
 

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -933,7 +933,7 @@ variable "velero_bucket_name" {
 variable "velero_cron_schedule" {
   type        = string
   default     = null
-  description = "Cron-formatted scheduled time."
+  description = "Cron-formatted scheduled time for the Velero backup."
 }
 
 variable "velero_log_level" {

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -930,6 +930,12 @@ variable "velero_bucket_name" {
   description = "The name of the S3 bucket that contains the Velero backup"
 }
 
+variable "velero_cron_schedule" {
+  type        = string
+  default     = null
+  description = "Cron-formatted scheduled time."
+}
+
 variable "velero_log_level" {
   type        = string
   default     = "info"


### PR DESCRIPTION
Since sandbox/QA/staging environments scale down at 18 UTC, if we want to test Velero we need to be able to override the schedule time so that it happens before the node scale down.