### PR TITLE
Disable serve_from_sub_path by default in Grafana

### DIFF
--- a/_sub/compute/helm-kube-prometheus-stack/main.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/main.tf
@@ -60,6 +60,7 @@ resource "helm_release" "kube_prometheus_stack" {
       affinity                    = var.affinity,
       grafana_slack_webhook       = var.slack_webhook,
       grafana_notifier_name       = var.grafana_notifier_name
+      grafana_serve_from_sub_path = var.grafana_serve_from_sub_path
     }),
 
     templatefile("${path.module}/values/prometheus.yaml", {

--- a/_sub/compute/helm-kube-prometheus-stack/values/grafana.yaml
+++ b/_sub/compute/helm-kube-prometheus-stack/values/grafana.yaml
@@ -50,7 +50,7 @@ grafana:
     server:
       domain: ${grafana_host}
       root_url: ${grafana_root_url}
-      serve_from_sub_path: true
+      serve_from_sub_path: ${grafana_serve_from_sub_path}
   ingress:
     enabled: false
     hosts:

--- a/_sub/compute/helm-kube-prometheus-stack/vars.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/vars.tf
@@ -190,3 +190,9 @@ variable "grafana_azure_tenant_id" {
   default     = ""
   description = "Azure Tenant ID"
 }
+
+variable "grafana_serve_from_sub_path" {
+  type        = bool
+  default     = false
+  description = "Serve Grafana from subpath specified in root_url setting. By default it is set to false for compatibility reasons"
+}

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -370,6 +370,7 @@ module "monitoring_kube_prometheus_stack" {
   grafana_storage_enabled     = var.monitoring_kube_prometheus_stack_grafana_storage_enabled
   grafana_storage_class       = var.monitoring_kube_prometheus_stack_grafana_storageclass
   grafana_storage_size        = var.monitoring_kube_prometheus_stack_grafana_storage_size
+  grafana_serve_from_sub_path = var.monitoring_kube_prometheus_stack_grafana_serve_from_sub_path
   grafana_azure_tenant_id     = var.monitoring_kube_prometheus_stack_azure_tenant_id != "" ? var.monitoring_kube_prometheus_stack_azure_tenant_id : var.atlantis_arm_tenant_id
   slack_webhook               = var.monitoring_kube_prometheus_stack_slack_webhook
   prometheus_storageclass     = var.monitoring_kube_prometheus_stack_prometheus_storageclass

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -272,6 +272,12 @@ variable "monitoring_kube_prometheus_stack_grafana_storage_size" {
   default     = ""
 }
 
+variable "monitoring_kube_prometheus_stack_grafana_serve_from_sub_path" {
+  type        = bool
+  default     = false
+  description = "Serve Grafana from subpath specified in root_url setting. By default it is set to false for compatibility reasons"
+}
+
 variable "monitoring_kube_prometheus_stack_azure_tenant_id" {
   type        = string
   default     = ""

--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -125,7 +125,7 @@ inputs = {
   # --------------------------------------------------
 
   monitoring_kube_prometheus_stack_deploy                            = true
-  monitoring_kube_prometheus_stack_chart_version                     = "47.0.0"
+  monitoring_kube_prometheus_stack_chart_version                     = "48.3.1"
   monitoring_kube_prometheus_stack_target_namespaces                 = "kube-system|monitoring"
   monitoring_kube_prometheus_stack_prometheus_storage_size           = "5Gi"
   monitoring_kube_prometheus_stack_prometheus_storageclass           = "gp2"


### PR DESCRIPTION
This feature toggle was added to be able to support Grafana 10 that comes with kube-prometheus-stack 48.0.0. 

Hence QA is also updated wit use kube-prometheus-stack 48.3.1 in preparation to upgrade production to the latest and greatest.