### PR TITLE
CIS monitoring controls remedies

### DIFF
--- a/_sub/security/cloudtrail-alarm/main.tf
+++ b/_sub/security/cloudtrail-alarm/main.tf
@@ -1,0 +1,29 @@
+resource "aws_cloudwatch_log_metric_filter" "filter" {
+  count          = var.deploy ? 1 : 0
+  name           = var.metric_filter_name
+  pattern        = var.metric_filter_pattern
+  log_group_name = var.logs_group_name
+
+  metric_transformation {
+    name      = var.metric_name
+    namespace = var.metric_namespace
+    value     = var.metric_value
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "alarm" {
+  count                     = var.deploy ? 1 : 0
+  alarm_name                = var.alarm_name
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = 1
+  metric_name               = var.metric_name
+  namespace                 = var.metric_namespace
+  period                    = 300
+  statistic                 = "Sum"
+  threshold                 = 1
+  alarm_description         = var.alarm_description
+  insufficient_data_actions = []
+  alarm_actions             = [var.alarm_sns_topic_arn]
+
+  depends_on = [aws_cloudwatch_log_metric_filter.filter]
+}

--- a/_sub/security/cloudtrail-alarm/outputs.tf
+++ b/_sub/security/cloudtrail-alarm/outputs.tf
@@ -1,3 +1,3 @@
-output "cloud_watch_alarm_arn" {
+output "cloudwatch_alarm_arn" {
   value = try(aws_cloudwatch_metric_alarm.alarm[0].arn, null)
 }

--- a/_sub/security/cloudtrail-alarm/outputs.tf
+++ b/_sub/security/cloudtrail-alarm/outputs.tf
@@ -1,0 +1,3 @@
+output "cloud_watch_alarm_arn" {
+  value = try(aws_cloudwatch_metric_alarm.alarm[0].arn, null)
+}

--- a/_sub/security/cloudtrail-alarm/vars.tf
+++ b/_sub/security/cloudtrail-alarm/vars.tf
@@ -1,0 +1,52 @@
+variable "deploy" {
+  description = "Deploy CloudWatch alarm."
+  type        = bool
+  default     = true
+}
+
+variable "metric_filter_name" {
+  description = "The name of the metric filter that will be added to the log group."
+  type        = string
+}
+
+variable "metric_filter_pattern" {
+  description = "The pattern the metric filter will apply the to the logged events."
+  type        = string
+}
+
+variable "logs_group_name" {
+  description = "The name of the CloudWatch log group to which the metric filter will be attached."
+  type        = string
+}
+
+variable "metric_name" {
+  description = "The name of the metric that is produced by the metric filter."
+  type        = string
+}
+
+variable "metric_namespace" {
+  description = "The namespace of the metric that is produced by the metric filter."
+  type        = string
+  default     = "LogMetrics"
+}
+
+variable "metric_value" {
+  description = "The value of the metric that is produced by the metric filter."
+  type        = string
+  default     = "1"
+}
+
+variable "alarm_name" {
+  description = "The name of the CloudWatch alarm."
+  type        = string
+}
+
+variable "alarm_description" {
+  description = "The description of the CloudWatch alarm."
+  type        = string
+}
+
+variable "alarm_sns_topic_arn" {
+  description = "The ARN of the SNS topic to which events from the CloudWatch alarm should be published."
+  type        = string
+}

--- a/_sub/security/cloudtrail-alarm/versions.tf
+++ b/_sub/security/cloudtrail-alarm/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.3.0, < 2.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.66.0"
+    }
+  }
+}

--- a/_sub/security/cloudtrail-config/main.tf
+++ b/_sub/security/cloudtrail-config/main.tf
@@ -1,3 +1,63 @@
+resource "aws_cloudwatch_log_group" "log_group" {
+  count = var.deploy && var.create_log_group ? 1 : 0
+  name  = "/cloudtrail/${var.trail_name}"
+}
+
+resource "aws_iam_role" "cloudtrail_to_cloudwatch" {
+  count = var.deploy && var.create_log_group ? 1 : 0
+  name  = "ct-cw-role-${var.trail_name}"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "cloudtrail.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "cloudtrail_to_cloudwatch" {
+  count = var.deploy && var.create_log_group ? 1 : 0
+  name  = "ct-cw-policy-${var.trail_name}"
+  role  = aws_iam_role.cloudtrail_to_cloudwatch[count.index].id
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "CreateLogStream",
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogStream"
+            ],
+            "Resource": [
+                "${aws_cloudwatch_log_group.log_group[count.index].arn}:*"
+            ]
+        },
+        {
+            "Sid": "PutLogEvents",
+            "Effect": "Allow",
+            "Action": [
+                "logs:PutLogEvents"
+            ],
+            "Resource": [
+                "${aws_cloudwatch_log_group.log_group[count.index].arn}:*"
+            ]
+        }
+    ]
+}
+EOF
+}
+
+
 # tfsec:ignore:aws-cloudtrail-enable-at-rest-encryption tfsec:ignore:aws-cloudtrail-ensure-cloudwatch-integration
 resource "aws_cloudtrail" "cloudtrail" {
   count                         = var.deploy ? 1 : 0
@@ -8,4 +68,6 @@ resource "aws_cloudtrail" "cloudtrail" {
   include_global_service_events = true
   enable_logging                = true
   enable_log_file_validation    = true
+  cloud_watch_logs_role_arn     = try(aws_iam_role.cloudtrail_to_cloudwatch[0].arn, null)
+  cloud_watch_logs_group_arn    = try("${aws_cloudwatch_log_group.log_group[0].arn}:*", null)
 }

--- a/_sub/security/cloudtrail-config/outputs.tf
+++ b/_sub/security/cloudtrail-config/outputs.tf
@@ -1,7 +1,7 @@
-output "cloud_watch_logs_group_name" {
+output "cloudwatch_logs_group_name" {
   value = try(aws_cloudwatch_log_group.log_group[0].name, null)
 }
 
-output "cloud_watch_logs_group_arn" {
+output "cloudwatch_logs_group_arn" {
   value = try(aws_cloudwatch_log_group.log_group[0].arn, null)
 }

--- a/_sub/security/cloudtrail-config/outputs.tf
+++ b/_sub/security/cloudtrail-config/outputs.tf
@@ -1,0 +1,7 @@
+output "cloud_watch_logs_group_name" {
+  value = try(aws_cloudwatch_log_group.log_group[0].name, null)
+}
+
+output "cloud_watch_logs_group_arn" {
+  value = try(aws_cloudwatch_log_group.log_group[0].arn, null)
+}

--- a/_sub/security/cloudtrail-config/vars.tf
+++ b/_sub/security/cloudtrail-config/vars.tf
@@ -19,3 +19,9 @@ variable "is_organization_trail" {
   description = "Specifies whether the trail is an AWS Organizations trail. Organization trails log events for the master account and all member accounts"
   default     = false
 }
+
+variable "create_log_group" {
+  type        = bool
+  description = "Specifies whether a CloudWatch log group should be created for the logs to be forwarded to."
+  default     = false
+}

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -201,7 +201,6 @@ resource "aws_sns_topic_subscription" "cis_controls" {
   provider = aws.workload
 }
 
-
 # --------------------------------------------------
 # CloudWatch controls
 # --------------------------------------------------
@@ -244,7 +243,6 @@ EOT
     aws = aws.workload
   }
 }
-
 
 # --------------------------------------------------
 # aws_context_account_created event

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -160,6 +160,33 @@ module "aws_iam_oidc_provider" {
 }
 
 # --------------------------------------------------
+# Account hardening
+# --------------------------------------------------
+
+module "cloudtrail_s3_local" {
+  source           = "../../_sub/storage/s3-cloudtrail-bucket"
+  create_s3_bucket = var.harden
+  s3_bucket        = "cloudtrail-local-${var.capability_root_id}"
+
+  providers = {
+    aws = aws.workload
+  }
+}
+
+module "cloudtrail_local" {
+  source     = "../../_sub/security/cloudtrail-config"
+  s3_bucket  = module.cloudtrail_s3_local.bucket_name
+  deploy     = var.harden
+  trail_name = "cloudtrail-local-${var.capability_root_id}"
+
+  # TODO(emil): add log group
+
+  providers = {
+    aws = aws.workload
+  }
+}
+
+# --------------------------------------------------
 # aws_context_account_created event
 # --------------------------------------------------
 

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -209,7 +209,7 @@ resource "aws_sns_topic_subscription" "cis_controls" {
 module "cis_control_cloudwatch_1" {
   source                = "../../_sub/security/cloudtrail-alarm"
   deploy                = var.harden
-  logs_group_name       = module.cloudtrail_local.cloud_watch_logs_group_name
+  logs_group_name       = module.cloudtrail_local.cloudwatch_logs_group_name
   alarm_sns_topic_arn   = var.harden ? aws_sns_topic.cis_controls[0].arn : null
   metric_filter_name    = "RootUsage"
   metric_filter_pattern = "{$.userIdentity.type=\"Root\" && $.userIdentity.invokedBy NOT EXISTS && $.eventType !=\"AwsServiceEvent\"}"
@@ -228,7 +228,7 @@ EOT
 module "cis_control_cloudwatch_2" {
   source                = "../../_sub/security/cloudtrail-alarm"
   deploy                = var.harden
-  logs_group_name       = module.cloudtrail_local.cloud_watch_logs_group_name
+  logs_group_name       = module.cloudtrail_local.cloudwatch_logs_group_name
   alarm_sns_topic_arn   = var.harden ? aws_sns_topic.cis_controls[0].arn : null
   metric_filter_name    = "UnauthorizedApiCalls"
   metric_filter_pattern = "{($.errorCode=\"*UnauthorizedOperation\") || ($.errorCode=\"AccessDenied*\")}"

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -185,8 +185,6 @@ module "cloudtrail_local" {
   }
 }
 
-# TODO create a metric filter
-
 # [CloudWatch.1] A log metric filter and alarm should exist for usage of the
 # "root" user
 # https://docs.aws.amazon.com/securityhub/latest/userguide/cloudwatch-controls.html#cloudwatch-1

--- a/security/org-account-context/vars.tf
+++ b/security/org-account-context/vars.tf
@@ -119,3 +119,8 @@ variable "create_aws_iam_access_key" {
   type    = bool
   default = false
 }
+
+variable "harden" {
+  type    = bool
+  default = false
+}

--- a/security/org-account-context/vars.tf
+++ b/security/org-account-context/vars.tf
@@ -124,3 +124,8 @@ variable "harden" {
   type    = bool
   default = false
 }
+
+variable "hardened_monitoring_email" {
+  type    = string
+  default = null
+}


### PR DESCRIPTION
- Ability to route CloudTrail logs to a CloudWatch log group 
- Ability to create a metric filter and an alarm from a CloudTrail log group.
- Ability to subscribe to a CloudTrail-based alarm.
- Ability to harden an `org-account-context` with the `harden` flag and subscribe to alerts via the `hardened_monitoring_email`.
- Remedies for `CloudWatch.1` and `CloudWatch.2` CIS 1.2 monitoring controls.