### PR TITLE
Add support for latest goldpinger. 

### DIFF
--- a/_sub/compute/helm-goldpinger/main.tf
+++ b/_sub/compute/helm-goldpinger/main.tf
@@ -1,7 +1,7 @@
 resource "helm_release" "goldpinger" {
   name          = "goldpinger"
   chart         = "goldpinger"
-  repository    = "https://charts.helm.sh/stable"
+  repository    = "https://okgolove.github.io/helm-charts/"
   version       = var.chart_version
   namespace     = var.namespace
   recreate_pods = true

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -204,7 +204,7 @@ variable "monitoring_goldpinger_deploy" {
 variable "monitoring_goldpinger_chart_version" {
   type        = string
   description = "Goldpinger helm chart version"
-  default     = null
+  default     = "6.0.1"
 }
 
 variable "monitoring_goldpinger_priority_class" {

--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -156,7 +156,8 @@ inputs = {
   # Goldpinger
   # --------------------------------------------------
 
-  monitoring_goldpinger_deploy = true
+  monitoring_goldpinger_deploy        = true
+  monitoring_goldpinger_chart_version = "6.0.1"
 
   # --------------------------------------------------
   # Crossplane


### PR DESCRIPTION
A new default version needed to be set in compute/services/vars.tf or else deployment would fail on systems where goldpinger has an old version installed from a previous helm repository