### PR TITLE
RDS is still publicly accessible by default, but this can be changed now

### DIFF
--- a/_sub/database/postgres-restore/main.tf
+++ b/_sub/database/postgres-restore/main.tf
@@ -37,7 +37,7 @@ resource "aws_db_parameter_group" "dbparams" {
 resource "aws_db_instance" "postgres" {
   engine                  = "postgres"
   engine_version          = var.engine_version
-  publicly_accessible     = "true"
+  publicly_accessible     = var.publicly_accessible
   deletion_protection     = var.deletion_protection
   backup_retention_period = 10
   apply_immediately       = true

--- a/_sub/database/postgres-restore/vars.tf
+++ b/_sub/database/postgres-restore/vars.tf
@@ -86,3 +86,9 @@ variable "engine_version" {
   description = "RDS engine version (expects major version)"
   default     = 14
 }
+
+variable "publicly_accessible" {
+  type        = bool
+  default     = true
+  description = "Should the database be public accessible?"
+}

--- a/_sub/database/postgres/main.tf
+++ b/_sub/database/postgres/main.tf
@@ -1,7 +1,7 @@
 locals {
-  engine_family = var.engine_version == null ? "postgres13" : "postgres${substr(var.engine_version, 0, 2)}"
+  engine_family     = var.engine_version == null ? "postgres13" : "postgres${substr(var.engine_version, 0, 2)}"
   rds_instance_tags = merge({ environment = var.environment }, var.rds_instance_tags, var.tags)
-  tags = merge({ environment = var.environment }, var.tags)
+  tags              = merge({ environment = var.environment }, var.tags)
 }
 
 #tfsec:ignore:no-public-ingress-sgr tfsec:ignore:aws-vpc-no-public-ingress-sg
@@ -47,7 +47,7 @@ resource "aws_db_parameter_group" "dbparams" {
 resource "aws_db_instance" "postgres" {
   engine                  = "postgres"
   engine_version          = var.engine_version
-  publicly_accessible     = "true"
+  publicly_accessible     = var.publicly_accessible
   backup_retention_period = var.db_backup_retention_period
   apply_immediately       = true
   deletion_protection     = var.deletion_protection

--- a/_sub/database/postgres/vars.tf
+++ b/_sub/database/postgres/vars.tf
@@ -96,13 +96,19 @@ variable "db_backup_retention_period" {
 }
 
 variable "rds_instance_tags" {
-  type = map(string)
+  type        = map(string)
   description = "A map of tags to apply only to the to RDS instance"
-  default = {}
+  default     = {}
 }
 
 variable "tags" {
-  type = map(string)
+  type        = map(string)
   description = "A map of tags to apply to all the resources deployed by the module"
-  default = {}
+  default     = {}
+}
+
+variable "publicly_accessible" {
+  type        = bool
+  default     = true
+  description = "Should the database be public accessible?"
 }

--- a/database/postgres-restore/main.tf
+++ b/database/postgres-restore/main.tf
@@ -11,6 +11,7 @@ module "postgres_restore" {
   db_master_password  = var.db_master_password
   skip_final_snapshot = var.skip_final_snapshot
   ssl_mode            = var.ssl_mode
+  publicly_accessible = var.db_publicly_accessible
 }
 
 module "param_store_pghost" {

--- a/database/postgres-restore/vars.tf
+++ b/database/postgres-restore/vars.tf
@@ -48,3 +48,9 @@ variable "ssl_mode" {
     error_message = "Invalid value for SSL mode. Valid values: Require, VerifyFull, VerifyCA."
   }
 }
+
+variable "db_publicly_accessible" {
+  type        = bool
+  default     = true
+  description = "Should the database be public accessible?"
+}

--- a/database/postgres/main.tf
+++ b/database/postgres/main.tf
@@ -18,6 +18,7 @@ module "postgres" {
   allow_major_version_upgrade = var.allow_major_version_upgrade
   ssl_mode                    = var.ssl_mode
   db_backup_retention_period  = var.db_backup_retention_period
+  publicly_accessible         = var.db_publicly_accessible
   rds_instance_tags           = var.rds_instance_tags
   tags                        = var.tags
 }

--- a/database/postgres/vars.tf
+++ b/database/postgres/vars.tf
@@ -82,13 +82,19 @@ variable "db_backup_retention_period" {
 }
 
 variable "rds_instance_tags" {
-  type = map(string)
+  type        = map(string)
   description = "A map of tags to apply only to the to RDS instance"
-  default = {}
+  default     = {}
 }
 
 variable "tags" {
-  type = map(string)
+  type        = map(string)
   description = "A map of tags to apply to all the resources deployed by the module"
-  default = {}
+  default     = {}
+}
+
+variable "db_publicly_accessible" {
+  type        = bool
+  default     = true
+  description = "Should the database be public accessible?"
 }


### PR DESCRIPTION
- RDS is still publicly accessible by default, but this can be changed now
- RDS is still publicly accessible by default, but this can be changed now

## Describe your changes
<!--Describe the change here-->

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
