### PR TITLE
Allow AWS Data Exchange service in us-east-1

### DIFF
--- a/security/org-policies/restrictive.tf
+++ b/security/org-policies/restrictive.tf
@@ -202,6 +202,7 @@ data "aws_iam_policy_document" "restrictive" {
       "notifications:List*",
       "sns:*",
       "resource-explorer-2:*",
+      "dataexchange:*"
     ]
     resources = ["*"]
     condition {


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
Adding the AWS Data Exchange service to the exclusion list for Data Platform to be able to use it in US-East-1.  The data source is only available there for the time being.
They will be looking into other offerings that can be restricted to EU regions.
## Issue ticket number and link
<!--#issue number here -->
230914386 - Permissions issue with AWS Data Exchange
## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
