### PR TITLE
Add support for snapshot.storage.k8s.io/v1 API

### DIFF
--- a/_sub/storage/external-snapshotter/dependencies.tf
+++ b/_sub/storage/external-snapshotter/dependencies.tf
@@ -1,0 +1,124 @@
+# --------------------------------------------------
+# Github
+# --------------------------------------------------
+
+data "github_branch" "flux_branch" {
+  repository = var.repo_name
+  branch     = var.repo_branch
+}
+
+
+# --------------------------------------------------
+# Common
+# --------------------------------------------------
+
+locals {
+  cluster_repo_path = "clusters/${var.cluster_name}"
+}
+
+
+# --------------------------------------------------
+# external-snapshotter-crd
+# --------------------------------------------------
+
+locals {
+  crd_repo_path    = "platform-apps/${var.cluster_name}/${var.deploy_name}-crd"
+
+  app_crd_path = {
+    "apiVersion" = "kustomize.toolkit.fluxcd.io/v1"
+    "kind"       = "Kustomization"
+    "metadata" = {
+      "name"      = "${var.deploy_name}-crd"
+      "namespace" = "flux-system"
+    }
+    "spec" = {
+      "interval" = "1m0s"
+      "sourceRef" = {
+        "kind" = "GitRepository"
+        "name" = "flux-system"
+      }
+      "path"  = "./${local.crd_repo_path}"
+      "prune" = var.prune
+    }
+  }
+
+  crd_init = {
+    "apiVersion" = "kustomize.config.k8s.io/v1beta1"
+    "kind"       = "Kustomization"
+    "resources" = [
+      "${var.gitops_apps_repo_url}/apps/${var.deploy_name}-crd?ref=${var.gitops_apps_repo_branch}"
+    ]
+  }
+}
+
+
+# --------------------------------------------------
+# external-snapshotter-controller
+# --------------------------------------------------
+
+locals {
+  controller_repo_path    = "platform-apps/${var.cluster_name}/${var.deploy_name}-controller"
+
+  app_controller_path = {
+    "apiVersion" = "kustomize.toolkit.fluxcd.io/v1"
+    "kind"       = "Kustomization"
+    "metadata" = {
+      "name"      = "${var.deploy_name}-controller"
+      "namespace" = "flux-system"
+    }
+    "spec" = {
+      "interval" = "1m0s"
+      "dependsOn" = [{"name" = "${var.deploy_name}-crd"}]
+      "sourceRef" = {
+        "kind" = "GitRepository"
+        "name" = "flux-system"
+      }
+      "path"  = "./${local.controller_repo_path}"
+      "prune" = var.prune
+    }
+  }
+
+  controller_init = {
+    "apiVersion" = "kustomize.config.k8s.io/v1beta1"
+    "kind"       = "Kustomization"
+    "resources" = [
+      "${var.gitops_apps_repo_url}/apps/${var.deploy_name}-controller?ref=${var.gitops_apps_repo_branch}"
+    ]
+  }
+}
+
+
+# --------------------------------------------------
+# external-snapshotter-config
+# --------------------------------------------------
+
+locals {
+  config_repo_path    = "platform-apps/${var.cluster_name}/${var.deploy_name}-config"
+
+  app_config_path = {
+    "apiVersion" = "kustomize.toolkit.fluxcd.io/v1"
+    "kind"       = "Kustomization"
+    "metadata" = {
+      "name"      = "${var.deploy_name}-config"
+      "namespace" = "flux-system"
+    }
+    "spec" = {
+      "interval" = "1m0s"
+      "dependsOn" = [{"name" = "${var.deploy_name}-controller"}]
+      "sourceRef" = {
+        "kind" = "GitRepository"
+        "name" = "flux-system"
+      }
+      "path"  = "./${local.config_repo_path}"
+      "prune" = var.prune
+    }
+  }
+
+  config_init = {
+    "apiVersion" = "kustomize.config.k8s.io/v1beta1"
+    "kind"       = "Kustomization"
+    "resources" = [
+      "${var.gitops_apps_repo_url}/apps/${var.deploy_name}-config?ref=${var.gitops_apps_repo_branch}"
+    ]
+  }
+}

--- a/_sub/storage/external-snapshotter/main.tf
+++ b/_sub/storage/external-snapshotter/main.tf
@@ -1,0 +1,69 @@
+# --------------------------------------------------
+# External-Snapshotter adds support for snapshot.storage.k8s.io/v1
+# https://github.com/kubernetes-csi/external-snapshotter/tree/master
+#
+# This is required to create EBS snapshots through Velero
+# --------------------------------------------------
+
+
+# --------------------------------------------------
+# external-snapshotter-crd
+# --------------------------------------------------
+
+resource "github_repository_file" "external-snapshotter_crd_path" {
+  repository          = var.repo_name
+  branch              = data.github_branch.flux_branch.branch
+  file                = "${local.cluster_repo_path}/${var.deploy_name}-crd.yaml"
+  content             = jsonencode(local.app_crd_path)
+  overwrite_on_create = var.overwrite_on_create
+}
+
+resource "github_repository_file" "external-snapshotter_crd_init" {
+  repository          = var.repo_name
+  branch              = data.github_branch.flux_branch.branch
+  file                = "${local.crd_repo_path}/kustomization.yaml"
+  content             = jsonencode(local.crd_init)
+  overwrite_on_create = var.overwrite_on_create
+}
+
+
+# --------------------------------------------------
+# external-snapshotter-controller
+# --------------------------------------------------
+
+resource "github_repository_file" "external-snapshotter_controller_path" {
+  repository          = var.repo_name
+  branch              = data.github_branch.flux_branch.branch
+  file                = "${local.cluster_repo_path}/${var.deploy_name}-controller.yaml"
+  content             = jsonencode(local.app_controller_path)
+  overwrite_on_create = var.overwrite_on_create
+}
+
+resource "github_repository_file" "external-snapshotter_controller_init" {
+  repository          = var.repo_name
+  branch              = data.github_branch.flux_branch.branch
+  file                = "${local.controller_repo_path}/kustomization.yaml"
+  content             = jsonencode(local.controller_init)
+  overwrite_on_create = var.overwrite_on_create
+}
+
+
+# --------------------------------------------------
+# external-snapshotter-config
+# --------------------------------------------------
+
+resource "github_repository_file" "external-snapshotter_config_path" {
+  repository          = var.repo_name
+  branch              = data.github_branch.flux_branch.branch
+  file                = "${local.cluster_repo_path}/${var.deploy_name}-config.yaml"
+  content             = jsonencode(local.app_config_path)
+  overwrite_on_create = var.overwrite_on_create
+}
+
+resource "github_repository_file" "external-snapshotter_config_init" {
+  repository          = var.repo_name
+  branch              = data.github_branch.flux_branch.branch
+  file                = "${local.config_repo_path}/kustomization.yaml"
+  content             = jsonencode(local.config_init)
+  overwrite_on_create = var.overwrite_on_create
+}

--- a/_sub/storage/external-snapshotter/vars.tf
+++ b/_sub/storage/external-snapshotter/vars.tf
@@ -1,0 +1,45 @@
+variable "cluster_name" {
+  type        = string
+  description = "The name of the EKS cluster."
+}
+
+variable "deploy_name" {
+  type        = string
+  description = "Unique identifier of the deployment, only needs override if deploying multiple instances"
+  default     = "external-snapshotter"
+}
+
+variable "repo_name" {
+  type        = string
+  description = "GitHub repository name for writing Flux manifests to."
+}
+
+variable "repo_branch" {
+  type        = string
+  default     = "main"
+  description = "The git branch."
+}
+
+variable "overwrite_on_create" {
+  type        = bool
+  default     = true
+  description = "Enable overwriting existing files"
+}
+
+variable "gitops_apps_repo_url" {
+  type        = string
+  default     = ""
+  description = "The https url for your GitOps manifests"
+}
+
+variable "gitops_apps_repo_branch" {
+  type        = string
+  default     = "main"
+  description = "The default branch for your GitOps manifests"
+}
+
+variable "prune" {
+  type        = bool
+  default     = true
+  description = "Enable Garbage collection"
+}

--- a/_sub/storage/external-snapshotter/versions.tf
+++ b/_sub/storage/external-snapshotter/versions.tf
@@ -1,0 +1,20 @@
+
+terraform {
+  required_version = ">= 1.3.0, < 2.0.0"
+
+  /*
+  Hashicorp-managed providers can be loaded implicitly
+  Need to explicitly specific 3rd party Providers
+  Version can still be controlled via main module
+  */
+
+  required_providers {
+
+    github = {
+      source  = "integrations/github"
+      version = "~> 5.40.0"
+    }
+
+  }
+
+}

--- a/_sub/storage/velero-flux/dependencies.tf
+++ b/_sub/storage/velero-flux/dependencies.tf
@@ -24,6 +24,7 @@ locals {
     }
     "spec" = {
       "interval" = "1m0s"
+      "dependsOn" = [{"name" = "external-snapshotter-config"}]
       "sourceRef" = {
         "kind" = "GitRepository"
         "name" = "flux-system"

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -690,6 +690,28 @@ module "fluentd_cloudwatch_flux_manifests" {
 }
 
 # --------------------------------------------------
+# External-Snapshotter adds support for snapshot.storage.k8s.io/v1
+# https://github.com/kubernetes-csi/external-snapshotter/tree/master
+# --------------------------------------------------
+
+module "external_snapshotter" {
+  source                  = "../../_sub/storage/external-snapshotter"
+  cluster_name            = var.eks_cluster_name
+  repo_name               = var.fluxcd_bootstrap_repo_name
+  repo_branch             = var.fluxcd_bootstrap_repo_branch
+  overwrite_on_create     = var.fluxcd_bootstrap_overwrite_on_create
+  gitops_apps_repo_url    = local.fluxcd_apps_repo_url
+  gitops_apps_repo_branch = var.fluxcd_apps_repo_branch
+  prune                   = var.fluxcd_prune
+
+  providers = {
+    github = github.fluxcd
+  }
+
+  depends_on = [module.platform_fluxcd]
+}
+
+# --------------------------------------------------
 # Velero - requires that s3-bucket-velero module
 # is already applied through Terragrunt.
 # --------------------------------------------------
@@ -717,7 +739,7 @@ module "velero_flux_manifests" {
     github = github.fluxcd
   }
 
-  depends_on = [module.platform_fluxcd]
+  depends_on = [module.platform_fluxcd, module.external_snapshotter]
 }
 
 


### PR DESCRIPTION
## Describe your changes
Currently we do not have support for snapshot backups of persistent volumes through Velero.

THIS PR MUST BE MERGED AFTER ANOTHER PR: https://github.com/dfds/platform-apps/pull/28

It will also FAIL in QA before the above PR is merged.

## Issue ticket number and link
https://github.com/dfds/cloudplatform/issues/1979 

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
