### PR TITLE
Turn off optional validation. This field is deprecated and removed in latest major version

### DIFF
--- a/_sub/compute/k8s-fluxcd/dependencies.tf
+++ b/_sub/compute/k8s-fluxcd/dependencies.tf
@@ -70,6 +70,5 @@ spec:
     name: platform-apps-git
   path: ./sources
   prune: true
-  validation: client
   YAML
 }


### PR DESCRIPTION
This is related to https://github.com/dfds/cloudplatform/issues/1781 which is about preparing for (and performing) upgrade of Flux CD and the Flux CD Terraform provider.