### PR TITLE
Change the Kustomize patch for velero to support the newer Helm chart versions

### DIFF
--- a/_sub/storage/velero-flux/dependencies.tf
+++ b/_sub/storage/velero-flux/dependencies.tf
@@ -85,7 +85,11 @@ spec:
     configuration:
       logLevel: ${var.log_level}
       backupStorageLocation:
+      - name: velero-storage
+        provider: aws
         bucket: ${var.bucket_name}
+        config:
+          region: eu-west-1
     serviceAccount:
       server:
         create: true

--- a/_sub/storage/velero-flux/dependencies.tf
+++ b/_sub/storage/velero-flux/dependencies.tf
@@ -86,7 +86,7 @@ spec:
       logLevel: ${var.log_level}
       backupStorageLocation:
       - name: velero-storage
-        provider: aws
+        provider: velero.io/aws
         bucket: ${var.bucket_name}
         config:
           region: eu-west-1

--- a/_sub/storage/velero-flux/dependencies.tf
+++ b/_sub/storage/velero-flux/dependencies.tf
@@ -85,8 +85,7 @@ spec:
     configuration:
       logLevel: ${var.log_level}
       backupStorageLocation:
-      - name: velero-storage
-        provider: velero.io/aws
+      - provider: velero.io/aws
         bucket: ${var.bucket_name}
         config:
           region: eu-west-1

--- a/_sub/storage/velero-flux/dependencies.tf
+++ b/_sub/storage/velero-flux/dependencies.tf
@@ -85,7 +85,7 @@ spec:
     configuration:
       logLevel: ${var.log_level}
       backupStorageLocation:
-      - provider: velero.io/aws
+      - provider: aws
         bucket: ${var.bucket_name}
         config:
           region: eu-west-1


### PR DESCRIPTION
- Use the new format for the Velero helm chart
- Change provider name
- Use default name for backup storage location
- Change provider name
