### PR TITLE
Enable org-audit CloudWatch log group and KMS CMK key.

### DIFF
--- a/_sub/storage/s3-cloudtrail-bucket/main.tf
+++ b/_sub/storage/s3-cloudtrail-bucket/main.tf
@@ -40,6 +40,9 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "bucket" {
 
   rule {
     bucket_key_enabled = true
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
   }
 }
 

--- a/security/cloudtrail-master/main.tf
+++ b/security/cloudtrail-master/main.tf
@@ -12,4 +12,6 @@ module "cloudtrail_central" {
   trail_name            = "org-audit"
   is_organization_trail = true
   deploy                = var.deploy
+  create_log_group      = true
+  create_kms_key        = true
 }


### PR DESCRIPTION
Also a fix for a noisy drift notification, which repeatedly suggests the changes like the following:

```
  ~ resource "aws_s3_bucket_server_side_encryption_configuration" "bucket" {
        # (1 unchanged attribute hidden)

      - rule {
          - bucket_key_enabled = true -> null

          - apply_server_side_encryption_by_default {
              - sse_algorithm = "AES256" -> null
            }
        }
      + rule {
          + bucket_key_enabled = true
        }
    }

```