### PR TITLE
Detect and report compliance changes related to access keys.

### DIFF
--- a/_sub/security/security-bot/vars.tf
+++ b/_sub/security/security-bot/vars.tf
@@ -21,12 +21,17 @@ variable "capability_root_id" {
   description = "The capability root ID for the AWS account that the bot will be monitoring."
 }
 
-variable "alarm_sns_topic_arn" {
-  type        = string
-  description = "The SNS topic where alerts are published."
-}
-
 variable "cloudwatch_logs_group_arn" {
   type        = string
   description = "The CloudWatch log group containing the CloudTrail events triggering the alarms."
+}
+
+variable "sns_topic_arn_cis_controls" {
+  type        = string
+  description = "The SNS topic where alerts are published related to the CIS controls."
+}
+
+variable "sns_topic_arn_compliance_changes" {
+  type        = string
+  description = "The SNS topic where changes to AWS Config resource compliance are published."
 }


### PR DESCRIPTION
In hardened accounts, one can recieve notifications when they access keys are older than 90 days or a user/credentials are not used for 45 days or more.

Messages can be sent via email or Slack.