### PR TITLE
Update RestrictivePolicy.json to allow Access-analyzer outside the eu regions

### DIFF
--- a/security/org-policies/policies/RestrictivePolicy.json
+++ b/security/org-policies/policies/RestrictivePolicy.json
@@ -117,7 +117,7 @@
             "Sid": "DenyAllOutsideEU",
             "Effect": "Deny",
             "NotAction": [
-                "access-analyzer:ValidatePolicy",
+                "access-analyzer:*",
                 "acm:*",
                 "aws-marketplace:*",
                 "aws-portal:*",


### PR DESCRIPTION
Update RestrictivePolicy.json to allow Access-analyzer, teams should be able to use Access-analyzer to assist with creating Least privilege policies. Currently it is ran in us-east-1.