### PR TITLE
Added norelease label automation and refactored renovate configurations

### DIFF
--- a/.github/pr-labels.yml
+++ b/.github/pr-labels.yml
@@ -1,0 +1,3 @@
+norelease:
+- all: ["!**/*.tf"]
+- all: ["test/**"]

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,63 @@
+name: "Pull Request Labeler"
+
+on:
+  pull_request_target:
+    types: ["opened"]
+    branches: ["master", "main"]
+
+jobs:
+  labeler:
+    if: github.event.pull_request.user.login == 'devex-sa'
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Apply labels
+        id: label-the-PR
+        uses: actions/labeler@v4
+        with:
+          configuration-path: ".github/pr-labels.yml"
+      
+      # Tried using a matrix for this but that floaded the PR checks
+      - name: Remove patch release
+        if: |
+          contains(steps.label-the-PR.outputs.all-labels, 'norelease') &&
+          contains(steps.label-the-PR.outputs.all-labels, 'release:patch')
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: 'release:patch'
+            })
+      - name: Remove minor release
+        if: |
+          contains(steps.label-the-PR.outputs.all-labels, 'norelease') &&
+          contains(steps.label-the-PR.outputs.all-labels, 'release:minor')
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: 'release:minor'
+            })
+      - name: Remove major release
+        if: |
+          contains(steps.label-the-PR.outputs.all-labels, 'norelease') &&
+          contains(steps.label-the-PR.outputs.all-labels, 'release:major')
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: 'release:major'
+            })

--- a/renovate.json
+++ b/renovate.json
@@ -23,30 +23,44 @@
                 "pin",
                 "digest",
                 "patch",
-                "lockFileMaintenance"
+                "lockFileMaintenance",
+                "minor",
+                "major"
             ],
-            "stabilityDays": 1,
-            "automerge": true,
-            "matchCurrentVersion": "!/^0/",
-            "ignoreTests": true,
+            "automerge": false,
+            "ignoreTests": false,
             "dependencyDashboard": true,
             "dependencyDashboardApproval": false
+        },
+        {
+            "matchUpdateTypes": [
+                "pin",
+                "digest",
+                "patch",
+                "lockFileMaintenance",
+                "minor"
+            ],
+            "matchCurrentVersion": "!/^0/"
+        },
+        {
+            "matchUpdateTypes": [
+                "pin",
+                "digest",
+                "patch",
+                "lockFileMaintenance"
+            ],
+            "addLabels": ["release:patch"],
+            "stabilityDays": 1
         },
         {
             "matchUpdateTypes": ["minor"],
-            "stabilityDays": 7,
-            "automerge": true,
-            "matchCurrentVersion": "!/^0/",
-            "ignoreTests": true,
-            "dependencyDashboard": true,
-            "dependencyDashboardApproval": false
+            "addLabels": ["release:minor"],
+            "stabilityDays": 7
         },
         {
             "matchUpdateTypes": ["major"],
-            "stabilityDays": 14,
-            "automerge": false,
-            "dependencyDashboard": true,
-            "dependencyDashboardApproval": false
+            "addLabels": ["release:major"],
+            "stabilityDays": 14
         }
     ],
     "azure-pipelines": {

--- a/renovate.json
+++ b/renovate.json
@@ -27,7 +27,6 @@
                 "minor",
                 "major"
             ],
-            "automerge": false,
             "ignoreTests": false,
             "dependencyDashboard": true,
             "dependencyDashboardApproval": false
@@ -50,17 +49,20 @@
                 "lockFileMaintenance"
             ],
             "addLabels": ["release:patch"],
-            "stabilityDays": 1
+            "stabilityDays": 1,
+            "automerge": true
         },
         {
             "matchUpdateTypes": ["minor"],
             "addLabels": ["release:minor"],
-            "stabilityDays": 7
+            "stabilityDays": 7,
+            "automerge": false
         },
         {
             "matchUpdateTypes": ["major"],
             "addLabels": ["release:major"],
-            "stabilityDays": 14
+            "stabilityDays": 14,
+            "automerge": false
         }
     ],
     "azure-pipelines": {


### PR DESCRIPTION
Renovatebot do not have sufficient AND/OR operators when it comes to matching file paths. So a different GH action was required. When we apply our own custom labels, Renovatebot cannot automerge unfortunately.

[Ops ticket](https://github.com/dfds/cloudplatform/issues/1865)