### PR TITLE
Set AWS account name in Security Bot instance.

### DIFF
--- a/_sub/security/hardened-account/main.tf
+++ b/_sub/security/hardened-account/main.tf
@@ -284,6 +284,7 @@ module "security-bot" {
   source                            = "../../../_sub/security/security-bot"
   deploy                            = var.harden && var.monitoring_slack_channel != null && var.monitoring_slack_token != null
   name                              = "security-bot"
+  account_name                      = var.account_name
   lambda_version                    = var.security_bot_lambda_version
   lambda_s3_bucket                  = var.security_bot_lambda_s3_bucket
   slack_token                       = var.monitoring_slack_token

--- a/_sub/security/security-bot/main.tf
+++ b/_sub/security/security-bot/main.tf
@@ -308,6 +308,7 @@ resource "aws_lambda_function" "bot" {
 
   environment {
     variables = {
+      AWS_ACCOUNT_NAME                  = var.account_name
       SLACK_TOKEN                       = aws_ssm_parameter.slack_token[0].name
       SLACK_CHANNEL                     = var.slack_channel
       CLOUD_WATCH_LOGS_GROUP_NAME       = var.cloudwatch_logs_group_name

--- a/_sub/security/security-bot/vars.tf
+++ b/_sub/security/security-bot/vars.tf
@@ -7,6 +7,10 @@ variable "name" {
   type = string
 }
 
+variable "account_name" {
+  type = string
+}
+
 variable "lambda_version" {
   type = string
 }


### PR DESCRIPTION
Utilized in version 2.0.0 to identify the account.