### PR TITLE
Renames/recreates CloudTrail's log group and provides ability to set retention period.

### DIFF
--- a/_sub/security/cloudtrail-config/main.tf
+++ b/_sub/security/cloudtrail-config/main.tf
@@ -132,8 +132,9 @@ resource "aws_kms_alias" "alias" {
 }
 
 resource "aws_cloudwatch_log_group" "log_group" {
-  count = var.deploy && var.create_log_group ? 1 : 0
-  name  = "/cloudtrail/${var.trail_name}"
+  count             = var.deploy && var.create_log_group ? 1 : 0
+  name              = "/aws/cloudtrail/${var.trail_name}"
+  retention_in_days = var.log_group_retention_in_days
 }
 
 data "aws_iam_policy_document" "trust" {

--- a/_sub/security/cloudtrail-config/vars.tf
+++ b/_sub/security/cloudtrail-config/vars.tf
@@ -26,6 +26,12 @@ variable "create_log_group" {
   default     = false
 }
 
+variable "log_group_retention_in_days" {
+  type        = number
+  description = "Number of days to retain records within the CloudWatch log group."
+  default     = 7
+}
+
 variable "create_kms_key" {
   type        = bool
   description = "Specifies whether a KMS customer-managed key should be created for the enabling server side encryption on the CloudTrail logs."

--- a/security/cloudtrail-master/main.tf
+++ b/security/cloudtrail-master/main.tf
@@ -7,11 +7,12 @@ terraform {
 }
 
 module "cloudtrail_central" {
-  source                = "../../_sub/security/cloudtrail-config"
-  s3_bucket             = var.cloudtrail_central_s3_bucket
-  trail_name            = "org-audit"
-  is_organization_trail = true
-  deploy                = var.deploy
-  create_log_group      = true
-  create_kms_key        = true
+  source                      = "../../_sub/security/cloudtrail-config"
+  s3_bucket                   = var.cloudtrail_central_s3_bucket
+  trail_name                  = "org-audit"
+  is_organization_trail       = true
+  deploy                      = var.deploy
+  create_log_group            = true
+  log_group_retention_in_days = var.log_group_retention_in_days
+  create_kms_key              = true
 }

--- a/security/cloudtrail-master/vars.tf
+++ b/security/cloudtrail-master/vars.tf
@@ -11,3 +11,9 @@ variable "cloudtrail_central_s3_bucket" {
 variable "deploy" {
   type = bool
 }
+
+variable "log_group_retention_in_days" {
+  type        = number
+  description = "Number of days to retain records within the CloudWatch log group."
+  default     = 7
+}


### PR DESCRIPTION
Prefixes CloudTrail log groups with `/aws/` a standard naming convention followed by other log groups within these modules. This will cause the log group to be destroyed and recreated, losing previously ingested data because of that this PR is marked as a major release.