### PR TITLE
Add module for managing legacy accounts

### DIFF
--- a/_sub/security/org-account/main.tf
+++ b/_sub/security/org-account/main.tf
@@ -8,6 +8,10 @@ resource "aws_organizations_account" "org_account" {
   provisioner "local-exec" {
     command = "sleep ${var.sleep_after}"
   }
+
+  lifecycle {
+    ignore_changes = [role_name, iam_user_access_to_billing]
+  }
 }
 
 resource "null_resource" "ubsubscribe_spam" {

--- a/_sub/security/org-account/outputs.tf
+++ b/_sub/security/org-account/outputs.tf
@@ -15,6 +15,6 @@ output "org_role_name" {
 }
 
 output "org_role_arn" {
-  value = "arn:aws:iam::${aws_organizations_account.org_account.id}:role/${aws_organizations_account.org_account.role_name}"
+  value = "arn:aws:iam::${aws_organizations_account.org_account.id}:role/${var.org_role_name}"
 }
 

--- a/security/legacy-account-context/dependencies.tf
+++ b/security/legacy-account-context/dependencies.tf
@@ -1,0 +1,10 @@
+data "aws_iam_policy_document" "assume_role_policy_master_account" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.master_account_id}:user/CerteroEndpointUser"]
+    }
+  }
+}

--- a/security/legacy-account-context/main.tf
+++ b/security/legacy-account-context/main.tf
@@ -249,100 +249,100 @@ module "iam_role_certero" {
 # AWS Resource Explorer
 # --------------------------------------------------
 
-# resource "aws_resourceexplorer2_index" "aggregator" {
-#   type = "AGGREGATOR"
+resource "aws_resourceexplorer2_index" "aggregator" {
+  type = "AGGREGATOR"
 
-#   provider = aws.workload
-# }
+  provider = aws.workload
+}
 
-# resource "aws_resourceexplorer2_view" "aggregator_view" {
-#   name         = "all-resources"
-#   default_view = true
+resource "aws_resourceexplorer2_view" "aggregator_view" {
+  name         = "all-resources"
+  default_view = true
 
-#   included_property {
-#     name = "tags"
-#   }
+  included_property {
+    name = "tags"
+  }
 
-#   depends_on = [aws_resourceexplorer2_index.aggregator]
-#   provider   = aws.workload
-# }
+  depends_on = [aws_resourceexplorer2_index.aggregator]
+  provider   = aws.workload
+}
 
-# resource "aws_resourceexplorer2_index" "us-east-1" {
-#   type     = "LOCAL"
-#   provider = aws.workload_us-east-1
-# }
+resource "aws_resourceexplorer2_index" "us-east-1" {
+  type     = "LOCAL"
+  provider = aws.workload_us-east-1
+}
 
-# resource "aws_resourceexplorer2_index" "us-east-2" {
-#   type     = "LOCAL"
-#   provider = aws.workload_us-east-2
-# }
+resource "aws_resourceexplorer2_index" "us-east-2" {
+  type     = "LOCAL"
+  provider = aws.workload_us-east-2
+}
 
-# resource "aws_resourceexplorer2_index" "us-west-1" {
-#   type     = "LOCAL"
-#   provider = aws.workload_us-west-1
-# }
+resource "aws_resourceexplorer2_index" "us-west-1" {
+  type     = "LOCAL"
+  provider = aws.workload_us-west-1
+}
 
-# resource "aws_resourceexplorer2_index" "us-west-2" {
-#   type     = "LOCAL"
-#   provider = aws.workload_us-west-2
-# }
+resource "aws_resourceexplorer2_index" "us-west-2" {
+  type     = "LOCAL"
+  provider = aws.workload_us-west-2
+}
 
-# resource "aws_resourceexplorer2_index" "ap-south-1" {
-#   type     = "LOCAL"
-#   provider = aws.workload_ap-south-1
-# }
+resource "aws_resourceexplorer2_index" "ap-south-1" {
+  type     = "LOCAL"
+  provider = aws.workload_ap-south-1
+}
 
-# resource "aws_resourceexplorer2_index" "ap-northeast-3" {
-#   type     = "LOCAL"
-#   provider = aws.workload_ap-northeast-3
-# }
+resource "aws_resourceexplorer2_index" "ap-northeast-3" {
+  type     = "LOCAL"
+  provider = aws.workload_ap-northeast-3
+}
 
-# resource "aws_resourceexplorer2_index" "ap-northeast-2" {
-#   type     = "LOCAL"
-#   provider = aws.workload_ap-northeast-2
-# }
+resource "aws_resourceexplorer2_index" "ap-northeast-2" {
+  type     = "LOCAL"
+  provider = aws.workload_ap-northeast-2
+}
 
-# resource "aws_resourceexplorer2_index" "ap-southeast-1" {
-#   type     = "LOCAL"
-#   provider = aws.workload_ap-southeast-1
-# }
+resource "aws_resourceexplorer2_index" "ap-southeast-1" {
+  type     = "LOCAL"
+  provider = aws.workload_ap-southeast-1
+}
 
-# resource "aws_resourceexplorer2_index" "ap-southeast-2" {
-#   type     = "LOCAL"
-#   provider = aws.workload_ap-southeast-2
-# }
+resource "aws_resourceexplorer2_index" "ap-southeast-2" {
+  type     = "LOCAL"
+  provider = aws.workload_ap-southeast-2
+}
 
-# resource "aws_resourceexplorer2_index" "ap-northeast-1" {
-#   type     = "LOCAL"
-#   provider = aws.workload_ap-northeast-1
-# }
+resource "aws_resourceexplorer2_index" "ap-northeast-1" {
+  type     = "LOCAL"
+  provider = aws.workload_ap-northeast-1
+}
 
-# resource "aws_resourceexplorer2_index" "ca-central-1" {
-#   type     = "LOCAL"
-#   provider = aws.workload_ca-central-1
-# }
+resource "aws_resourceexplorer2_index" "ca-central-1" {
+  type     = "LOCAL"
+  provider = aws.workload_ca-central-1
+}
 
-# resource "aws_resourceexplorer2_index" "eu-west-1" {
-#   type     = "LOCAL"
-#   provider = aws.workload_eu-west-1
-# }
+resource "aws_resourceexplorer2_index" "eu-west-1" {
+  type     = "LOCAL"
+  provider = aws.workload_eu-west-1
+}
 
-# resource "aws_resourceexplorer2_index" "eu-west-2" {
-#   type     = "LOCAL"
-#   provider = aws.workload_eu-west-2
-# }
+resource "aws_resourceexplorer2_index" "eu-west-2" {
+  type     = "LOCAL"
+  provider = aws.workload_eu-west-2
+}
 
-# resource "aws_resourceexplorer2_index" "eu-west-3" {
-#   type     = "LOCAL"
-#   provider = aws.workload_eu-west-3
-# }
+resource "aws_resourceexplorer2_index" "eu-west-3" {
+  type     = "LOCAL"
+  provider = aws.workload_eu-west-3
+}
 
-# resource "aws_resourceexplorer2_index" "eu-north-1" {
-#   type     = "LOCAL"
-#   provider = aws.workload_eu-north-1
-# }
+resource "aws_resourceexplorer2_index" "eu-north-1" {
+  type     = "LOCAL"
+  provider = aws.workload_eu-north-1
+}
 
-# resource "aws_resourceexplorer2_index" "sa-east-1" {
-#   type     = "LOCAL"
-#   provider = aws.workload_sa-east-1
-# }
+resource "aws_resourceexplorer2_index" "sa-east-1" {
+  type     = "LOCAL"
+  provider = aws.workload_sa-east-1
+}

--- a/security/legacy-account-context/main.tf
+++ b/security/legacy-account-context/main.tf
@@ -1,0 +1,348 @@
+# --------------------------------------------------
+# Init
+# --------------------------------------------------
+
+terraform {
+  # The configuration for this backend will be filled in by Terragrunt
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  # Assume role in Master account
+  assume_role {
+    role_arn = "arn:aws:iam::${var.master_account_id}:role/${var.prime_role_name}"
+  }
+}
+
+# Need explicit credentials in Master, to be able to assume Organizational Role in Workload account
+provider "aws" {
+  region     = var.aws_region
+  alias      = "workload"
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+
+  # Assume the Organizational role in Workload account
+  assume_role {
+    role_arn = "arn:aws:iam::${var.account_id}:role/${var.org_role_name}"
+  }
+}
+
+
+# --------------------------------------------------
+# Resource Explorer providers in all enabled regions
+# --------------------------------------------------
+
+# EU
+provider "aws" {
+  region     = "eu-west-1"
+  alias      = "workload_eu-west-1"
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+
+provider "aws" {
+  region     = "eu-west-2"
+  alias      = "workload_eu-west-2"
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+
+provider "aws" {
+  region     = "eu-west-3"
+  alias      = "workload_eu-west-3"
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+
+provider "aws" {
+  region     = "eu-north-1"
+  alias      = "workload_eu-north-1"
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+
+# USA
+provider "aws" {
+  region     = "us-east-1"
+  alias      = "workload_us-east-1"
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+
+provider "aws" {
+  region     = "us-east-2"
+  alias      = "workload_us-east-2"
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+
+provider "aws" {
+  region     = "us-west-1"
+  alias      = "workload_us-west-1"
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+
+provider "aws" {
+  region     = "us-west-2"
+  alias      = "workload_us-west-2"
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+# Asia Pacific
+provider "aws" {
+  region     = "ap-south-1"
+  alias      = "workload_ap-south-1"
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+
+provider "aws" {
+  region     = "ap-northeast-3"
+  alias      = "workload_ap-northeast-3"
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+
+provider "aws" {
+  region     = "ap-northeast-2"
+  alias      = "workload_ap-northeast-2"
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+
+
+provider "aws" {
+  region     = "ap-southeast-1"
+  alias      = "workload_ap-southeast-1"
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+
+provider "aws" {
+  region     = "ap-southeast-2"
+  alias      = "workload_ap-southeast-2"
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+
+provider "aws" {
+  region     = "ap-northeast-1"
+  alias      = "workload_ap-northeast-1"
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+
+# Canada
+provider "aws" {
+  region     = "ca-central-1"
+  alias      = "workload_ca-central-1"
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+
+# South America
+provider "aws" {
+  region     = "sa-east-1"
+  alias      = "workload_sa-east-1"
+  access_key = var.access_key_master
+  secret_key = var.secret_key_master
+  assume_role {
+    role_arn = module.org_account.org_role_arn
+  }
+}
+
+# --------------------------------------------------
+# Create account
+# --------------------------------------------------
+
+module "org_account" {
+  source        = "../../_sub/security/org-account"
+  name          = var.name
+  org_role_name = var.org_role_name
+  email         = var.email
+  parent_id     = var.parent_id
+  sleep_after   = 120
+}
+
+module "iam_account_alias" {
+  source        = "../../_sub/security/iam-account-alias"
+  account_alias = module.org_account.name
+
+  providers = {
+    aws = aws.workload
+  }
+}
+
+# --------------------------------------------------
+# Certero
+# --------------------------------------------------
+
+module "iam_policies" {
+  source                            = "../../_sub/security/iam-policies"
+  iam_role_trusted_account_root_arn = ["arn:aws:iam::${var.core_account_id}:root"] # Account ID from variable instead of data.aws_caller_identity - seems to get rate-throttled
+}
+
+module "iam_role_certero" {
+  source               = "../../_sub/security/iam-role"
+  role_name            = "CerteroRole"
+  role_description     = "Used by CerteroRole to make inventory of AWS resources"
+  max_session_duration = 3600
+  assume_role_policy   = data.aws_iam_policy_document.assume_role_policy_master_account.json
+  role_policy_name     = "CerteroEndpoint"
+  role_policy_document = module.iam_policies.certero_endpoint
+
+  providers = {
+    aws = aws.workload
+  }
+}
+
+# --------------------------------------------------
+# AWS Resource Explorer
+# --------------------------------------------------
+
+# resource "aws_resourceexplorer2_index" "aggregator" {
+#   type = "AGGREGATOR"
+
+#   provider = aws.workload
+# }
+
+# resource "aws_resourceexplorer2_view" "aggregator_view" {
+#   name         = "all-resources"
+#   default_view = true
+
+#   included_property {
+#     name = "tags"
+#   }
+
+#   depends_on = [aws_resourceexplorer2_index.aggregator]
+#   provider   = aws.workload
+# }
+
+# resource "aws_resourceexplorer2_index" "us-east-1" {
+#   type     = "LOCAL"
+#   provider = aws.workload_us-east-1
+# }
+
+# resource "aws_resourceexplorer2_index" "us-east-2" {
+#   type     = "LOCAL"
+#   provider = aws.workload_us-east-2
+# }
+
+# resource "aws_resourceexplorer2_index" "us-west-1" {
+#   type     = "LOCAL"
+#   provider = aws.workload_us-west-1
+# }
+
+# resource "aws_resourceexplorer2_index" "us-west-2" {
+#   type     = "LOCAL"
+#   provider = aws.workload_us-west-2
+# }
+
+# resource "aws_resourceexplorer2_index" "ap-south-1" {
+#   type     = "LOCAL"
+#   provider = aws.workload_ap-south-1
+# }
+
+# resource "aws_resourceexplorer2_index" "ap-northeast-3" {
+#   type     = "LOCAL"
+#   provider = aws.workload_ap-northeast-3
+# }
+
+# resource "aws_resourceexplorer2_index" "ap-northeast-2" {
+#   type     = "LOCAL"
+#   provider = aws.workload_ap-northeast-2
+# }
+
+# resource "aws_resourceexplorer2_index" "ap-southeast-1" {
+#   type     = "LOCAL"
+#   provider = aws.workload_ap-southeast-1
+# }
+
+# resource "aws_resourceexplorer2_index" "ap-southeast-2" {
+#   type     = "LOCAL"
+#   provider = aws.workload_ap-southeast-2
+# }
+
+# resource "aws_resourceexplorer2_index" "ap-northeast-1" {
+#   type     = "LOCAL"
+#   provider = aws.workload_ap-northeast-1
+# }
+
+# resource "aws_resourceexplorer2_index" "ca-central-1" {
+#   type     = "LOCAL"
+#   provider = aws.workload_ca-central-1
+# }
+
+# resource "aws_resourceexplorer2_index" "eu-west-1" {
+#   type     = "LOCAL"
+#   provider = aws.workload_eu-west-1
+# }
+
+# resource "aws_resourceexplorer2_index" "eu-west-2" {
+#   type     = "LOCAL"
+#   provider = aws.workload_eu-west-2
+# }
+
+# resource "aws_resourceexplorer2_index" "eu-west-3" {
+#   type     = "LOCAL"
+#   provider = aws.workload_eu-west-3
+# }
+
+# resource "aws_resourceexplorer2_index" "eu-north-1" {
+#   type     = "LOCAL"
+#   provider = aws.workload_eu-north-1
+# }
+
+# resource "aws_resourceexplorer2_index" "sa-east-1" {
+#   type     = "LOCAL"
+#   provider = aws.workload_sa-east-1
+# }

--- a/security/legacy-account-context/outputs.tf
+++ b/security/legacy-account-context/outputs.tf
@@ -1,0 +1,20 @@
+output "email" {
+  value = module.org_account.email
+}
+
+output "id" {
+  value = module.org_account.id
+}
+
+output "name" {
+  value = module.org_account.name
+}
+
+output "org_role_name" {
+  value = module.org_account.org_role_name
+}
+
+output "org_role_arn" {
+  value = module.org_account.org_role_arn
+}
+

--- a/security/legacy-account-context/vars.tf
+++ b/security/legacy-account-context/vars.tf
@@ -1,0 +1,47 @@
+variable "aws_region" {
+  type = string
+}
+
+variable "master_account_id" {
+  type        = string
+  description = "The AWS account ID of the Organizations Master account"
+}
+
+variable "core_account_id" {
+  type        = string
+  description = "The AWS account ID of the Organizations Core account"
+}
+
+variable "access_key_master" {
+  type = string
+}
+
+variable "secret_key_master" {
+  type = string
+}
+
+variable "account_id" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
+variable "org_role_name" {
+  type = string
+}
+
+variable "prime_role_name" {
+  type = string
+}
+
+variable "email" {
+  type = string
+}
+
+variable "parent_id" {
+  type        = string
+  description = "The ID of the parent AWS Organization OU."
+  default     = ""
+}

--- a/security/legacy-account-context/versions.tf
+++ b/security/legacy-account-context/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0, < 2.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.3.0"
+    }
+  }
+}


### PR DESCRIPTION
- Avoid circular dependency and force replace on org-account after import
- Add module for handling legacy accounts
- Enable resource explorer indexes in all enabled regions
