### PR TITLE
Moved log anomaly from oxygen account to log account

### DIFF
--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -381,6 +381,10 @@ module "cloudwatch_alarm_log_anomaly" {
   source        = "../../_sub/monitoring/cloudwatch-alarms/log-anomaly/"
   deploy        = var.cloudwatch_alarm_log_anomaly_deploy
   sns_topic_arn = module.alarm_notifier.sns_arn
+
+  providers = {
+    aws = aws.logs
+  }
 }
 
 # --------------------------------------------------


### PR DESCRIPTION
The log anomaly CloudWatch alarm was falsely deployed to the Oxygen account, this should remedy that.