### PR TITLE
fix: re-upgrade to grafana unified alerting

### DIFF
--- a/_sub/compute/helm-kube-prometheus-stack/values/grafana-notifiers.yaml
+++ b/_sub/compute/helm-kube-prometheus-stack/values/grafana-notifiers.yaml
@@ -17,9 +17,3 @@ grafana:
             uploadImage: true
             url: ${grafana_slack_webhook}
             username: alertbot
-  grafana.ini:
-    force_migration: true
-    unified_alerting:
-      enabled: false
-    alerting:
-      enabled: true


### PR DESCRIPTION
This PR will re-upgrade Grafana to the new unified alerting again so that we can export the Alerting yaml once complete