### PR TITLE
fix: temporarily revert to legacy grafana alerts

### DIFF
--- a/_sub/compute/helm-kube-prometheus-stack/values/grafana-notifiers.yaml
+++ b/_sub/compute/helm-kube-prometheus-stack/values/grafana-notifiers.yaml
@@ -17,3 +17,8 @@ grafana:
             uploadImage: true
             url: ${grafana_slack_webhook}
             username: alertbot
+  grafana.ini:
+     unified_alerting:
+       enabled: false
+     alerting:
+       enabled: true

--- a/_sub/compute/helm-kube-prometheus-stack/values/grafana-notifiers.yaml
+++ b/_sub/compute/helm-kube-prometheus-stack/values/grafana-notifiers.yaml
@@ -18,7 +18,7 @@ grafana:
             url: ${grafana_slack_webhook}
             username: alertbot
   grafana.ini:
-     unified_alerting:
-       enabled: false
-     alerting:
-       enabled: true
+    unified_alerting:
+      enabled: false
+    alerting:
+      enabled: true

--- a/_sub/compute/helm-kube-prometheus-stack/values/grafana-notifiers.yaml
+++ b/_sub/compute/helm-kube-prometheus-stack/values/grafana-notifiers.yaml
@@ -18,6 +18,7 @@ grafana:
             url: ${grafana_slack_webhook}
             username: alertbot
   grafana.ini:
+    force_migration: true
     unified_alerting:
       enabled: false
     alerting:


### PR DESCRIPTION
This PR will temporarily revert to legacy Grafana alerts

It will allow us to re-import our alerts in a format we can then revert this change again to automatically upgrade them so that they are present in the new format, and then we can export them and put into source control.