### PR TITLE
Stop hardening the default security groups.

### DIFF
--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -375,6 +375,7 @@ resource "aws_cloudwatch_event_rule" "compliance_changes" {
         { "prefix" : "securityhub-cmk-backing-key-rotation-enabled" },
         { "prefix" : "securityhub-rds-storage-encrypted" },
         { "prefix" : "securityhub-s3-bucket-server-side-encryption-enabled" },
+        { "prefix" : "securityhub-vpc-default-security-group-closed" },
       ]
     }
   })

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -687,22 +687,6 @@ module "default_vpc_flow_log_2" {
 }
 
 # --------------------------------------------------
-# Default security groups
-# --------------------------------------------------
-
-resource "aws_default_security_group" "default" {
-  count    = var.harden ? 1 : 0
-  vpc_id   = aws_default_vpc.default[count.index].id
-  provider = aws.workload
-}
-
-resource "aws_default_security_group" "default_2" {
-  count    = var.harden ? 1 : 0
-  vpc_id   = aws_default_vpc.default_2[count.index].id
-  provider = aws.workload_2
-}
-
-# --------------------------------------------------
 # EBS encryption by default
 # --------------------------------------------------
 


### PR DESCRIPTION
Meeting this security control should be the responsibility of the individual teams.

This also adds compliance changes to this rule to the EventBridge rule which feeds into Security Bot so that it can be monitored through that.