### PR TITLE
Improve messages related to access keys from Security Bot.

### DIFF
--- a/_sub/security/security-bot/main.tf
+++ b/_sub/security/security-bot/main.tf
@@ -223,6 +223,18 @@ data "aws_iam_policy_document" "lambda" {
 
     resources = [aws_kms_key.key[0].arn]
   }
+
+  statement {
+    sid    = "ReadIam"
+    effect = "Allow"
+    actions = [
+      "iam:ListUsers",
+      "iam:ListAccessKeys",
+      "iam:GetAccessKeyLastUsed"
+    ]
+
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_policy" "lambda_policy" {


### PR DESCRIPTION
- Maps user ID to user name.
- Post metadata for relevant access keys as a reply to the main notification thread.