### PR TITLE
Increase Security Bot timeout

### DIFF
--- a/_sub/security/security-bot/main.tf
+++ b/_sub/security/security-bot/main.tf
@@ -303,7 +303,7 @@ resource "aws_lambda_function" "bot" {
   role          = aws_iam_role.lambda[0].arn
   handler       = "bootstrap"
   runtime       = "go1.x"
-  timeout       = 10
+  timeout       = 300
 
   environment {
     variables = {


### PR DESCRIPTION
It now handles Slack rate limiting within the function by sleeping.
I am sure this can be done better, but this is good enough for now.