### PR TITLE
Enabe resource explorer in all available regions

### DIFF
--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -64,6 +64,223 @@ provider "aws" {
   }
 }
 
+####################################################################################################################
+# Following providers are needed to deploy Resource Explorer in all available regions
+####################################################################################################################
+# EU
+provider "aws" {
+  region = "eu-west-1"
+  alias  = "workload_eu-west-1"
+
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "workload_eu-west-2"
+
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+provider "aws" {
+  region = "eu-west-3"
+  alias  = "workload_eu-west-3"
+
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+
+provider "aws" {
+  region = "eu-north-1"
+  alias  = "workload_eu-north-1"
+
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+
+# USA
+provider "aws" {
+  region = "us-east-1"
+  alias  = "workload_us-east-1"
+
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+provider "aws" {
+  region = "us-east-2"
+  alias  = "workload_us-east-2"
+
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+provider "aws" {
+  region = "us-west-1"
+  alias  = "workload_us-west-1"
+
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+provider "aws" {
+  region = "us-west-2"
+  alias  = "workload_us-west-2"
+
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+# Asia Pacific
+provider "aws" {
+  region = "ap-south-1"
+  alias  = "workload_ap-south-1"
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+provider "aws" {
+  region = "ap-northeast-3"
+  alias  = "workload_ap-northeast-3"
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+provider "aws" {
+  region = "ap-northeast-2"
+  alias  = "workload_ap-northeast-2"
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+
+
+provider "aws" {
+  region = "ap-southeast-1"
+  alias  = "workload_ap-southeast-1"
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+provider "aws" {
+  region = "ap-southeast-2"
+  alias  = "workload_ap-southeast-2"
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+
+provider "aws" {
+  region = "ap-northeast-1"
+  alias  = "workload_ap-northeast-1"
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+
+# Canada
+provider "aws" {
+  region = "ca-central-1"
+  alias  = "workload_ca-central-1"
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+# South America
+provider "aws" {
+  region = "sa-east-1"
+  alias  = "workload_sa-east-1"
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+####################################################################################################################
+
+
 terraform {
   # The configuration for this backend will be filled in by Terragrunt
   backend "s3" {
@@ -705,11 +922,13 @@ resource "aws_resourceexplorer2_index" "aggregator" {
   provider = aws.workload
 }
 
-resource "aws_resourceexplorer2_index" "eu_west_1" {
-  type = "LOCAL"
+# # TODO: Remove and re-add using specific provider with naming
+# resource "aws_resourceexplorer2_index" "eu_west_1" {
+#   type = "LOCAL"
 
-  provider = aws.workload_2
-}
+#   provider = aws.workload_2
+# }
+
 
 resource "aws_resourceexplorer2_view" "aggregator_view" {
   name         = "all-resources"
@@ -721,4 +940,98 @@ resource "aws_resourceexplorer2_view" "aggregator_view" {
 
   depends_on = [aws_resourceexplorer2_index.aggregator]
   provider   = aws.workload
+}
+
+
+resource "aws_resourceexplorer2_index" "us-east-1" {
+  type = "LOCAL"
+
+  provider = aws.workload_us-east-1
+}
+
+resource "aws_resourceexplorer2_index" "us-east-2" {
+  type = "LOCAL"
+
+  provider = aws.workload_us-east-2
+}
+resource "aws_resourceexplorer2_index" "us-west-1" {
+  type = "LOCAL"
+
+  provider = aws.workload_us-west-1
+}
+
+resource "aws_resourceexplorer2_index" "us-west-2" {
+  type = "LOCAL"
+
+  provider = aws.workload_us-west-2
+}
+
+resource "aws_resourceexplorer2_index" "ap-south-1" {
+  type = "LOCAL"
+
+  provider = aws.workload_ap-south-1
+}
+
+resource "aws_resourceexplorer2_index" "ap-northeast-3" {
+  type = "LOCAL"
+
+  provider = aws.workload_ap-northeast-3
+}
+
+resource "aws_resourceexplorer2_index" "ap-northeast-2" {
+  type = "LOCAL"
+
+  provider = aws.workload_ap-northeast-2
+}
+
+resource "aws_resourceexplorer2_index" "ap-southeast-1" {
+  type = "LOCAL"
+
+  provider = aws.workload_ap-southeast-1
+}
+resource "aws_resourceexplorer2_index" "ap-southeast-2" {
+  type = "LOCAL"
+
+  provider = aws.workload_ap-southeast-2
+}
+resource "aws_resourceexplorer2_index" "ap-northeast-1" {
+  type = "LOCAL"
+
+  provider = aws.workload_ap-northeast-1
+}
+
+resource "aws_resourceexplorer2_index" "ca-central-1" {
+  type = "LOCAL"
+
+  provider = aws.workload_ca-central-1
+}
+
+resource "aws_resourceexplorer2_index" "eu-west-1" {
+  type = "LOCAL"
+
+  provider = aws.workload_eu-west-1
+}
+resource "aws_resourceexplorer2_index" "eu-west-2" {
+  type = "LOCAL"
+
+  provider = aws.workload_eu-west-2
+}
+
+resource "aws_resourceexplorer2_index" "eu-west-3" {
+  type = "LOCAL"
+
+  provider = aws.workload_eu-west-3
+}
+
+resource "aws_resourceexplorer2_index" "eu-north-1" {
+  type = "LOCAL"
+
+  provider = aws.workload_eu-north-1
+}
+
+
+resource "aws_resourceexplorer2_index" "sa-east-1" {
+  type = "LOCAL"
+
+  provider = aws.workload_sa-east-1
 }

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -922,14 +922,6 @@ resource "aws_resourceexplorer2_index" "aggregator" {
   provider = aws.workload
 }
 
-# # TODO: Remove and re-add using specific provider with naming
-# resource "aws_resourceexplorer2_index" "eu_west_1" {
-#   type = "LOCAL"
-
-#   provider = aws.workload_2
-# }
-
-
 resource "aws_resourceexplorer2_view" "aggregator_view" {
   name         = "all-resources"
   default_view = true

--- a/security/org-account/main.tf
+++ b/security/org-account/main.tf
@@ -24,6 +24,221 @@ provider "aws" {
   alias = "workload_2"
 }
 
+####################################################################################################################
+# Following providers are needed to deploy Resource Explorer in all available regions
+####################################################################################################################
+# EU
+provider "aws" {
+  region = "eu-west-1"
+  alias  = "workload_eu-west-1"
+
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "workload_eu-west-2"
+
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+provider "aws" {
+  region = "eu-west-3"
+  alias  = "workload_eu-west-3"
+
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+
+provider "aws" {
+  region = "eu-north-1"
+  alias  = "workload_eu-north-1"
+
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+
+# USA
+provider "aws" {
+  region = "us-east-1"
+  alias  = "workload_us-east-1"
+
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+provider "aws" {
+  region = "us-east-2"
+  alias  = "workload_us-east-2"
+
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+provider "aws" {
+  region = "us-west-1"
+  alias  = "workload_us-west-1"
+
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+provider "aws" {
+  region = "us-west-2"
+  alias  = "workload_us-west-2"
+
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+# Asia Pacific
+provider "aws" {
+  region = "ap-south-1"
+  alias  = "workload_ap-south-1"
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+provider "aws" {
+  region = "ap-northeast-3"
+  alias  = "workload_ap-northeast-3"
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+provider "aws" {
+  region = "ap-northeast-2"
+  alias  = "workload_ap-northeast-2"
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+
+provider "aws" {
+  region = "ap-southeast-1"
+  alias  = "workload_ap-southeast-1"
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+provider "aws" {
+  region = "ap-southeast-2"
+  alias  = "workload_ap-southeast-2"
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+
+provider "aws" {
+  region = "ap-northeast-1"
+  alias  = "workload_ap-northeast-1"
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+
+# Canada
+provider "aws" {
+  region = "ca-central-1"
+  alias  = "workload_ca-central-1"
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+# South America
+provider "aws" {
+  region = "sa-east-1"
+  alias  = "workload_sa-east-1"
+  # Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+####################################################################################################################
+
 terraform {
   # The configuration for this backend will be filled in by Terragrunt
   backend "s3" {
@@ -92,12 +307,6 @@ resource "aws_resourceexplorer2_index" "aggregator" {
   provider = aws.workload
 }
 
-resource "aws_resourceexplorer2_index" "eu_west_1" {
-  type = "LOCAL"
-
-  provider = aws.workload_2
-}
-
 resource "aws_resourceexplorer2_view" "aggregator_view" {
   name         = "all-resources"
   default_view = true
@@ -108,4 +317,98 @@ resource "aws_resourceexplorer2_view" "aggregator_view" {
 
   depends_on = [aws_resourceexplorer2_index.aggregator]
   provider   = aws.workload
+}
+
+
+resource "aws_resourceexplorer2_index" "us-east-1" {
+  type = "LOCAL"
+
+  provider = aws.workload_us-east-1
+}
+
+resource "aws_resourceexplorer2_index" "us-east-2" {
+  type = "LOCAL"
+
+  provider = aws.workload_us-east-2
+}
+resource "aws_resourceexplorer2_index" "us-west-1" {
+  type = "LOCAL"
+
+  provider = aws.workload_us-west-1
+}
+
+resource "aws_resourceexplorer2_index" "us-west-2" {
+  type = "LOCAL"
+
+  provider = aws.workload_us-west-2
+}
+
+resource "aws_resourceexplorer2_index" "ap-south-1" {
+  type = "LOCAL"
+
+  provider = aws.workload_ap-south-1
+}
+
+resource "aws_resourceexplorer2_index" "ap-northeast-3" {
+  type = "LOCAL"
+
+  provider = aws.workload_ap-northeast-3
+}
+
+resource "aws_resourceexplorer2_index" "ap-northeast-2" {
+  type = "LOCAL"
+
+  provider = aws.workload_ap-northeast-2
+}
+
+resource "aws_resourceexplorer2_index" "ap-southeast-1" {
+  type = "LOCAL"
+
+  provider = aws.workload_ap-southeast-1
+}
+resource "aws_resourceexplorer2_index" "ap-southeast-2" {
+  type = "LOCAL"
+
+  provider = aws.workload_ap-southeast-2
+}
+resource "aws_resourceexplorer2_index" "ap-northeast-1" {
+  type = "LOCAL"
+
+  provider = aws.workload_ap-northeast-1
+}
+
+resource "aws_resourceexplorer2_index" "ca-central-1" {
+  type = "LOCAL"
+
+  provider = aws.workload_ca-central-1
+}
+
+resource "aws_resourceexplorer2_index" "eu-west-1" {
+  type = "LOCAL"
+
+  provider = aws.workload_eu-west-1
+}
+resource "aws_resourceexplorer2_index" "eu-west-2" {
+  type = "LOCAL"
+
+  provider = aws.workload_eu-west-2
+}
+
+resource "aws_resourceexplorer2_index" "eu-west-3" {
+  type = "LOCAL"
+
+  provider = aws.workload_eu-west-3
+}
+
+resource "aws_resourceexplorer2_index" "eu-north-1" {
+  type = "LOCAL"
+
+  provider = aws.workload_eu-north-1
+}
+
+
+resource "aws_resourceexplorer2_index" "sa-east-1" {
+  type = "LOCAL"
+
+  provider = aws.workload_sa-east-1
 }


### PR DESCRIPTION
- Needed aws providers for all regions add.
- AWS providers except for eu-central-1 use region as part of their names
- Affects Capability accounts
- Affects System accounts