### PR TITLE
Enables VPC flow logging

### DIFF
--- a/_sub/compute/eks-cluster/network.tf
+++ b/_sub/compute/eks-cluster/network.tf
@@ -3,7 +3,6 @@
 data "aws_availability_zones" "available" {
 }
 
-# tfsec:ignore:aws-ec2-require-vpc-flow-logs-for-all-vpcs
 resource "aws_vpc" "eks" {
   cidr_block = "10.0.0.0/16"
 
@@ -11,6 +10,12 @@ resource "aws_vpc" "eks" {
     "Name"                                      = "eks-${var.cluster_name}-cluster"
     "kubernetes.io/cluster/${var.cluster_name}" = "shared"
   }
+}
+
+module "flow_log" {
+  source   = "../../../_sub/network/vpc-flow-log"
+  log_name = "eks-${var.cluster_name}-cluster"
+  vpc_id   = aws_vpc.eks.id
 }
 
 resource "aws_subnet" "eks" {
@@ -26,4 +31,3 @@ resource "aws_subnet" "eks" {
     "kubernetes.io/cluster/${var.cluster_name}" = "shared"
   }
 }
-

--- a/_sub/network/vpc-flow-log/main.tf
+++ b/_sub/network/vpc-flow-log/main.tf
@@ -1,0 +1,55 @@
+resource "aws_cloudwatch_log_group" "vpc_eks" {
+  name              = "/aws/vpc/${var.log_name}"
+  retention_in_days = var.retention_in_days
+}
+
+data "aws_iam_policy_document" "flow_log_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["vpc-flow-logs.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "flow_log" {
+  name               = "vpc-flow-log-${var.log_name}"
+  assume_role_policy = data.aws_iam_policy_document.flow_log_assume_role.json
+}
+
+resource "aws_flow_log" "eks" {
+  iam_role_arn    = aws_iam_role.flow_log.arn
+  log_destination = aws_cloudwatch_log_group.vpc_eks.arn
+  traffic_type    = "REJECT"
+  vpc_id          = var.vpc_id
+}
+
+data "aws_iam_policy_document" "flow_log" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams",
+    ]
+
+    resources = [
+      "${aws_cloudwatch_log_group.vpc_eks.arn}",
+      "${aws_cloudwatch_log_group.vpc_eks.arn}:*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "flow_log" {
+  name   = "vpc-flow-log-${var.log_name}"
+  role   = aws_iam_role.flow_log.id
+  policy = data.aws_iam_policy_document.flow_log.json
+}
+

--- a/_sub/network/vpc-flow-log/vars.tf
+++ b/_sub/network/vpc-flow-log/vars.tf
@@ -1,0 +1,12 @@
+variable "log_name" {
+  type = string
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "retention_in_days" {
+  type    = number
+  default = 7
+}

--- a/_sub/network/vpc-flow-log/versions.tf
+++ b/_sub/network/vpc-flow-log/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.3.0, < 2.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.67.0"
+    }
+  }
+}

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -275,6 +275,42 @@ module "config_local_2" {
 }
 
 # --------------------------------------------------
+# Default VPC flow logging
+# --------------------------------------------------
+
+resource "aws_default_vpc" "default" {
+  count    = var.harden ? 1 : 0
+  provider = aws.workload
+}
+
+module "default_vpc_flow_log" {
+  count    = var.harden ? 1 : 0
+  source   = "../../_sub/network/vpc-flow-log"
+  log_name = "default-vpc-${var.aws_region}"
+  vpc_id   = aws_default_vpc.default[count.index].id
+
+  providers = {
+    aws = aws.workload
+  }
+}
+
+resource "aws_default_vpc" "default_2" {
+  count    = var.harden ? 1 : 0
+  provider = aws.workload_2
+}
+
+module "default_vpc_flow_log_2" {
+  count    = var.harden ? 1 : 0
+  source   = "../../_sub/network/vpc-flow-log"
+  log_name = "default-vpc-${var.aws_region_2}"
+  vpc_id   = aws_default_vpc.default_2[count.index].id
+
+  providers = {
+    aws = aws.workload_2
+  }
+}
+
+# --------------------------------------------------
 # Password policy
 # --------------------------------------------------
 


### PR DESCRIPTION
- Routed to CloudWatch
- Retained for 7 days by default
- Only for rejected packets
- Create a VPC flow log for the EKS cluster VPC
- Create VPC flow logs for the default VPCs within hardened accounts