### PR TITLE
feat: add a 24h repeat interval grafana alert notification policy

### DIFF
--- a/_sub/compute/helm-kube-prometheus-stack/dependencies.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/dependencies.tf
@@ -108,6 +108,11 @@ locals {
             group_interval: 5m
             object_matchers:
             - ['__contacts__', '=~', '.*"${var.grafana_notifier_name}".*']
+          - match:
+            receiver: "${var.grafana_notifier_name}"
+            repeat_interval: 24h
+            object_matchers:
+            - ['repeat', '=', '24h']
       EOT
     }
   }


### PR DESCRIPTION
## Describe your changes
This PR adds a new notification policy to Grafana for alerts. To use you add a label to your alert of "repeat" = "24h" and the alert will use this notification policy and repeat on a 24h interval instead of the default 4h

## Issue ticket number and link
Required for https://github.com/dfds/cloudplatform/issues/1816 and https://github.com/dfds/cloudplatform/issues/2116

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
