### PR TITLE
Avoid printing AWS credentials. Also some formatting of bash script apply_blaster_configmap.sh

### DIFF
--- a/_sub/compute/eks-heptio/apply_blaster_configmap.sh
+++ b/_sub/compute/eks-heptio/apply_blaster_configmap.sh
@@ -1,18 +1,16 @@
 #!/bin/bash
 
 # Exit if any of the intermediate steps fail
-set -ex
+set -e
 
 # Prints commands if debug mode is enabled
 # [ "$DEBUG" == 'true' ] && set -x
 
-
 # Ensure at least two arguments were passed
 if [ -z "$2" ]; then
-    echo "Need at least two arguments"
-    exit
+	echo "Need at least two arguments"
+	exit
 fi
-
 
 # Define varibales
 APPLY_S3_CONFIGMAP=0
@@ -23,67 +21,58 @@ CONFIGMAP_KEY=$4
 CONFIGMAP_PATH_S3=s3://${CONFIGMAP_BUCKET}/${CONFIGMAP_KEY}
 DEFAULT_CONFIGMAP_PATH=$5
 
-
 # Use function to delay expansion of variable containing assumed creds
-function SplitAssumedCreds()
-{
-    AWS_ASSUMED_ACCESS_KEY_ID=${AWS_ASSUMED_CREDS[0]}
-    AWS_ASSUMED_SECRET_ACCESS_KEY=${AWS_ASSUMED_CREDS[1]}
-    AWS_ASSUMED_SESSION_TOKEN=${AWS_ASSUMED_CREDS[2]}
-    echo "Assumed access key ID:     $AWS_ASSUMED_ACCESS_KEY_ID"
-    echo "Assumed secret access key: ${AWS_ASSUMED_SECRET_ACCESS_KEY:0:5}***${AWS_ASSUMED_SECRET_ACCESS_KEY: -5}"
-    echo "Assumed session token:     $AWS_ASSUMED_SESSION_TOKEN"
+function SplitAssumedCreds() {
+	AWS_ASSUMED_ACCESS_KEY_ID=${AWS_ASSUMED_CREDS[0]}
+	AWS_ASSUMED_SECRET_ACCESS_KEY=${AWS_ASSUMED_CREDS[1]}
+	AWS_ASSUMED_SESSION_TOKEN=${AWS_ASSUMED_CREDS[2]}
 }
-
 
 # Generate AWS CLI config files, if
 if [ -n "$4" ]; then
-    AWS_ASSUME_ARN=$6
-    AWS_ASSUMED_CREDS=($(aws --region "$REGION" sts assume-role \
-        --role-arn "$AWS_ASSUME_ARN" \
-        --role-session-name "ApplyBlasterConfigmap" \
-        --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
-        --output text))
-    SplitAssumedCreds
+	AWS_ASSUME_ARN=$6
+	AWS_ASSUMED_CREDS=($(aws --region "$REGION" sts assume-role \
+		--role-arn "$AWS_ASSUME_ARN" \
+		--role-session-name "ApplyBlasterConfigmap" \
+		--query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
+		--output text))
+	SplitAssumedCreds
 fi
-
 
 # Determine if configmap file exists in S3
 if [ -n "$AWS_ASSUMED_CREDS" ]; then
-    AWS_ACCESS_KEY_ID=${AWS_ASSUMED_ACCESS_KEY_ID} \
-    AWS_SECRET_ACCESS_KEY=${AWS_ASSUMED_SECRET_ACCESS_KEY} \
-    AWS_SESSION_TOKEN=${AWS_ASSUMED_SESSION_TOKEN} \
-    aws --region "$REGION" s3 ls "$CONFIGMAP_PATH_S3" >/dev/null && APPLY_S3_CONFIGMAP=1
+	AWS_ACCESS_KEY_ID=${AWS_ASSUMED_ACCESS_KEY_ID} \
+		AWS_SECRET_ACCESS_KEY=${AWS_ASSUMED_SECRET_ACCESS_KEY} \
+		AWS_SESSION_TOKEN=${AWS_ASSUMED_SESSION_TOKEN} \
+		aws --region "$REGION" s3 ls "$CONFIGMAP_PATH_S3" >/dev/null && APPLY_S3_CONFIGMAP=1
 else
-    aws --region "$REGION" s3 ls "$CONFIGMAP_PATH_S3" >/dev/null && APPLY_S3_CONFIGMAP=1
+	aws --region "$REGION" s3 ls "$CONFIGMAP_PATH_S3" >/dev/null && APPLY_S3_CONFIGMAP=1
 fi
-
 
 # Output current configmap
 # echo "Current configmap:"
 # kubectl --kubeconfig $KUBE_CONFIG_PATH -n kube-system get configmap aws-auth -o yaml
 
-
 # Apply configmap
 if [ $APPLY_S3_CONFIGMAP -eq 1 ]; then
 
-    echo "Applying configmap from ${CONFIGMAP_PATH_S3}:"
+	echo "Applying configmap from ${CONFIGMAP_PATH_S3}:"
 
-    if [ -n "$AWS_ASSUMED_CREDS" ]; then
-        AWS_ACCESS_KEY_ID=${AWS_ASSUMED_ACCESS_KEY_ID} \
-        AWS_SECRET_ACCESS_KEY=${AWS_ASSUMED_SECRET_ACCESS_KEY} \
-        AWS_SESSION_TOKEN=${AWS_ASSUMED_SESSION_TOKEN} \
-        aws --region "$REGION" s3 cp "$CONFIGMAP_PATH_S3" "/tmp/${CONFIGMAP_KEY}"
-    else
-        aws --region "$REGION" s3 cp "$CONFIGMAP_PATH_S3" "/tmp/${CONFIGMAP_KEY}"
-    fi
+	if [ -n "$AWS_ASSUMED_CREDS" ]; then
+		AWS_ACCESS_KEY_ID=${AWS_ASSUMED_ACCESS_KEY_ID} \
+			AWS_SECRET_ACCESS_KEY=${AWS_ASSUMED_SECRET_ACCESS_KEY} \
+			AWS_SESSION_TOKEN=${AWS_ASSUMED_SESSION_TOKEN} \
+			aws --region "$REGION" s3 cp "$CONFIGMAP_PATH_S3" "/tmp/${CONFIGMAP_KEY}"
+	else
+		aws --region "$REGION" s3 cp "$CONFIGMAP_PATH_S3" "/tmp/${CONFIGMAP_KEY}"
+	fi
 
-    # cat /tmp/${CONFIGMAP_KEY}
-    kubectl --kubeconfig "$KUBE_CONFIG_PATH" apply -f "/tmp/${CONFIGMAP_KEY}"
+	# cat /tmp/${CONFIGMAP_KEY}
+	kubectl --kubeconfig "$KUBE_CONFIG_PATH" apply -f "/tmp/${CONFIGMAP_KEY}"
 
 else
 
-    echo "No configmap found at \"$CONFIGMAP_PATH_S3\" or permission denied. Applying default configmap."
-    kubectl --kubeconfig "$KUBE_CONFIG_PATH" apply -f "$DEFAULT_CONFIGMAP_PATH"
+	echo "No configmap found at \"$CONFIGMAP_PATH_S3\" or permission denied. Applying default configmap."
+	kubectl --kubeconfig "$KUBE_CONFIG_PATH" apply -f "$DEFAULT_CONFIGMAP_PATH"
 
 fi

--- a/_sub/compute/eks-heptio/main.tf
+++ b/_sub/compute/eks-heptio/main.tf
@@ -52,6 +52,7 @@ resource "null_resource" "enable-workers-from-s3" {
 
   provisioner "local-exec" {
     command = "bash ${path.module}/apply_blaster_configmap.sh ${data.aws_region.current.name} ${var.kubeconfig_path} ${var.blaster_configmap_s3_bucket} ${var.blaster_configmap_key} ${local.path_default_configmap} ${var.aws_assume_role_arn}"
+    quiet   = true
   }
 
   depends_on = [


### PR DESCRIPTION
## Describe your changes
ADO Pipeline currently prints AWS creds. This PR remediates that by:
1. Remove echo of AWS creds in _sub/compute/eks-heptio/apply_blaster_configmap.sh
2. Change "set -xe" to "set -e" in _sub/compute/eks-heptio/apply_blaster_configmap.sh
3. Set quiet = true for the local-exec in _sub/compute/eks-heptio/main.tf

## Issue ticket number and link
https://github.com/dfds/cloudplatform/issues/1883

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)

## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
