### PR TITLE
Deploy Security Bot from S3 with versioning.

### DIFF
--- a/_sub/security/security-bot/main.tf
+++ b/_sub/security/security-bot/main.tf
@@ -294,17 +294,16 @@ resource "aws_iam_role_policy_attachment" "exec" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
+# Source can be found at https://github.com/dfds/security-bot
 resource "aws_lambda_function" "bot" {
   count         = var.deploy ? 1 : 0
-  filename      = "${path.module}/lambda/security-bot.zip"
+  s3_bucket     = var.lambda_s3_bucket
+  s3_key        = "security-bot/security-bot-${var.lambda_version}.zip"
   function_name = aws_iam_role.lambda[0].name
   role          = aws_iam_role.lambda[0].arn
   handler       = "bootstrap"
   runtime       = "go1.x"
   timeout       = 10
-
-  # Source can be found at https://github.com/dfds/security-bot
-  source_code_hash = filebase64sha256("${path.module}/lambda/security-bot.zip")
 
   environment {
     variables = {

--- a/_sub/security/security-bot/vars.tf
+++ b/_sub/security/security-bot/vars.tf
@@ -7,6 +7,15 @@ variable "name" {
   type = string
 }
 
+variable "lambda_version" {
+  type = string
+}
+
+variable "lambda_s3_bucket" {
+  type        = string
+  description = "The S3 bucket where the Lambda package is stored."
+}
+
 variable "slack_token" {
   type      = string
   sensitive = true

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -590,6 +590,8 @@ module "security-bot" {
   source                            = "../../_sub/security/security-bot"
   deploy                            = var.harden && var.hardened_monitoring_slack_channel != null && var.hardened_monitoring_slack_token != null
   name                              = "security-bot"
+  lambda_version                    = var.security_bot_lambda_version
+  lambda_s3_bucket                  = var.security_bot_lambda_s3_bucket
   slack_token                       = var.hardened_monitoring_slack_token
   slack_channel                     = var.hardened_monitoring_slack_channel
   capability_root_id                = var.capability_root_id

--- a/security/org-account-context/vars.tf
+++ b/security/org-account-context/vars.tf
@@ -120,6 +120,15 @@ variable "harden" {
   default = false
 }
 
+variable "security_bot_lambda_version" {
+  type = string
+}
+
+variable "security_bot_lambda_s3_bucket" {
+  type        = string
+  description = "The S3 bucket where the Security Bot Lambda package is stored."
+}
+
 variable "hardened_monitoring_email" {
   type    = string
   default = null


### PR DESCRIPTION
Major release because we need to specify these variables in the pipelines:

```
variable "security_bot_lambda_version" {
  type = string
}

variable "security_bot_lambda_s3_bucket" {
  type        = string
  description = "The S3 bucket where the Security Bot Lambda package is stored."
}
```