### PR TITLE
feat: add resourceexplorer-read role to org-account-context

### DIFF
--- a/_sub/monitoring/aws-resource-explorer-metrics/main.tf
+++ b/_sub/monitoring/aws-resource-explorer-metrics/main.tf
@@ -1,0 +1,41 @@
+resource "aws_iam_role" "resourceexplorer_read" {
+  name               = "resourceexplorer-read"
+  assume_role_policy = data.aws_iam_policy_document.resourceexplorer_read_assume.json
+}
+
+data "aws_iam_policy_document" "resourceexplorer_read_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [var.allowed_assume_arn]
+    }
+  }
+}
+
+resource "aws_iam_policy" "resourceexplorer_read" {
+  name        = "resource-explorer-read"
+  description = "Policy used for reading resource explorer info"
+  policy      = data.aws_iam_policy_document.resourceexplorer_read.json
+}
+
+data "aws_iam_policy_document" "resourceexplorer_read" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "resource-explorer-2:List*",
+      "resource-explorer-2:Get*",
+      "resource-explorer-2:Search",
+      "resource-explorer-2:BatchGetView",
+      "ec2:DescribeRegions",
+      "ram:ListResources"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "resourceexplorer_read" {
+  role       = aws_iam_role.resourceexplorer_read.name
+  policy_arn = aws_iam_policy.resourceexplorer_read.arn
+}

--- a/_sub/monitoring/aws-resource-explorer-metrics/vars.tf
+++ b/_sub/monitoring/aws-resource-explorer-metrics/vars.tf
@@ -1,0 +1,3 @@
+variable "allowed_assume_arn" {
+  description = "The ARN allowed to assume this role"
+}

--- a/_sub/monitoring/aws-resource-explorer-metrics/versions.tf
+++ b/_sub/monitoring/aws-resource-explorer-metrics/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.3.0, < 2.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.6.0"
+    }
+  }
+}

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -1061,6 +1061,16 @@ module "kafka_produce_account_created" {
 # AWS Resource Explorer Feature
 # --------------------------------------------------
 
+module "aws_resource_explorer-metrics" {
+  source = "../../_sub/monitoring/aws-resource-explorer-metrics"
+
+  allowed_assume_arn = "arn:aws:iam::${var.master_account_id}:role/aws-resource-exporter"
+
+  providers = {
+    aws = aws.workload
+  }
+}
+
 resource "aws_resourceexplorer2_index" "aggregator" {
   type = "AGGREGATOR"
 


### PR DESCRIPTION
This PR adds a read role to access AWS resource-explorer-2 into org-account-context that can be assumed by a role in the master account