### PR TITLE
Add SupportAccess permission set.

### DIFF
--- a/_sub/security/iam-identity-center/main.tf
+++ b/_sub/security/iam-identity-center/main.tf
@@ -29,3 +29,16 @@ resource "aws_ssoadmin_permission_set_inline_policy" "capabilityaccess" {
   instance_arn       = aws_ssoadmin_permission_set.capabilityaccess.instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.capabilityaccess.arn
 }
+
+resource "aws_ssoadmin_permission_set" "supportaccess" {
+  name             = "SupportAccess"
+  description      = "The permission set for handling support cases within capabilities"
+  instance_arn     = tolist(data.aws_ssoadmin_instances.dfds.arns)[0]
+  session_duration = "PT8H"
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "supportaccess" {
+  instance_arn       = aws_ssoadmin_permission_set.supportaccess.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.supportaccess.arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/AWSSupportAccess"
+}


### PR DESCRIPTION
This is permission set will be used on hardened accounts to allow users to assume a limited role for handling support tickets.