### PR TITLE
feat: add facility to create sso permission assignments

### DIFF
--- a/_sub/security/iam-identity-center-assignment/main.tf
+++ b/_sub/security/iam-identity-center-assignment/main.tf
@@ -1,0 +1,28 @@
+data "aws_ssoadmin_instances" "dfds" {}
+
+data "aws_ssoadmin_permission_set" "permission_set" {
+  instance_arn = tolist(data.aws_ssoadmin_instances.dfds.arns)[0]
+  name         = var.permission_set_name
+}
+
+data "aws_identitystore_group" "group" {
+  identity_store_id = tolist(data.aws_ssoadmin_instances.dfds.identity_store_ids)[0]
+
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "DisplayName"
+      attribute_value = var.group_name
+    }
+  }
+}
+
+resource "aws_ssoadmin_account_assignment" "assignment" {
+  instance_arn       = tolist(data.aws_ssoadmin_instances.dfds.arns)[0]
+  permission_set_arn = data.aws_ssoadmin_permission_set.permission_set.arn
+
+  principal_id   = data.aws_identitystore_group.group.group_id
+  principal_type = "GROUP"
+
+  target_id   = var.aws_account_id
+  target_type = "AWS_ACCOUNT"
+}

--- a/_sub/security/iam-identity-center-assignment/vars.tf
+++ b/_sub/security/iam-identity-center-assignment/vars.tf
@@ -1,0 +1,11 @@
+variable "permission_set_name" {
+    type = string
+}
+
+variable "group_name" {
+    type = string
+}
+
+variable "aws_account_id" {
+    type = string
+}

--- a/_sub/security/iam-identity-center-assignment/versions.tf
+++ b/_sub/security/iam-identity-center-assignment/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.3.0, < 2.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.66.0"
+    }
+  }
+}

--- a/_sub/security/iam-policies/main.tf
+++ b/_sub/security/iam-policies/main.tf
@@ -54,6 +54,27 @@ data "aws_iam_policy_document" "create_org_account" {
     resources = ["*"]
     effect    = "Allow"
   }
+
+  statement {
+    sid = "AssignPermissionSet"
+
+    actions = [
+      "sso:ListInstances",
+      "identitystore:GetGroupId",
+      "identitystore:DescribeGroup",
+      "sso:ListPermissionSets",
+      "sso:CreateAccountAssignment",
+      "sso:DeleteAccountAssignment",
+      "sso:DescribePermissionSet",
+      "sso:ListTagsForResource",
+      "sso:ListPermissionSetsProvisionedToAccount",
+      "sso:ListAccountAssignments",
+      "sso:DescribeAccountAssignmentCreationStatus",
+    ]
+
+    resources = ["*"]
+    effect    = "Allow"
+  }
 }
 
 # Assume Non-core Accounts

--- a/security/org-account-assume/vars.tf
+++ b/security/org-account-assume/vars.tf
@@ -47,3 +47,16 @@ variable "parent_id" {
   description = "The ID of the parent AWS Organization OU. Defaults to the root."
   default     = "r-65k1"
 }
+
+variable "aws_region_sso" {
+  type = string
+  default = "eu-west-1"
+}
+
+variable "sso_admin_permission_set_name" {
+    type = string
+}
+
+variable "sso_admin_group_name" {
+    type = string
+}


### PR DESCRIPTION
This adds the ability to assign sso permission set to accounts created via org-account-assume