### PR TITLE
Deploy Security Bot within hardened accounts.

### DIFF
--- a/_sub/security/security-bot/main.tf
+++ b/_sub/security/security-bot/main.tf
@@ -1,0 +1,254 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_session_context" "current" {
+  arn = data.aws_caller_identity.current.arn
+}
+
+resource "aws_sqs_queue" "queue" {
+  count       = var.deploy ? 1 : 0
+  name_prefix = var.name
+}
+
+data "aws_iam_policy_document" "sqs_policy" {
+  count = var.deploy ? 1 : 0
+
+  statement {
+    sid       = "Admin"
+    effect    = "Allow"
+    actions   = ["sqs:*"]
+    resources = [aws_sqs_queue.queue[0].arn]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+  }
+
+  statement {
+    sid       = "SNSSubscription"
+    effect    = "Allow"
+    actions   = ["sqs:SendMessage"]
+    resources = [aws_sqs_queue.queue[0].arn]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+
+      values = [var.alarm_sns_topic_arn]
+    }
+  }
+}
+
+resource "aws_sqs_queue_policy" "sqs" {
+  count     = var.deploy ? 1 : 0
+  queue_url = aws_sqs_queue.queue[0].id
+
+  policy = data.aws_iam_policy_document.sqs_policy[0].json
+}
+
+resource "aws_sns_topic_subscription" "alarms" {
+  count     = var.deploy ? 1 : 0
+  topic_arn = var.alarm_sns_topic_arn
+  protocol  = "sqs"
+  endpoint  = aws_sqs_queue.queue[0].arn
+}
+
+data "aws_iam_policy_document" "trust" {
+  count = var.deploy ? 1 : 0
+  statement {
+    sid     = "AssumeRole"
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_kms_key" "key" {
+  count                    = var.deploy ? 1 : 0
+  description              = "Security SSM SSE"
+  key_usage                = "ENCRYPT_DECRYPT"
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  is_enabled               = true
+  deletion_window_in_days  = 30
+  enable_key_rotation      = true
+}
+
+resource "aws_ssm_parameter" "slack_token" {
+  count       = var.deploy ? 1 : 0
+  name        = "/managed/security/slack-token"
+  description = "The Slack token for the Security Bot Lambda."
+  type        = "SecureString"
+  key_id      = aws_kms_key.key[0].key_id
+  value       = var.slack_token
+}
+
+resource "aws_kms_alias" "alias" {
+  count         = var.deploy ? 1 : 0
+  name          = "alias/ssm/security"
+  target_key_id = aws_kms_key.key[0].key_id
+}
+
+data "aws_iam_policy_document" "key_policy" {
+  count = var.deploy ? 1 : 0
+
+  statement {
+    sid       = "AllowLambdaDecryption"
+    effect    = "Allow"
+    actions   = ["kms:Decrypt"]
+    resources = ["*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [aws_iam_role.lambda[0].arn]
+    }
+  }
+
+  statement {
+    sid    = "AllowAdminAccess"
+    effect = "Allow"
+    actions = [
+      "kms:Create*",
+      "kms:Decrypt",
+      "kms:Describe*",
+      "kms:Enable*",
+      "kms:Encrypt",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Update*",
+      "kms:Revoke*",
+      "kms:Disable*",
+      "kms:Get*",
+      "kms:Delete*",
+      "kms:TagResource",
+      "kms:UntagResource",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion"
+    ]
+    resources = ["*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_iam_session_context.current.issuer_arn]
+    }
+  }
+}
+
+resource "aws_kms_key_policy" "policy" {
+  count  = var.deploy ? 1 : 0
+  key_id = aws_kms_key.key[0].key_id
+  policy = data.aws_iam_policy_document.key_policy[0].json
+}
+
+data "aws_iam_policy_document" "lambda" {
+  count = var.deploy ? 1 : 0
+
+  statement {
+    sid    = "ConsumeMessages"
+    effect = "Allow"
+    actions = [
+      "sqs:ReceiveMessage",
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes"
+    ]
+
+    resources = [aws_sqs_queue.queue[0].arn]
+  }
+
+  statement {
+    sid    = "CloudTrailLogs"
+    effect = "Allow"
+    actions = [
+      "logs:FilterLogEvents",
+    ]
+
+    resources = [
+      var.cloudwatch_logs_group_arn,
+      "${var.cloudwatch_logs_group_arn}:log-stream:"
+    ]
+  }
+
+  statement {
+    sid    = "ReadSSMParams"
+    effect = "Allow"
+    actions = [
+      "ssm:GetParameter",
+    ]
+
+    resources = [aws_ssm_parameter.slack_token[0].arn]
+  }
+
+  statement {
+    sid    = "DecryptSSMParams"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+    ]
+
+    resources = [aws_kms_key.key[0].arn]
+  }
+}
+
+resource "aws_iam_policy" "lambda_policy" {
+  count       = var.deploy ? 1 : 0
+  name        = "lambda-${aws_sqs_queue.queue[0].name}"
+  description = "Attach this policy to the Security Bot Lambda consuming from the ${aws_sqs_queue.queue[0].name} queue"
+  policy      = data.aws_iam_policy_document.lambda[0].json
+}
+
+resource "aws_iam_role" "lambda" {
+  count       = var.deploy ? 1 : 0
+  name_prefix = var.name
+
+  assume_role_policy = data.aws_iam_policy_document.trust[0].json
+}
+
+resource "aws_iam_role_policy_attachment" "lambda" {
+  count      = var.deploy ? 1 : 0
+  role       = aws_iam_role.lambda[0].name
+  policy_arn = aws_iam_policy.lambda_policy[0].arn
+}
+
+resource "aws_iam_role_policy_attachment" "exec" {
+  count      = var.deploy ? 1 : 0
+  role       = aws_iam_role.lambda[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_lambda_function" "bot" {
+  count         = var.deploy ? 1 : 0
+  filename      = "${path.module}/lambda/security-bot.zip"
+  function_name = aws_iam_role.lambda[0].name
+  role          = aws_iam_role.lambda[0].arn
+  handler       = "bootstrap"
+  runtime       = "go1.x"
+
+  # Source can be found at https://github.com/dfds/security-bot
+  source_code_hash = filebase64sha256("${path.module}/lambda/security-bot.zip")
+
+  environment {
+    variables = {
+      SLACK_TOKEN        = aws_ssm_parameter.slack_token[0].name
+      SLACK_CHANNEL      = var.slack_channel
+      CAPABILITY_ROOT_ID = var.capability_root_id
+    }
+  }
+}
+
+resource "aws_lambda_event_source_mapping" "sqs" {
+  count                              = var.deploy ? 1 : 0
+  event_source_arn                   = aws_sqs_queue.queue[0].arn
+  enabled                            = true
+  function_name                      = aws_lambda_function.bot[0].arn
+  batch_size                         = 10
+  maximum_batching_window_in_seconds = 5
+}
+

--- a/_sub/security/security-bot/outputs.tf
+++ b/_sub/security/security-bot/outputs.tf
@@ -1,0 +1,3 @@
+output "sns_arn" {
+  value = try(aws_sqs_queue.queue[0].arn, "")
+}

--- a/_sub/security/security-bot/vars.tf
+++ b/_sub/security/security-bot/vars.tf
@@ -1,0 +1,32 @@
+variable "deploy" {
+  type    = bool
+  default = true
+}
+
+variable "name" {
+  type = string
+}
+
+variable "slack_token" {
+  type      = string
+  sensitive = true
+}
+
+variable "slack_channel" {
+  type = string
+}
+
+variable "capability_root_id" {
+  type        = string
+  description = "The capability root ID for the AWS account that the bot will be monitoring."
+}
+
+variable "alarm_sns_topic_arn" {
+  type        = string
+  description = "The SNS topic where alerts are published."
+}
+
+variable "cloudwatch_logs_group_arn" {
+  type        = string
+  description = "The CloudWatch log group containing the CloudTrail events triggering the alarms."
+}

--- a/_sub/security/security-bot/versions.tf
+++ b/_sub/security/security-bot/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.3.0, < 2.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.3.0"
+    }
+  }
+}

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -437,7 +437,7 @@ resource "aws_sns_topic" "cis_controls" {
 }
 
 resource "aws_sns_topic_subscription" "cis_controls" {
-  count     = var.harden ? 1 : 0
+  count     = var.harden && var.hardened_monitoring_email != null ? 1 : 0
   topic_arn = aws_sns_topic.cis_controls[count.index].arn
   protocol  = "email"
   endpoint  = var.hardened_monitoring_email
@@ -463,6 +463,21 @@ module "cloudtrail_local" {
   trail_name       = "cloudtrail-local-${var.capability_root_id}"
   create_log_group = var.harden
   create_kms_key   = var.harden
+
+  providers = {
+    aws = aws.workload
+  }
+}
+
+module "security-bot" {
+  source                    = "../../_sub/security/security-bot"
+  deploy                    = var.harden && var.hardened_monitoring_slack_channel != null && var.hardened_monitoring_slack_token != null
+  name                      = "security-bot"
+  slack_token               = var.hardened_monitoring_slack_token
+  slack_channel             = var.hardened_monitoring_slack_channel
+  alarm_sns_topic_arn       = aws_sns_topic.cis_controls[0].arn
+  cloudwatch_logs_group_arn = module.cloudtrail_local.cloudwatch_logs_group_arn
+  capability_root_id        = var.capability_root_id
 
   providers = {
     aws = aws.workload

--- a/security/org-account-context/vars.tf
+++ b/security/org-account-context/vars.tf
@@ -119,6 +119,17 @@ variable "hardened_monitoring_email" {
   default = null
 }
 
+variable "hardened_monitoring_slack_channel" {
+  type    = string
+  default = null
+}
+
+variable "hardened_monitoring_slack_token" {
+  type      = string
+  sensitive = true
+  default   = null
+}
+
 variable "aws_region_sso" {
   type    = string
   default = "eu-west-1"


### PR DESCRIPTION
- Establishes SQS queue to buffer SNS notifications from the CIS control alarms.
- Deploys the [_Security Bot_](https://github.com/dfds/security-bot) Lambda function to consume the SQS queue, query the CloudWatch log group, and post events to a Slack channel.
- Places the Slack token into a secure SSM parameter encrypted with a KMS key which can only be decrypted by the Lambda execution role and the pipeline user managing the key.
- Allows one to set up monitoring channels with an email and/or Slack channel within hardened accounts.