### PR TITLE
Ability to specify AWS session names on account contexts.

### DIFF
--- a/security/legacy-account-context/main.tf
+++ b/security/legacy-account-context/main.tf
@@ -13,7 +13,8 @@ provider "aws" {
 
   # Assume role in Master account
   assume_role {
-    role_arn = "arn:aws:iam::${var.master_account_id}:role/${var.prime_role_name}"
+    role_arn     = "arn:aws:iam::${var.master_account_id}:role/${var.prime_role_name}"
+    session_name = var.aws_session_name
   }
 }
 
@@ -26,7 +27,8 @@ provider "aws" {
 
   # Assume the Organizational role in Workload account
   assume_role {
-    role_arn = "arn:aws:iam::${var.account_id}:role/${var.org_role_name}"
+    role_arn     = "arn:aws:iam::${var.account_id}:role/${var.org_role_name}"
+    session_name = var.aws_session_name
   }
 }
 
@@ -42,7 +44,8 @@ provider "aws" {
   access_key = var.access_key_master
   secret_key = var.secret_key_master
   assume_role {
-    role_arn = module.org_account.org_role_arn
+    role_arn     = module.org_account.org_role_arn
+    session_name = var.aws_session_name
   }
 }
 
@@ -52,7 +55,8 @@ provider "aws" {
   access_key = var.access_key_master
   secret_key = var.secret_key_master
   assume_role {
-    role_arn = module.org_account.org_role_arn
+    role_arn     = module.org_account.org_role_arn
+    session_name = var.aws_session_name
   }
 }
 
@@ -62,7 +66,8 @@ provider "aws" {
   access_key = var.access_key_master
   secret_key = var.secret_key_master
   assume_role {
-    role_arn = module.org_account.org_role_arn
+    role_arn     = module.org_account.org_role_arn
+    session_name = var.aws_session_name
   }
 }
 
@@ -72,7 +77,8 @@ provider "aws" {
   access_key = var.access_key_master
   secret_key = var.secret_key_master
   assume_role {
-    role_arn = module.org_account.org_role_arn
+    role_arn     = module.org_account.org_role_arn
+    session_name = var.aws_session_name
   }
 }
 
@@ -83,7 +89,8 @@ provider "aws" {
   access_key = var.access_key_master
   secret_key = var.secret_key_master
   assume_role {
-    role_arn = module.org_account.org_role_arn
+    role_arn     = module.org_account.org_role_arn
+    session_name = var.aws_session_name
   }
 }
 
@@ -93,7 +100,8 @@ provider "aws" {
   access_key = var.access_key_master
   secret_key = var.secret_key_master
   assume_role {
-    role_arn = module.org_account.org_role_arn
+    role_arn     = module.org_account.org_role_arn
+    session_name = var.aws_session_name
   }
 }
 
@@ -103,7 +111,8 @@ provider "aws" {
   access_key = var.access_key_master
   secret_key = var.secret_key_master
   assume_role {
-    role_arn = module.org_account.org_role_arn
+    role_arn     = module.org_account.org_role_arn
+    session_name = var.aws_session_name
   }
 }
 
@@ -113,7 +122,8 @@ provider "aws" {
   access_key = var.access_key_master
   secret_key = var.secret_key_master
   assume_role {
-    role_arn = module.org_account.org_role_arn
+    role_arn     = module.org_account.org_role_arn
+    session_name = var.aws_session_name
   }
 }
 # Asia Pacific
@@ -123,7 +133,8 @@ provider "aws" {
   access_key = var.access_key_master
   secret_key = var.secret_key_master
   assume_role {
-    role_arn = module.org_account.org_role_arn
+    role_arn     = module.org_account.org_role_arn
+    session_name = var.aws_session_name
   }
 }
 
@@ -133,7 +144,8 @@ provider "aws" {
   access_key = var.access_key_master
   secret_key = var.secret_key_master
   assume_role {
-    role_arn = module.org_account.org_role_arn
+    role_arn     = module.org_account.org_role_arn
+    session_name = var.aws_session_name
   }
 }
 
@@ -143,7 +155,8 @@ provider "aws" {
   access_key = var.access_key_master
   secret_key = var.secret_key_master
   assume_role {
-    role_arn = module.org_account.org_role_arn
+    role_arn     = module.org_account.org_role_arn
+    session_name = var.aws_session_name
   }
 }
 
@@ -154,7 +167,8 @@ provider "aws" {
   access_key = var.access_key_master
   secret_key = var.secret_key_master
   assume_role {
-    role_arn = module.org_account.org_role_arn
+    role_arn     = module.org_account.org_role_arn
+    session_name = var.aws_session_name
   }
 }
 
@@ -164,7 +178,8 @@ provider "aws" {
   access_key = var.access_key_master
   secret_key = var.secret_key_master
   assume_role {
-    role_arn = module.org_account.org_role_arn
+    role_arn     = module.org_account.org_role_arn
+    session_name = var.aws_session_name
   }
 }
 
@@ -174,7 +189,8 @@ provider "aws" {
   access_key = var.access_key_master
   secret_key = var.secret_key_master
   assume_role {
-    role_arn = module.org_account.org_role_arn
+    role_arn     = module.org_account.org_role_arn
+    session_name = var.aws_session_name
   }
 }
 
@@ -185,7 +201,8 @@ provider "aws" {
   access_key = var.access_key_master
   secret_key = var.secret_key_master
   assume_role {
-    role_arn = module.org_account.org_role_arn
+    role_arn     = module.org_account.org_role_arn
+    session_name = var.aws_session_name
   }
 }
 
@@ -196,7 +213,8 @@ provider "aws" {
   access_key = var.access_key_master
   secret_key = var.secret_key_master
   assume_role {
-    role_arn = module.org_account.org_role_arn
+    role_arn     = module.org_account.org_role_arn
+    session_name = var.aws_session_name
   }
 }
 

--- a/security/legacy-account-context/vars.tf
+++ b/security/legacy-account-context/vars.tf
@@ -2,6 +2,12 @@ variable "aws_region" {
   type = string
 }
 
+variable "aws_session_name" {
+  type        = string
+  description = "An identifier for the AWS session name. This can be useful in identifiying which pipeline executed the Terraform."
+  default     = null
+}
+
 variable "master_account_id" {
   type        = string
   description = "The AWS account ID of the Organizations Master account"

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -7,7 +7,8 @@ provider "aws" {
 
   # Assume role in Master account
   assume_role {
-    role_arn = "arn:aws:iam::${var.master_account_id}:role/${var.prime_role_name}"
+    role_arn     = "arn:aws:iam::${var.master_account_id}:role/${var.prime_role_name}"
+    session_name = var.aws_session_name
   }
 }
 
@@ -22,7 +23,8 @@ provider "aws" {
 
   # Assume role in Shared account
   assume_role {
-    role_arn = "arn:aws:iam::${var.shared_account_id}:role/${var.prime_role_name}"
+    role_arn     = "arn:aws:iam::${var.shared_account_id}:role/${var.prime_role_name}"
+    session_name = var.aws_session_name
   }
 }
 
@@ -36,7 +38,8 @@ provider "aws" {
 
   # Assume the Organizational role in Workload account
   assume_role {
-    role_arn = module.org_account.org_role_arn
+    role_arn     = module.org_account.org_role_arn
+    session_name = var.aws_session_name
   }
 }
 
@@ -50,7 +53,8 @@ provider "aws" {
 
   # Assume the Organizational role in Workload account
   assume_role {
-    role_arn = module.org_account.org_role_arn
+    role_arn     = module.org_account.org_role_arn
+    session_name = var.aws_session_name
   }
 }
 
@@ -60,7 +64,8 @@ provider "aws" {
 
   # Assume role in Master account
   assume_role {
-    role_arn = "arn:aws:iam::${var.master_account_id}:role/${var.prime_role_name}"
+    role_arn     = "arn:aws:iam::${var.master_account_id}:role/${var.prime_role_name}"
+    session_name = var.aws_session_name
   }
 }
 
@@ -78,7 +83,8 @@ provider "aws" {
 
   # Assume the Organizational role in Workload account
   assume_role {
-    role_arn = module.org_account.org_role_arn
+    role_arn     = module.org_account.org_role_arn
+    session_name = var.aws_session_name
   }
 }
 provider "aws" {
@@ -91,7 +97,8 @@ provider "aws" {
 
   # Assume the Organizational role in Workload account
   assume_role {
-    role_arn = module.org_account.org_role_arn
+    role_arn     = module.org_account.org_role_arn
+    session_name = var.aws_session_name
   }
 }
 provider "aws" {
@@ -104,7 +111,8 @@ provider "aws" {
 
   # Assume the Organizational role in Workload account
   assume_role {
-    role_arn = module.org_account.org_role_arn
+    role_arn     = module.org_account.org_role_arn
+    session_name = var.aws_session_name
   }
 }
 
@@ -119,7 +127,8 @@ provider "aws" {
 
   # Assume the Organizational role in Workload account
   assume_role {
-    role_arn = module.org_account.org_role_arn
+    role_arn     = module.org_account.org_role_arn
+    session_name = var.aws_session_name
   }
 }
 provider "aws" {
@@ -132,7 +141,8 @@ provider "aws" {
 
   # Assume the Organizational role in Workload account
   assume_role {
-    role_arn = module.org_account.org_role_arn
+    role_arn     = module.org_account.org_role_arn
+    session_name = var.aws_session_name
   }
 }
 provider "aws" {
@@ -145,7 +155,8 @@ provider "aws" {
 
   # Assume the Organizational role in Workload account
   assume_role {
-    role_arn = module.org_account.org_role_arn
+    role_arn     = module.org_account.org_role_arn
+    session_name = var.aws_session_name
   }
 }
 provider "aws" {
@@ -158,7 +169,8 @@ provider "aws" {
 
   # Assume the Organizational role in Workload account
   assume_role {
-    role_arn = module.org_account.org_role_arn
+    role_arn     = module.org_account.org_role_arn
+    session_name = var.aws_session_name
   }
 }
 
@@ -988,7 +1000,7 @@ resource "aws_resourceexplorer2_index" "eu-west-1" {
 # --------------------------------------------------
 
 module "github_oidc_provider" {
-  count  = length(var.repositories) > 0 && length(var.oidc_role_access) > 0 ? 1 : 0
+  count = length(var.repositories) > 0 && length(var.oidc_role_access) > 0 ? 1 : 0
   providers = {
     aws = aws.workload
   }

--- a/security/org-account-context/vars.tf
+++ b/security/org-account-context/vars.tf
@@ -4,6 +4,12 @@ variable "aws_region" {
   type = string
 }
 
+variable "aws_session_name" {
+  type        = string
+  description = "An identifier for the AWS session name. This can be useful in identifiying which pipeline executed the Terraform."
+  default     = null
+}
+
 variable "master_account_id" {
   type        = string
   description = "The AWS account ID of the Organizations Master account"


### PR DESCRIPTION
This should help other accounts identify which pipeline performed the actions on their account when reviewing CloudTrail events.