### PR TITLE
Fixing terraform object to json issue.

### DIFF
--- a/security/org-policies/main.tf
+++ b/security/org-policies/main.tf
@@ -6,7 +6,7 @@ module "org_policy_preventive_policy" {
   source         = "../../_sub/security/org-service-control-policy"
   name           = "PreventivePolicy"
   description    = "Enables best practices for keeping accounts secure and limits when a breach occurs"
-  policy         = data.aws_iam_policy_document.preventive.json
+  policy         = jsonencode(jsondecode(data.aws_iam_policy_document.preventive.json))
   attach_targets = var.preventive_policy_attach_targets
 }
 
@@ -14,7 +14,7 @@ module "org_policy_integrity_policy" {
   source         = "../../_sub/security/org-service-control-policy"
   name           = "IntegrityPolicy"
   description    = "Enables us to have better confidence in the information, logs and auditing provided by AWS"
-  policy         = data.aws_iam_policy_document.integrity.json
+  policy         = jsonencode(jsondecode(data.aws_iam_policy_document.integrity.json))
   attach_targets = var.integrity_policy_attach_targets
 }
 
@@ -22,7 +22,7 @@ module "org_policy_restrictive_policy" {
   source         = "../../_sub/security/org-service-control-policy"
   name           = "RestrictivePolicy"
   description    = "Used to stop bad practices in the teams, either when there is an alternative or it has been judged to pose a risk"
-  policy         = data.aws_iam_policy_document.restrictive.json
+  policy         = jsonencode(jsondecode(data.aws_iam_policy_document.restrictive.json))
   attach_targets = var.restrictive_policy_attach_targets
 }
 
@@ -30,6 +30,6 @@ module "org_policy_reservation_policy" {
   source         = "../../_sub/security/org-service-control-policy"
   name           = "ReservationPolicy"
   description    = "Enables us to limit teams from committing us to long term reservations"
-  policy         = data.aws_iam_policy_document.reservation.json
+  policy         = jsonencode(jsondecode(data.aws_iam_policy_document.reservation.json))
   attach_targets = var.reservation_policy_attach_targets
 }


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
Terraform does not remove empty spaces when transfering to JSON, resulting in some policies to be bigger than their limit. This fixes that issue.
## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)

## Checklist before approving the PR
- [x] Run `atlantis plan`
- [x] Terraform Plan looks good

## Is the change just for staging or also for production?
- [x] Apply a release tag `release:(major|minor|patch)` or `norelease` if there is no changes to the Terraform code
