### PR TITLE
Add db_backup_retention_period variable to enable the tagging policy

### DIFF
--- a/_sub/database/postgres/main.tf
+++ b/_sub/database/postgres/main.tf
@@ -51,7 +51,7 @@ resource "aws_db_instance" "postgres" {
   engine                  = "postgres"
   engine_version          = var.engine_version
   publicly_accessible     = "true"
-  backup_retention_period = 10
+  backup_retention_period = var.db_backup_retention_period
   apply_immediately       = true
   deletion_protection     = var.deletion_protection
   identifier              = "${var.application}-postgres-${var.environment}"

--- a/_sub/database/postgres/vars.tf
+++ b/_sub/database/postgres/vars.tf
@@ -87,3 +87,9 @@ variable "deletion_protection" {
   default     = true
   description = "Protect database against deletion?"
 }
+
+variable "db_backup_retention_period" {
+  type        = number
+  description = "The days to retain database backups for"
+  default     = 10
+}

--- a/database/postgres/README.md
+++ b/database/postgres/README.md
@@ -17,3 +17,4 @@ The connection strings, passwords etc can be found in parameter store in the sam
 - db_allocated_storage - 10 (The amount of space, in GB, to allocate for the database. Optional, but defaults to 20)
 - db_max_allocated_storage - 30 (The space limit, in GB, which autoscaling can scale up to. Optional, default to 0 - autoscaling disabled)
 - allow_major_version_upgrade = true (Define if major version upgrades to the Postgres engine are allowed. Optional, but defaults to true)
+- db_backup_retention_period - 30 (The number of days to retain backups for. Optional, but defaults to 10)

--- a/database/postgres/main.tf
+++ b/database/postgres/main.tf
@@ -17,6 +17,7 @@ module "postgres" {
   db_max_allocated_storage    = var.db_max_allocated_storage
   allow_major_version_upgrade = var.allow_major_version_upgrade
   ssl_mode                    = var.ssl_mode
+  db_backup_retention_period  = var.db_backup_retention_period
 }
 
 module "param_store_pghost" {

--- a/database/postgres/vars.tf
+++ b/database/postgres/vars.tf
@@ -74,3 +74,9 @@ variable "ssl_mode" {
     error_message = "Invalid value for SSL mode. Valid values: Require, VerifyFull, VerifyCA."
   }
 }
+
+variable "db_backup_retention_period" {
+  type        = number
+  description = "The days to retain database backups for"
+  default     = 10
+}


### PR DESCRIPTION
## Describe your changes
Added db_backup_retention_period variable for the RDS module.

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
