### PR TITLE
Enable AWS Config with Conformance Packs on hardened accounts

### DIFF
--- a/_sub/security/config-config/conformance-packs/Operational-Best-Practices-for-CIS-AWS-v1.4-Level2.yaml
+++ b/_sub/security/config-config/conformance-packs/Operational-Best-Practices-for-CIS-AWS-v1.4-Level2.yaml
@@ -1,0 +1,746 @@
+##################################################################################
+#
+#   Conformance Pack:
+#     Operational Best Practices for CIS AWS Foundations Benchmark Level 2
+#
+#   This conformance pack helps verify compliance with CIS AWS Foundations Benchmark Level 2 requirements.
+#
+#   See Parameters section for names and descriptions of required parameters.
+#
+##################################################################################
+
+Parameters:
+  AccessKeysRotatedParamMaxAccessKeyAge:
+    Default: "90"
+    Type: String
+  IamPasswordPolicyParamMaxPasswordAge:
+    Default: "90"
+    Type: String
+  IamPasswordPolicyParamMinimumPasswordLength:
+    Default: "14"
+    Type: String
+  IamPasswordPolicyParamPasswordReusePrevention:
+    Default: "24"
+    Type: String
+  IamPasswordPolicyParamRequireLowercaseCharacters:
+    Default: "true"
+    Type: String
+  IamPasswordPolicyParamRequireNumbers:
+    Default: "true"
+    Type: String
+  IamPasswordPolicyParamRequireSymbols:
+    Default: "true"
+    Type: String
+  IamPasswordPolicyParamRequireUppercaseCharacters:
+    Default: "true"
+    Type: String
+  IamPolicyInUseParamPolicyARN:
+    Default: arn:aws:iam::aws:policy/AWSSupportAccess
+    Type: String
+  IamUserUnusedCredentialsCheckParamMaxCredentialUsageAge:
+    Default: "45"
+    Type: String
+  RestrictedIncomingTrafficParamBlockedPort3:
+    Default: "3389"
+    Type: String
+  S3AccountLevelPublicAccessBlocksPeriodicParamBlockPublicAcls:
+    Default: "True"
+    Type: String
+  S3AccountLevelPublicAccessBlocksPeriodicParamBlockPublicPolicy:
+    Default: "True"
+    Type: String
+  S3AccountLevelPublicAccessBlocksPeriodicParamIgnorePublicAcls:
+    Default: "True"
+    Type: String
+  S3AccountLevelPublicAccessBlocksPeriodicParamRestrictPublicBuckets:
+    Default: "True"
+    Type: String
+  S3BucketVersioningEnabledParamIsMfaDeleteEnabled:
+    Default: "TRUE"
+    Type: String
+Resources:
+  AccessKeysRotated:
+    Properties:
+      ConfigRuleName: access-keys-rotated
+      InputParameters:
+        maxAccessKeyAge:
+          Fn::If:
+            - accessKeysRotatedParamMaxAccessKeyAge
+            - Ref: AccessKeysRotatedParamMaxAccessKeyAge
+            - Ref: AWS::NoValue
+      Source:
+        Owner: AWS
+        SourceIdentifier: ACCESS_KEYS_ROTATED
+    Type: AWS::Config::ConfigRule
+  AccountPartOfOrganizations:
+    Properties:
+      ConfigRuleName: account-part-of-organizations
+      Source:
+        Owner: AWS
+        SourceIdentifier: ACCOUNT_PART_OF_ORGANIZATIONS
+    Type: AWS::Config::ConfigRule
+  CloudTrailCloudWatchLogsEnabled:
+    Properties:
+      ConfigRuleName: cloud-trail-cloud-watch-logs-enabled
+      Source:
+        Owner: AWS
+        SourceIdentifier: CLOUD_TRAIL_CLOUD_WATCH_LOGS_ENABLED
+    Type: AWS::Config::ConfigRule
+  CloudTrailEncryptionEnabled:
+    Properties:
+      ConfigRuleName: cloud-trail-encryption-enabled
+      Source:
+        Owner: AWS
+        SourceIdentifier: CLOUD_TRAIL_ENCRYPTION_ENABLED
+    Type: AWS::Config::ConfigRule
+  CloudTrailLogFileValidationEnabled:
+    Properties:
+      ConfigRuleName: cloud-trail-log-file-validation-enabled
+      Source:
+        Owner: AWS
+        SourceIdentifier: CLOUD_TRAIL_LOG_FILE_VALIDATION_ENABLED
+    Type: AWS::Config::ConfigRule
+  CloudtrailS3DataeventsEnabled:
+    Properties:
+      ConfigRuleName: cloudtrail-s3-dataevents-enabled
+      Source:
+        Owner: AWS
+        SourceIdentifier: CLOUDTRAIL_S3_DATAEVENTS_ENABLED
+    Type: AWS::Config::ConfigRule
+  CmkBackingKeyRotationEnabled:
+    Properties:
+      ConfigRuleName: cmk-backing-key-rotation-enabled
+      Source:
+        Owner: AWS
+        SourceIdentifier: CMK_BACKING_KEY_ROTATION_ENABLED
+    Type: AWS::Config::ConfigRule
+  Ec2EbsEncryptionByDefault:
+    Properties:
+      ConfigRuleName: ec2-ebs-encryption-by-default
+      Source:
+        Owner: AWS
+        SourceIdentifier: EC2_EBS_ENCRYPTION_BY_DEFAULT
+    Type: AWS::Config::ConfigRule
+  EncryptedVolumes:
+    Properties:
+      ConfigRuleName: encrypted-volumes
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::EC2::Volume
+      Source:
+        Owner: AWS
+        SourceIdentifier: ENCRYPTED_VOLUMES
+    Type: AWS::Config::ConfigRule
+  IamNoInlinePolicyCheck:
+    Properties:
+      ConfigRuleName: iam-no-inline-policy-check
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::IAM::User
+          - AWS::IAM::Role
+          - AWS::IAM::Group
+      Source:
+        Owner: AWS
+        SourceIdentifier: IAM_NO_INLINE_POLICY_CHECK
+    Type: AWS::Config::ConfigRule
+  IamPasswordPolicy:
+    Properties:
+      ConfigRuleName: iam-password-policy
+      InputParameters:
+        MaxPasswordAge:
+          Fn::If:
+            - iamPasswordPolicyParamMaxPasswordAge
+            - Ref: IamPasswordPolicyParamMaxPasswordAge
+            - Ref: AWS::NoValue
+        MinimumPasswordLength:
+          Fn::If:
+            - iamPasswordPolicyParamMinimumPasswordLength
+            - Ref: IamPasswordPolicyParamMinimumPasswordLength
+            - Ref: AWS::NoValue
+        PasswordReusePrevention:
+          Fn::If:
+            - iamPasswordPolicyParamPasswordReusePrevention
+            - Ref: IamPasswordPolicyParamPasswordReusePrevention
+            - Ref: AWS::NoValue
+        RequireLowercaseCharacters:
+          Fn::If:
+            - iamPasswordPolicyParamRequireLowercaseCharacters
+            - Ref: IamPasswordPolicyParamRequireLowercaseCharacters
+            - Ref: AWS::NoValue
+        RequireNumbers:
+          Fn::If:
+            - iamPasswordPolicyParamRequireNumbers
+            - Ref: IamPasswordPolicyParamRequireNumbers
+            - Ref: AWS::NoValue
+        RequireSymbols:
+          Fn::If:
+            - iamPasswordPolicyParamRequireSymbols
+            - Ref: IamPasswordPolicyParamRequireSymbols
+            - Ref: AWS::NoValue
+        RequireUppercaseCharacters:
+          Fn::If:
+            - iamPasswordPolicyParamRequireUppercaseCharacters
+            - Ref: IamPasswordPolicyParamRequireUppercaseCharacters
+            - Ref: AWS::NoValue
+      Source:
+        Owner: AWS
+        SourceIdentifier: IAM_PASSWORD_POLICY
+    Type: AWS::Config::ConfigRule
+  IamPolicyInUse:
+    Properties:
+      ConfigRuleName: iam-policy-in-use
+      InputParameters:
+        policyARN:
+          Fn::If:
+            - iamPolicyInUseParamPolicyARN
+            - Ref: IamPolicyInUseParamPolicyARN
+            - Ref: AWS::NoValue
+      Source:
+        Owner: AWS
+        SourceIdentifier: IAM_POLICY_IN_USE
+    Type: AWS::Config::ConfigRule
+  IamPolicyNoStatementsWithAdminAccess:
+    Properties:
+      ConfigRuleName: iam-policy-no-statements-with-admin-access
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::IAM::Policy
+      Source:
+        Owner: AWS
+        SourceIdentifier: IAM_POLICY_NO_STATEMENTS_WITH_ADMIN_ACCESS
+    Type: AWS::Config::ConfigRule
+  IamRootAccessKeyCheck:
+    Properties:
+      ConfigRuleName: iam-root-access-key-check
+      Source:
+        Owner: AWS
+        SourceIdentifier: IAM_ROOT_ACCESS_KEY_CHECK
+    Type: AWS::Config::ConfigRule
+  IamUserGroupMembershipCheck:
+    Properties:
+      ConfigRuleName: iam-user-group-membership-check
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::IAM::User
+      Source:
+        Owner: AWS
+        SourceIdentifier: IAM_USER_GROUP_MEMBERSHIP_CHECK
+    Type: AWS::Config::ConfigRule
+  IamUserNoPoliciesCheck:
+    Properties:
+      ConfigRuleName: iam-user-no-policies-check
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::IAM::User
+      Source:
+        Owner: AWS
+        SourceIdentifier: IAM_USER_NO_POLICIES_CHECK
+    Type: AWS::Config::ConfigRule
+  IamUserUnusedCredentialsCheck:
+    Properties:
+      ConfigRuleName: iam-user-unused-credentials-check
+      InputParameters:
+        maxCredentialUsageAge:
+          Fn::If:
+            - iamUserUnusedCredentialsCheckParamMaxCredentialUsageAge
+            - Ref: IamUserUnusedCredentialsCheckParamMaxCredentialUsageAge
+            - Ref: AWS::NoValue
+      Source:
+        Owner: AWS
+        SourceIdentifier: IAM_USER_UNUSED_CREDENTIALS_CHECK
+    Type: AWS::Config::ConfigRule
+  IncomingSshDisabled:
+    Properties:
+      ConfigRuleName: restricted-ssh
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::EC2::SecurityGroup
+      Source:
+        Owner: AWS
+        SourceIdentifier: INCOMING_SSH_DISABLED
+    Type: AWS::Config::ConfigRule
+  MfaEnabledForIamConsoleAccess:
+    Properties:
+      ConfigRuleName: mfa-enabled-for-iam-console-access
+      Source:
+        Owner: AWS
+        SourceIdentifier: MFA_ENABLED_FOR_IAM_CONSOLE_ACCESS
+    Type: AWS::Config::ConfigRule
+  MultiRegionCloudTrailEnabled:
+    Properties:
+      ConfigRuleName: multi-region-cloudtrail-enabled
+      Source:
+        Owner: AWS
+        SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED
+    Type: AWS::Config::ConfigRule
+  RdsSnapshotEncrypted:
+    Properties:
+      ConfigRuleName: rds-snapshot-encrypted
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBSnapshot
+          - AWS::RDS::DBClusterSnapshot
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_SNAPSHOT_ENCRYPTED
+    Type: AWS::Config::ConfigRule
+  RdsStorageEncrypted:
+    Properties:
+      ConfigRuleName: rds-storage-encrypted
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBInstance
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_STORAGE_ENCRYPTED
+    Type: AWS::Config::ConfigRule
+  RestrictedIncomingTraffic:
+    Properties:
+      ConfigRuleName: restricted-common-ports
+      InputParameters:
+        blockedPort3:
+          Fn::If:
+            - restrictedIncomingTrafficParamBlockedPort3
+            - Ref: RestrictedIncomingTrafficParamBlockedPort3
+            - Ref: AWS::NoValue
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::EC2::SecurityGroup
+      Source:
+        Owner: AWS
+        SourceIdentifier: RESTRICTED_INCOMING_TRAFFIC
+    Type: AWS::Config::ConfigRule
+  RootAccountHardwareMfaEnabled:
+    Properties:
+      ConfigRuleName: root-account-hardware-mfa-enabled
+      Source:
+        Owner: AWS
+        SourceIdentifier: ROOT_ACCOUNT_HARDWARE_MFA_ENABLED
+    Type: AWS::Config::ConfigRule
+  RootAccountMfaEnabled:
+    Properties:
+      ConfigRuleName: root-account-mfa-enabled
+      Source:
+        Owner: AWS
+        SourceIdentifier: ROOT_ACCOUNT_MFA_ENABLED
+    Type: AWS::Config::ConfigRule
+  S3AccountLevelPublicAccessBlocksPeriodic:
+    Properties:
+      ConfigRuleName: s3-account-level-public-access-blocks-periodic
+      InputParameters:
+        BlockPublicAcls:
+          Fn::If:
+            - s3AccountLevelPublicAccessBlocksPeriodicParamBlockPublicAcls
+            - Ref: S3AccountLevelPublicAccessBlocksPeriodicParamBlockPublicAcls
+            - Ref: AWS::NoValue
+        BlockPublicPolicy:
+          Fn::If:
+            - s3AccountLevelPublicAccessBlocksPeriodicParamBlockPublicPolicy
+            - Ref: S3AccountLevelPublicAccessBlocksPeriodicParamBlockPublicPolicy
+            - Ref: AWS::NoValue
+        IgnorePublicAcls:
+          Fn::If:
+            - s3AccountLevelPublicAccessBlocksPeriodicParamIgnorePublicAcls
+            - Ref: S3AccountLevelPublicAccessBlocksPeriodicParamIgnorePublicAcls
+            - Ref: AWS::NoValue
+        RestrictPublicBuckets:
+          Fn::If:
+            - s3AccountLevelPublicAccessBlocksPeriodicParamRestrictPublicBuckets
+            - Ref: S3AccountLevelPublicAccessBlocksPeriodicParamRestrictPublicBuckets
+            - Ref: AWS::NoValue
+      Source:
+        Owner: AWS
+        SourceIdentifier: S3_ACCOUNT_LEVEL_PUBLIC_ACCESS_BLOCKS_PERIODIC
+    Type: AWS::Config::ConfigRule
+  S3BucketLevelPublicAccessProhibited:
+    Properties:
+      ConfigRuleName: s3-bucket-level-public-access-prohibited
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::S3::Bucket
+      Source:
+        Owner: AWS
+        SourceIdentifier: S3_BUCKET_LEVEL_PUBLIC_ACCESS_PROHIBITED
+    Type: AWS::Config::ConfigRule
+  S3BucketLoggingEnabled:
+    Properties:
+      ConfigRuleName: s3-bucket-logging-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::S3::Bucket
+      Source:
+        Owner: AWS
+        SourceIdentifier: S3_BUCKET_LOGGING_ENABLED
+    Type: AWS::Config::ConfigRule
+  S3BucketPublicReadProhibited:
+    Properties:
+      ConfigRuleName: s3-bucket-public-read-prohibited
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::S3::Bucket
+      Source:
+        Owner: AWS
+        SourceIdentifier: S3_BUCKET_PUBLIC_READ_PROHIBITED
+    Type: AWS::Config::ConfigRule
+  S3BucketPublicWriteProhibited:
+    Properties:
+      ConfigRuleName: s3-bucket-public-write-prohibited
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::S3::Bucket
+      Source:
+        Owner: AWS
+        SourceIdentifier: S3_BUCKET_PUBLIC_WRITE_PROHIBITED
+    Type: AWS::Config::ConfigRule
+  S3BucketServerSideEncryptionEnabled:
+    Properties:
+      ConfigRuleName: s3-bucket-server-side-encryption-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::S3::Bucket
+      Source:
+        Owner: AWS
+        SourceIdentifier: S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED
+    Type: AWS::Config::ConfigRule
+  S3BucketSslRequestsOnly:
+    Properties:
+      ConfigRuleName: s3-bucket-ssl-requests-only
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::S3::Bucket
+      Source:
+        Owner: AWS
+        SourceIdentifier: S3_BUCKET_SSL_REQUESTS_ONLY
+    Type: AWS::Config::ConfigRule
+  S3BucketVersioningEnabled:
+    Properties:
+      ConfigRuleName: s3-bucket-versioning-enabled
+      InputParameters:
+        isMfaDeleteEnabled:
+          Fn::If:
+            - s3BucketVersioningEnabledParamIsMfaDeleteEnabled
+            - Ref: S3BucketVersioningEnabledParamIsMfaDeleteEnabled
+            - Ref: AWS::NoValue
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::S3::Bucket
+      Source:
+        Owner: AWS
+        SourceIdentifier: S3_BUCKET_VERSIONING_ENABLED
+    Type: AWS::Config::ConfigRule
+  VpcDefaultSecurityGroupClosed:
+    Properties:
+      ConfigRuleName: vpc-default-security-group-closed
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::EC2::SecurityGroup
+      Source:
+        Owner: AWS
+        SourceIdentifier: VPC_DEFAULT_SECURITY_GROUP_CLOSED
+    Type: AWS::Config::ConfigRule
+  VpcFlowLogsEnabled:
+    Properties:
+      ConfigRuleName: vpc-flow-logs-enabled
+      Source:
+        Owner: AWS
+        SourceIdentifier: VPC_FLOW_LOGS_ENABLED
+    Type: AWS::Config::ConfigRule
+  AccountContactDetailsConfigured:
+    Properties:
+      ConfigRuleName: account-contact-details-configured
+      Description: Ensure the contact email and telephone number for AWS accounts are current and map to more than one individual in your organization. Within the My Account section of the console ensure correct information is specified in the Contact Information section.
+      Source:
+        Owner: AWS
+        SourceIdentifier: AWS_CONFIG_PROCESS_CHECK
+    Type: AWS::Config::ConfigRule
+  AccountSecurityContactConfigured:
+    Properties:
+      ConfigRuleName: account-security-contact-configured
+      Description: Ensure the contact email and telephone number for the your organizations security team are current. Within the My Account section of the AWS Management Console ensure the correct information is specified in the Security section.
+      Source:
+        Owner: AWS
+        SourceIdentifier: AWS_CONFIG_PROCESS_CHECK
+    Type: AWS::Config::ConfigRule
+  AccountSecurityQuestionsConfigured:
+    Properties:
+      ConfigRuleName: account-security-questions-configured
+      Description: Ensure the security questions that can be used to authenticate individuals calling AWS customer service for support are configured. Within the My Account section of the AWS Management Console ensure three security challenge questions are configured.
+      Source:
+        Owner: AWS
+        SourceIdentifier: AWS_CONFIG_PROCESS_CHECK
+    Type: AWS::Config::ConfigRule
+  RootAccountRegularUse:
+    Properties:
+      ConfigRuleName: root-account-regular-use
+      Description: Ensure the use of the root account is avoided for everyday tasks. Within IAM, run a credential report to examine when the root user was last used.
+      Source:
+        Owner: AWS
+        SourceIdentifier: AWS_CONFIG_PROCESS_CHECK
+    Type: AWS::Config::ConfigRule
+  IAMUserConsoleAndAPIAccessAtCreation:
+    Properties:
+      ConfigRuleName: iam-user-console-and-api-access-at-creation
+      Description: Ensure access keys are not setup during the initial user setup for all IAM users that have a console password. For all IAM users with console access, compare the user 'Creation time` to the Access Key `Created` date.
+      Source:
+        Owner: AWS
+        SourceIdentifier: AWS_CONFIG_PROCESS_CHECK
+    Type: AWS::Config::ConfigRule
+  IAMUserSingleAccessKey:
+    Properties:
+      ConfigRuleName: iam-user-single-access-key
+      Description: Ensure there is only one active access key available for any single IAM user. For all IAM users check that there is only one active key used within the Security Credentials tab for each user within IAM.
+      Source:
+        Owner: AWS
+        SourceIdentifier: AWS_CONFIG_PROCESS_CHECK
+    Type: AWS::Config::ConfigRule
+  IAMExpiredCertificates:
+    Properties:
+      ConfigRuleName: iam-expired-certificates
+      Description: Ensure that all the expired SSL/TLS certificates stored in IAM are removed. From the command line with the installed AWS CLI run the 'aws iam list-server-certificates' command and determine if there are any expired server certificates.
+      Source:
+        Owner: AWS
+        SourceIdentifier: AWS_CONFIG_PROCESS_CHECK
+    Type: AWS::Config::ConfigRule
+  IAMAccessAnalyzerEnabled:
+    Properties:
+      ConfigRuleName: iam-access-analyzer-enabled
+      Description: Ensure that IAM Access analyzer is enabled. Within the IAM section of the console, select Access analyzer and ensure that the STATUS is set to Active.
+      Source:
+        Owner: AWS
+        SourceIdentifier: AWS_CONFIG_PROCESS_CHECK
+    Type: AWS::Config::ConfigRule
+  ConfigEnabledAllRegions:
+    Properties:
+      ConfigRuleName: config-enabled-all-regions
+      Description: Ensure AWS Config is enabled in all AWS Regions. Within the AWS Config section of the console, for each Region enabled ensure the AWS Config recorder is configured correctly. Ensure recording of global AWS resources is enabled at least in one Region.
+      Source:
+        Owner: AWS
+        SourceIdentifier: AWS_CONFIG_PROCESS_CHECK
+    Type: AWS::Config::ConfigRule
+  AlarmUnauthorizedAPIcalls:
+    Properties:
+      ConfigRuleName: alarm-unauthorized-api-calls
+      Description: Ensure a log metric filter and an alarm exists for unauthorized API calls.
+      Source:
+        Owner: AWS
+        SourceIdentifier: AWS_CONFIG_PROCESS_CHECK
+    Type: AWS::Config::ConfigRule
+  AlarmSignInWithoutMFA:
+    Properties:
+      ConfigRuleName: alarm-sign-in-without-mfa
+      Description: Ensure a log metric filter and an alarm exists for AWS Management Console sign-in without Multi-Factor Authentication (MFA).
+      Source:
+        Owner: AWS
+        SourceIdentifier: AWS_CONFIG_PROCESS_CHECK
+    Type: AWS::Config::ConfigRule
+  AlarmRootAccountUse:
+    Properties:
+      ConfigRuleName: alarm-root-account-use
+      Description: Ensure a log metric filter and an alarm exists for usage of the root account.
+      Source:
+        Owner: AWS
+        SourceIdentifier: AWS_CONFIG_PROCESS_CHECK
+    Type: AWS::Config::ConfigRule
+  AlarmIAMpolicyChange:
+    Properties:
+      ConfigRuleName: alarm-iam-policy-change
+      Description: Ensure a log metric filter and an alarm exists for IAM policy changes.
+      Source:
+        Owner: AWS
+        SourceIdentifier: AWS_CONFIG_PROCESS_CHECK
+    Type: AWS::Config::ConfigRule
+  AlarmCloudtrailConfigChange:
+    Properties:
+      ConfigRuleName: alarm-cloudtrail-config-change
+      Description: Ensure a log metric filter and an alarm exists for AWS CloudTrail configuration changes.
+      Source:
+        Owner: AWS
+        SourceIdentifier: AWS_CONFIG_PROCESS_CHECK
+    Type: AWS::Config::ConfigRule
+  AlarmS3BucketPolicyChange:
+    Properties:
+      ConfigRuleName: alarm-s3-bucket-policy-change
+      Description: Ensure a log metric filter and an alarm exists for Amazon S3 bucket policy changes.
+      Source:
+        Owner: AWS
+        SourceIdentifier: AWS_CONFIG_PROCESS_CHECK
+    Type: AWS::Config::ConfigRule
+  AlarmVPCNetworkGatewayChange:
+    Properties:
+      ConfigRuleName: alarm-vpc-network-gateway-change
+      Description: Ensure a log metric filter and an alarm exists for changes to network gateways.
+      Source:
+        Owner: AWS
+        SourceIdentifier: AWS_CONFIG_PROCESS_CHECK
+    Type: AWS::Config::ConfigRule
+  AlarmVPCroutetableChange:
+    Properties:
+      ConfigRuleName: alarm-vpc-route-table-change
+      Description: Ensure a log metric filter and an alarm exists for route table changes.
+      Source:
+        Owner: AWS
+        SourceIdentifier: AWS_CONFIG_PROCESS_CHECK
+    Type: AWS::Config::ConfigRule
+  AlarmVPCChange:
+    Properties:
+      ConfigRuleName: alarm-vpc-change
+      Description: Ensure a log metric filter and an alarm exists for Amazon Virtual Private Cloud (VPC) changes.
+      Source:
+        Owner: AWS
+        SourceIdentifier: AWS_CONFIG_PROCESS_CHECK
+    Type: AWS::Config::ConfigRule
+  AlarmOrganizationsChange:
+    Properties:
+      ConfigRuleName: alarm-organizations-change
+      Description: Ensure a log metric filter and an alarm exists for AWS Organizations changes.
+      Source:
+        Owner: AWS
+        SourceIdentifier: AWS_CONFIG_PROCESS_CHECK
+    Type: AWS::Config::ConfigRule
+  VPCNetworkACLOpenAdminPorts:
+    Properties:
+      ConfigRuleName: vpc-networkacl-open-admin-ports
+      Description: Ensure no network ACLs allow public ingress to the remote server administration ports. Within the VPC section of the console, ensure there are network ACLs with a source of '0.0.0.0/0' with allowing ports or port ranges including remote server admin ports.
+      Source:
+        Owner: AWS
+        SourceIdentifier: AWS_CONFIG_PROCESS_CHECK
+    Type: AWS::Config::ConfigRule
+  Ec2InstanceProfileAttached:
+    Properties:
+      ConfigRuleName: ec2-instance-profile-attached
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::EC2::Instance
+      Source:
+        Owner: AWS
+        SourceIdentifier: EC2_INSTANCE_PROFILE_ATTACHED
+    Type: AWS::Config::ConfigRule
+  AlarmConsoleAuthFailures:
+    Properties:
+      ConfigRuleName: alarm-console-auth-failures
+      Description: Ensure a log metric filter and an alarm exists for AWS Management Console authentication failures.
+      Source:
+        Owner: AWS
+        SourceIdentifier: AWS_CONFIG_PROCESS_CHECK
+    Type: AWS::Config::ConfigRule
+  AlarmKmsDisableOrDeleteCmk:
+    Properties:
+      ConfigRuleName: alarm-kms-disable-or-delete-cmk
+      Description: Ensure a log metric filter and an alarm exists for disabling or scheduled deletion of customer created CMKs.
+      Source:
+        Owner: AWS
+        SourceIdentifier: AWS_CONFIG_PROCESS_CHECK
+    Type: AWS::Config::ConfigRule
+  AlarmAwsConfigChange:
+    Properties:
+      ConfigRuleName: alarm-aws-config-change
+      Description: Ensure a log metric filter and an alarm exists for AWS Config configuration changes.
+      Source:
+        Owner: AWS
+        SourceIdentifier: AWS_CONFIG_PROCESS_CHECK
+    Type: AWS::Config::ConfigRule
+  AlarmVpcSecrityGroupChange:
+    Properties:
+      ConfigRuleName: alarm-vpc-secrity-group-change
+      Description: Ensure a log metric filter and an alarm exists for security group changes.
+      Source:
+        Owner: AWS
+        SourceIdentifier: AWS_CONFIG_PROCESS_CHECK
+    Type: AWS::Config::ConfigRule
+  AlarmVpcNaclChange:
+    Properties:
+      ConfigRuleName: alarm-vpc-nacl-change
+      Description: Ensure a log metric filter and an alarm exists for changes to Network Access Control Lists (NACL).
+      Source:
+        Owner: AWS
+        SourceIdentifier: AWS_CONFIG_PROCESS_CHECK
+    Type: AWS::Config::ConfigRule
+  VpcPeeringLeastAccess:
+    Properties:
+      ConfigRuleName: vpc-peering-least-access
+      Description: Ensure the routing tables for Amazon VPC peering are "least access". Within the VPC section of the console, examine the route table entries to ensure that the least number of subnets or hosts are required to accomplish the purpose for peering are routable.
+      Source:
+        Owner: AWS
+        SourceIdentifier: AWS_CONFIG_PROCESS_CHECK
+    Type: AWS::Config::ConfigRule
+Conditions:
+  accessKeysRotatedParamMaxAccessKeyAge:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: AccessKeysRotatedParamMaxAccessKeyAge
+  iamPasswordPolicyParamMaxPasswordAge:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: IamPasswordPolicyParamMaxPasswordAge
+  iamPasswordPolicyParamMinimumPasswordLength:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: IamPasswordPolicyParamMinimumPasswordLength
+  iamPasswordPolicyParamPasswordReusePrevention:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: IamPasswordPolicyParamPasswordReusePrevention
+  iamPasswordPolicyParamRequireLowercaseCharacters:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: IamPasswordPolicyParamRequireLowercaseCharacters
+  iamPasswordPolicyParamRequireNumbers:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: IamPasswordPolicyParamRequireNumbers
+  iamPasswordPolicyParamRequireSymbols:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: IamPasswordPolicyParamRequireSymbols
+  iamPasswordPolicyParamRequireUppercaseCharacters:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: IamPasswordPolicyParamRequireUppercaseCharacters
+  iamPolicyInUseParamPolicyARN:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: IamPolicyInUseParamPolicyARN
+  iamUserUnusedCredentialsCheckParamMaxCredentialUsageAge:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: IamUserUnusedCredentialsCheckParamMaxCredentialUsageAge
+  restrictedIncomingTrafficParamBlockedPort3:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: RestrictedIncomingTrafficParamBlockedPort3
+  s3AccountLevelPublicAccessBlocksPeriodicParamBlockPublicAcls:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: S3AccountLevelPublicAccessBlocksPeriodicParamBlockPublicAcls
+  s3AccountLevelPublicAccessBlocksPeriodicParamBlockPublicPolicy:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: S3AccountLevelPublicAccessBlocksPeriodicParamBlockPublicPolicy
+  s3AccountLevelPublicAccessBlocksPeriodicParamIgnorePublicAcls:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: S3AccountLevelPublicAccessBlocksPeriodicParamIgnorePublicAcls
+  s3AccountLevelPublicAccessBlocksPeriodicParamRestrictPublicBuckets:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: S3AccountLevelPublicAccessBlocksPeriodicParamRestrictPublicBuckets
+  s3BucketVersioningEnabledParamIsMfaDeleteEnabled:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: S3BucketVersioningEnabledParamIsMfaDeleteEnabled

--- a/_sub/security/config-config/main.tf
+++ b/_sub/security/config-config/main.tf
@@ -1,0 +1,59 @@
+# Policies
+
+data "aws_iam_policy_document" "recorder" {
+  statement {
+    effect  = "Allow"
+    actions = ["s3:*"]
+    resources = [
+      var.s3_bucket_arn,
+      "${var.s3_bucket_arn}/*"
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "assume_recorder_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "recorder" {
+  name               = "aws-config-recorder"
+  assume_role_policy = data.aws_iam_policy_document.assume_recorder_role.json
+}
+
+resource "aws_iam_role_policy" "recorder" {
+  name   = "aws-config-recorder"
+  role   = aws_iam_role.recorder.id
+  policy = data.aws_iam_policy_document.recorder.json
+}
+
+resource "aws_iam_role_policy_attachment" "recorder" {
+  role       = aws_iam_role.recorder.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWS_ConfigRole"
+}
+
+# AWS Config
+
+resource "aws_config_configuration_recorder" "this" {
+  name     = "aws-config-recorder"
+  role_arn = aws_iam_role.recorder.arn
+}
+
+resource "aws_config_delivery_channel" "this" {
+  name           = "aws-config-delivery-channel"
+  s3_bucket_name = var.s3_bucket_name
+}
+
+resource "aws_config_configuration_recorder_status" "this" {
+  name       = aws_config_configuration_recorder.this.name
+  is_enabled = true
+  depends_on = [aws_config_delivery_channel.this]
+}

--- a/_sub/security/config-config/main.tf
+++ b/_sub/security/config-config/main.tf
@@ -57,3 +57,16 @@ resource "aws_config_configuration_recorder_status" "this" {
   is_enabled = true
   depends_on = [aws_config_delivery_channel.this]
 }
+
+# Conformance packs
+
+resource "aws_config_conformance_pack" "pack" {
+  for_each = var.conformance_packs
+  name     = replace(lower(each.value), "/[^a-z0-9-]/", "-")
+
+  # Conformance packs can be imported from this repository:
+  # https://github.com/awslabs/aws-config-rules/tree/master/aws-config-conformance-packs
+  template_body = file("${path.module}/conformance-packs/${each.value}.yaml")
+
+  depends_on = [aws_config_configuration_recorder.this]
+}

--- a/_sub/security/config-config/vars.tf
+++ b/_sub/security/config-config/vars.tf
@@ -1,0 +1,15 @@
+variable "deploy" {
+  description = "Configure AWS Config feature toggle."
+  type        = bool
+  default     = true
+}
+
+variable "s3_bucket_name" {
+  type        = string
+  description = "The name of the S3 Bucket where AWS Config inventory and logs will be stored."
+}
+
+variable "s3_bucket_arn" {
+  type        = string
+  description = "The name of the S3 Bucket where AWS Config inventory and logs will be stored."
+}

--- a/_sub/security/config-config/vars.tf
+++ b/_sub/security/config-config/vars.tf
@@ -13,3 +13,9 @@ variable "s3_bucket_arn" {
   type        = string
   description = "The name of the S3 Bucket where AWS Config inventory and logs will be stored."
 }
+
+variable "conformance_packs" {
+  type        = set(string)
+  description = "The list of the AWS Config conformance packs that one would like to enable."
+  default     = []
+}

--- a/_sub/security/config-config/versions.tf
+++ b/_sub/security/config-config/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.3.0, < 2.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.66.0"
+    }
+  }
+}

--- a/_sub/storage/s3-config-bucket/data.tf
+++ b/_sub/storage/s3-config-bucket/data.tf
@@ -1,0 +1,58 @@
+data "aws_iam_policy_document" "this" {
+  statement {
+    sid    = "AWSConfigAclCheck"
+    effect = "Allow"
+    principals {
+      identifiers = [
+        "config.amazonaws.com"
+      ]
+      type = "Service"
+    }
+    actions = [
+      "s3:GetBucketAcl"
+    ]
+    resources = [
+      "arn:aws:s3:::${var.s3_bucket}"
+    ]
+  }
+
+  statement {
+    sid    = "AWSConfigExistinceCheck"
+    effect = "Allow"
+    principals {
+      identifiers = [
+        "config.amazonaws.com"
+      ]
+      type = "Service"
+    }
+    actions = [
+      "s3:ListBucket"
+    ]
+    resources = [
+      "arn:aws:s3:::${var.s3_bucket}"
+    ]
+  }
+
+
+  statement {
+    sid    = "AWSConfigWrite"
+    effect = "Allow"
+    principals {
+      identifiers = [
+        "config.amazonaws.com"
+      ]
+      type = "Service"
+    }
+    actions = [
+      "s3:PutObject"
+    ]
+    resources = [
+      "arn:aws:s3:::${var.s3_bucket}/*"
+    ]
+    condition {
+      test     = "StringEquals"
+      values   = ["bucket-owner-full-control"]
+      variable = "s3:x-amz-acl"
+    }
+  }
+}

--- a/_sub/storage/s3-config-bucket/main.tf
+++ b/_sub/storage/s3-config-bucket/main.tf
@@ -1,0 +1,31 @@
+resource "aws_s3_bucket" "bucket" {
+  count  = var.create_s3_bucket ? 1 : 0
+  bucket = var.s3_bucket
+  tags = {
+    "Managed by" = "Terraform"
+  }
+
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_policy" "this" {
+  count  = var.create_s3_bucket ? 1 : 0
+  bucket = aws_s3_bucket.bucket[count.index].bucket
+  policy = data.aws_iam_policy_document.this.json
+}
+
+resource "aws_s3_bucket_ownership_controls" "bucket_ownership_controls" {
+  count  = var.create_s3_bucket ? 1 : 0
+  bucket = aws_s3_bucket.bucket[count.index].id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_acl" "bucket_acl" {
+  count  = var.create_s3_bucket ? 1 : 0
+  bucket = aws_s3_bucket.bucket[count.index].id
+  acl    = "private"
+
+  depends_on = [aws_s3_bucket_ownership_controls.bucket_ownership_controls]
+}

--- a/_sub/storage/s3-config-bucket/outputs.tf
+++ b/_sub/storage/s3-config-bucket/outputs.tf
@@ -1,0 +1,8 @@
+output "bucket_name" {
+  value = try(aws_s3_bucket.bucket[0].bucket, null)
+}
+
+output "bucket_arn" {
+  value = try(aws_s3_bucket.bucket[0].arn, null)
+}
+

--- a/_sub/storage/s3-config-bucket/vars.tf
+++ b/_sub/storage/s3-config-bucket/vars.tf
@@ -1,0 +1,10 @@
+variable "s3_bucket" {
+  type        = string
+  description = "The name of the S3 Bucket where the AWS Config inventory will be stored."
+}
+
+variable "create_s3_bucket" {
+  type    = bool
+  default = false
+}
+

--- a/_sub/storage/s3-config-bucket/versions.tf
+++ b/_sub/storage/s3-config-bucket/versions.tf
@@ -1,0 +1,10 @@
+
+terraform {
+  required_version = ">= 1.3.0, < 2.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.66.0"
+    }
+  }
+}

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -212,9 +212,18 @@ module "config_s3_local" {
   }
 }
 
-# TODO(emil): enable aws config
+module "config_local" {
+  source         = "../../_sub/security/config-config"
+  s3_bucket_name = module.config_s3_local.bucket_name
+  s3_bucket_arn  = module.config_s3_local.bucket_arn
+  deploy         = var.harden
 
-# TODO(emil): deploy conformance pack
+  # TODO(emil): deploy conformance pack as a variable to this module
+
+  providers = {
+    aws = aws.workload
+  }
+}
 
 # --------------------------------------------------
 # CloudWatch controls

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -213,12 +213,11 @@ module "config_s3_local" {
 }
 
 module "config_local" {
-  source         = "../../_sub/security/config-config"
-  s3_bucket_name = module.config_s3_local.bucket_name
-  s3_bucket_arn  = module.config_s3_local.bucket_arn
-  deploy         = var.harden
-
-  # TODO(emil): deploy conformance pack as a variable to this module
+  source            = "../../_sub/security/config-config"
+  deploy            = var.harden
+  s3_bucket_name    = module.config_s3_local.bucket_name
+  s3_bucket_arn     = module.config_s3_local.bucket_arn
+  conformance_packs = ["Operational-Best-Practices-for-CIS-AWS-v1.4-Level2"]
 
   providers = {
     aws = aws.workload


### PR DESCRIPTION
- Module for AWS Config bucket
- Module for enabling AWS Config and Conformance Packs
- Enabling AWS Config and the `Operational Best Practices for CIS AWS Foundations Benchmark v1.4 Level 2` conformance pack for hardened accounts