### PR TITLE
Create a workflow to create security releases

### DIFF
--- a/.github/workflows/auto-release-security.yml
+++ b/.github/workflows/auto-release-security.yml
@@ -1,0 +1,22 @@
+name: Security release on merge
+
+on:
+  push:
+    branches: [master, main]
+    paths:
+      - security/**
+      - _sub/security/**
+
+  # On very rare occasions, a security feature is turned on in different directories than defined in 'paths'. Then a manual release is possible.
+  workflow_dispatch:
+
+jobs:
+  auto-release:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: rymndhng/release-on-push-action@master
+        with:
+          bump_version_scheme: patch
+          tag_prefix: security-


### PR DESCRIPTION
## Describe your changes
This is a proof of concept to check if we can have multiple releases on the same repo, but that triggers for a specific sets of paths. In this case changes to security and _sub/security should trigger a release with a security- release. 

Phase two is to check:
- Does it cause problems for downstream repos that uses renovate?
- Can donstream repos be configured to use the security- releases?

## Issue ticket number and link
https://github.com/dfds/cloudplatform/issues/1920

## Checklist before requesting a review
Some checks not applicable. 

- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
