### PR TITLE
Remove Atlantis check from this PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,9 +9,6 @@
 - [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
 - [ ] I have rebased the code to master (or merged in the latest from master)
 
-## Checklist before approving the PR
-- [ ] Run `atlantis plan`
-- [ ] Terraform Plan looks good
 
 ## Is it a new release?
 - [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code


### PR DESCRIPTION
Atlantis is not used in QA

## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
