### PR TITLE
Provide SSO role access in default aws-auth.

### DIFF
--- a/_sub/compute/eks-heptio/default-auth-cm.yaml
+++ b/_sub/compute/eks-heptio/default-auth-cm.yaml
@@ -10,3 +10,9 @@ data:
       groups:
         - system:bootstrappers
         - system:nodes
+%{ for arn in capability_access_arns ~}
+    - rolearn: ${arn}
+      username: aws:capabilityaccess
+      groups:
+        - system:masters
+%{ endfor ~}


### PR DESCRIPTION
Allows one to use the AWS EKS console to browse Kubernetes resources.

You can see the EKS console working here:
<img width="1317" alt="Screenshot 2023-06-05 at 16 39 57" src="https://github.com/dfds/infrastructure-modules/assets/2730310/b24b13e6-584b-44a2-9719-f69f56194f33">
