### PR TITLE
Harden default security groups

### DIFF
--- a/_sub/compute/eks-cluster/network.tf
+++ b/_sub/compute/eks-cluster/network.tf
@@ -12,6 +12,11 @@ resource "aws_vpc" "eks" {
   }
 }
 
+# Disable ingress/egress in the default security group in the VPC
+resource "aws_default_security_group" "default" {
+  vpc_id = aws_vpc.eks.id
+}
+
 module "flow_log" {
   source   = "../../../_sub/network/vpc-flow-log"
   log_name = "eks-${var.cluster_name}-cluster"

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -311,6 +311,22 @@ module "default_vpc_flow_log_2" {
 }
 
 # --------------------------------------------------
+# Default security groups
+# --------------------------------------------------
+
+resource "aws_default_security_group" "default" {
+  count    = var.harden ? 1 : 0
+  vpc_id   = aws_default_vpc.default[count.index].id
+  provider = aws.workload
+}
+
+resource "aws_default_security_group" "default_2" {
+  count    = var.harden ? 1 : 0
+  vpc_id   = aws_default_vpc.default_2[count.index].id
+  provider = aws.workload_2
+}
+
+# --------------------------------------------------
 # Password policy
 # --------------------------------------------------
 


### PR DESCRIPTION
Disables egress/ingress in the default security groups for hardened accounts's VPC and the EKS cluster VPC.