### PR TITLE
Modernize and simplify our usage of EKS add-ons

### DIFF
--- a/_sub/compute/eks-addons/dependencies.tf
+++ b/_sub/compute/eks-addons/dependencies.tf
@@ -1,67 +1,31 @@
-# Apply specific versions of Kubernetes add-ons depending on EKS version
-# Cluster:          https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html
-# CNI:              https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
-# CoreDNS:          https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html
-# Kube-proxy:       https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html
-# EBS CSI driver:   https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html
+data "aws_eks_addon_version" "vpc_cni" {
+  addon_name         = "vpc-cni"
+  kubernetes_version = var.cluster_version
+  most_recent        = var.most_recent
+}
 
-# Get current default build of an add-on:
-# aws eks describe-addon-versions --kubernetes-version 1.27 --addon-name vpc-cni | jq -r '.addons[].addonVersions[] | select(.compatibilities[].defaultVersion == true) | .addonVersion'
-# aws eks describe-addon-versions --kubernetes-version 1.27 --addon-name coredns | jq -r '.addons[].addonVersions[] | select(.compatibilities[].defaultVersion == true) | .addonVersion'
-# aws eks describe-addon-versions --kubernetes-version 1.27 --addon-name kube-proxy | jq -r '.addons[].addonVersions[] | select(.compatibilities[].defaultVersion == true) | .addonVersion'
-# aws eks describe-addon-versions --kubernetes-version 1.27 --addon-name aws-ebs-csi-driver | jq -r '.addons[].addonVersions[] | select(.compatibilities[].defaultVersion == true) | .addonVersion'
+data "aws_eks_addon_version" "coredns" {
+  addon_name         = "coredns"
+  kubernetes_version = var.cluster_version
+  most_recent        = var.most_recent
+}
 
-locals {
-  vpccni_version_map = {
-    "1.19" = "v1.11.2-eksbuild.1"
-    "1.20" = "v1.11.2-eksbuild.1"
-    "1.21" = "v1.11.2-eksbuild.1"
-    "1.22" = "v1.11.4-eksbuild.1"
-    "1.23" = "v1.12.0-eksbuild.1"
-    "1.24" = "v1.12.2-eksbuild.1"
-    "1.25" = "v1.12.2-eksbuild.1"
-    "1.26" = "v1.12.6-eksbuild.1"
-    "1.27" = "v1.12.6-eksbuild.2"
-   }
+data "aws_eks_addon_version" "kube_proxy" {
+  addon_name         = "kube-proxy"
+  kubernetes_version = var.cluster_version
+  most_recent        = var.most_recent
+}
 
-  coredns_version_map = {
-    "1.19" = "v1.8.0-eksbuild.1"
-    "1.20" = "v1.8.3-eksbuild.1"
-    "1.21" = "v1.8.4-eksbuild.1"
-    "1.22" = "v1.8.7-eksbuild.1"
-    "1.23" = "v1.8.7-eksbuild.3"
-    "1.24" = "v1.8.7-eksbuild.4"
-    "1.25" = "v1.9.3-eksbuild.2"
-    "1.26" = "v1.9.3-eksbuild.3"
-    "1.27" = "v1.10.1-eksbuild.1"
-  }
-
-  kubeproxy_version_map = {
-    "1.19" = "v1.19.6-eksbuild.2"
-    "1.20" = "v1.20.4-eksbuild.2"
-    "1.21" = "v1.21.2-eksbuild.2"
-    "1.22" = "v1.22.11-eksbuild.2"
-    "1.23" = "v1.23.8-eksbuild.2"
-    "1.24" = "v1.24.7-eksbuild.2"
-    "1.25" = "v1.25.6-eksbuild.1"
-    "1.26" = "v1.26.2-eksbuild.1"
-    "1.27" = "v1.27.1-eksbuild.1"
-  }
-
-  awsebscsidriver_version_map = {
-    "1.22" = "v1.11.4-eksbuild.1"
-    "1.23" = "v1.14.0-eksbuild.1"
-    "1.24" = "v1.16.1-eksbuild.1"
-    "1.25" = "v1.16.1-eksbuild.1"
-    "1.26" = "v1.18.0-eksbuild.1"
-    "1.27" = "v1.19.0-eksbuild.1"
-  }
+data "aws_eks_addon_version" "aws_ebs_csi_driver" {
+  addon_name         = "aws-ebs-csi-driver"
+  kubernetes_version = var.cluster_version
+  most_recent        = var.most_recent
 }
 
 # Lookup actual add-on versions
 locals {
-  vpccni_version          = var.vpccni_version_override == "" ? local.vpccni_version_map[var.cluster_version] : var.vpccni_version_override
-  coredns_version         = var.coredns_version_override == "" ? local.coredns_version_map[var.cluster_version] : var.coredns_version_override
-  kubeproxy_version       = var.kubeproxy_version_override == "" ? local.kubeproxy_version_map[var.cluster_version] : var.kubeproxy_version_override
-  awsebscsidriver_version = var.awsebscsidriver_version_override == "" ? local.awsebscsidriver_version_map[var.cluster_version] : var.awsebscsidriver_version_override
+  vpccni_version          = var.vpccni_version_override == "" ? data.aws_eks_addon_version.vpc_cni.version : var.vpccni_version_override
+  coredns_version         = var.coredns_version_override == "" ? data.aws_eks_addon_version.coredns.version : var.coredns_version_override
+  kubeproxy_version       = var.kubeproxy_version_override == "" ? data.aws_eks_addon_version.kube_proxy.version : var.kubeproxy_version_override
+  awsebscsidriver_version = var.awsebscsidriver_version_override == "" ? data.aws_eks_addon_version.aws_ebs_csi_driver.version : var.awsebscsidriver_version_override
 }

--- a/_sub/compute/eks-addons/main.tf
+++ b/_sub/compute/eks-addons/main.tf
@@ -7,29 +7,33 @@ resource "aws_eks_addon" "vpc-cni" {
       "ENABLE_PREFIX_DELEGATION" = tostring(var.vpccni_prefix_delegation_enabled)
     }
   })
-  resolve_conflicts = "OVERWRITE"
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
 }
 
 resource "aws_eks_addon" "coredns" {
-  cluster_name      = var.cluster_name
-  addon_name        = "coredns"
-  addon_version     = local.coredns_version
-  resolve_conflicts = "OVERWRITE"
+  cluster_name                = var.cluster_name
+  addon_name                  = "coredns"
+  addon_version               = local.coredns_version
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
 }
 
 resource "aws_eks_addon" "kube-proxy" {
-  cluster_name      = var.cluster_name
-  addon_name        = "kube-proxy"
-  addon_version     = local.kubeproxy_version
-  resolve_conflicts = "OVERWRITE"
+  cluster_name                = var.cluster_name
+  addon_name                  = "kube-proxy"
+  addon_version               = local.kubeproxy_version
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
 }
 
 resource "aws_eks_addon" "aws-ebs-csi-driver" {
-  cluster_name             = var.cluster_name
-  addon_name               = "aws-ebs-csi-driver"
-  addon_version            = local.awsebscsidriver_version
-  resolve_conflicts        = "OVERWRITE"
-  service_account_role_arn = aws_iam_role.ebs-csi-driver-role.arn
+  cluster_name                = var.cluster_name
+  addon_name                  = "aws-ebs-csi-driver"
+  addon_version               = local.awsebscsidriver_version
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
+  service_account_role_arn    = aws_iam_role.ebs-csi-driver-role.arn
 
   depends_on = [
     aws_iam_role_policy_attachment.managed-ebs-csi-driver-policy

--- a/_sub/compute/eks-addons/vars.tf
+++ b/_sub/compute/eks-addons/vars.tf
@@ -35,3 +35,9 @@ variable "vpccni_prefix_delegation_enabled" {
   description = "Whether to enable prefix delegation mode on the VPC CNI addon."
   default     = false
 }
+
+variable "most_recent" {
+  type        = bool
+  default     = false
+  description = "Should we use the latest version of an EKS add-on?"
+}

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -209,6 +209,7 @@ module "eks_addons" {
   vpccni_version_override          = var.eks_addon_vpccni_version_override
   vpccni_prefix_delegation_enabled = var.eks_addon_vpccni_prefix_delegation_enabled
   awsebscsidriver_version_override = var.eks_addon_awsebscsidriver_version_override
+  most_recent                      = var.eks_addon_most_recent
   cluster_version                  = var.eks_cluster_version
   eks_openid_connect_provider_url  = module.eks_cluster.eks_openid_connect_provider_url
 }

--- a/compute/eks-ec2/vars.tf
+++ b/compute/eks-ec2/vars.tf
@@ -117,6 +117,12 @@ variable "eks_addon_awsebscsidriver_version_override" {
   default = ""
 }
 
+variable "eks_addon_most_recent" {
+  type        = bool
+  default     = false
+  description = "Should we use the latest version of an EKS add-on?"
+}
+
 variable "eks_public_s3_bucket" {
   description = "The name of the public S3 bucket, where non-sensitive Kubeconfig will be copied to"
   type        = string

--- a/test/integration/eu-west-1/k8s-qa/cluster/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/cluster/terragrunt.hcl
@@ -24,6 +24,7 @@ inputs = {
   eks_cluster_version                        = "1.27"
   eks_cluster_zones                          = 2
   eks_addon_vpccni_prefix_delegation_enabled = true
+  eks_addon_most_recent                      = true
 
   eks_worker_ssh_ip_whitelist = ["193.9.230.0/24"]
   eks_worker_ssh_public_key   = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDS85QojLMO8eI5ArwburDpVthEZmW3IVs4/nmv7YnDMgs+ucJmW/etm7MlkRDvWphH4X/6mSGGmylJq7vUIn5rHMG0KTFxg06G2ZJ0zS6ryQ89tDLA9LXhD3q//TzXDFJ4ztjcSyxL1fSW44Lpmt7l7wWHdgrMaP3db2TRYOKY2/0iC22TwQKjTSGku59sFmv3XkLVBehO3fFOXcbLChZ4+maPMmgJDUyYMVSVZNJ2YsjFHHeaYClaN0az0Agcab2HIZMZh0Vv08ro0Se5ZBUjyfoPuDe3WjutkivePajG710k10vSOx6X5CHO3bZvQEBA8klCY58Xp2XrzSChNZhP eks-deploy-hellman"

--- a/test/integration/hooks/custom_hook_01.sh
+++ b/test/integration/hooks/custom_hook_01.sh
@@ -19,13 +19,4 @@ echo "KUBECONFIG=$KUBECONFIG"
 
 cd "$PARENT_DIR/eu-west-1/k8s-qa/services" || return
 
-kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.65.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
-kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.65.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
-kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.65.1/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
-kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.65.1/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
-kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.65.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
-kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.65.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
-kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.65.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
-kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.65.1/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
-kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.65.1/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
-kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.65.1/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+echo "This hook can be used for new purposes"


### PR DESCRIPTION
- Dynamic add-ons
- - Use resolve_conflicts_on_create and resolve_conflicts_on_update instead of deprecated attribute resolve_conflicts in aws_eks_addon. - Set QA to use latest versions of EKS addons
