### PR TITLE
enable resource explorer in ou accounts

### DIFF
--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -721,3 +721,32 @@ module "datadog" {
     aws = aws.workload
   }
 }
+
+
+# --------------------------------------------------
+# AWS Resource Explorer Feature
+# --------------------------------------------------
+
+resource "aws_resourceexplorer2_index" "aggregator" {
+  type = "AGGREGATOR"
+
+  provider = aws.workload
+}
+
+resource "aws_resourceexplorer2_index" "eu_west_1" {
+  type = "LOCAL"
+
+  provider = aws.workload_2
+}
+
+resource "aws_resourceexplorer2_view" "aggregator_view" {
+  name = "all-resources"
+  default_view = true
+
+  included_property {
+    name = "tags"
+  }
+
+  depends_on = [aws_resourceexplorer2_index.aggregator]
+  provider = aws.workload
+}

--- a/security/org-account/main.tf
+++ b/security/org-account/main.tf
@@ -93,3 +93,31 @@ module "datadog" {
     aws = aws.workload
   }
 }
+
+# --------------------------------------------------
+# AWS Resource Explorer Feature
+# --------------------------------------------------
+
+resource "aws_resourceexplorer2_index" "aggregator" {
+  type = "AGGREGATOR"
+
+  provider = aws.workload
+}
+
+resource "aws_resourceexplorer2_index" "eu_west_1" {
+  type = "LOCAL"
+
+  provider = aws.workload_2
+}
+
+resource "aws_resourceexplorer2_view" "aggregator_view" {
+  name = "all-resources"
+  default_view = true
+
+  included_property {
+    name = "tags"
+  }
+
+  depends_on = [aws_resourceexplorer2_index.aggregator]
+  provider = aws.workload
+}


### PR DESCRIPTION
Enable resource discovery on AWS accounts in much accurate way. Much better than resource inventory! 
Adds resources index for eu-central-1
Adds resources index for eu-west-1
Adds view for resource index from eu-central-1