### PR TITLE
Add option to use Velero for creating snapshot backups of EBS volumes

### DIFF
--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -730,6 +730,7 @@ module "velero_flux_manifests" {
   image_tag               = var.velero_image_tag
   plugin_for_aws_version  = var.velero_plugin_for_aws_version
   plugin_for_csi_version  = var.velero_plugin_for_csi_version
+  snapshots_enabled       = var.velero_snapshots_enabled
   overwrite_on_create     = var.fluxcd_bootstrap_overwrite_on_create
   gitops_apps_repo_url    = local.fluxcd_apps_repo_url
   gitops_apps_repo_branch = var.fluxcd_apps_repo_branch

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -1080,6 +1080,13 @@ variable "velero_plugin_for_csi_version" {
   }
 }
 
+variable "velero_snapshots_enabled" {
+  type        = bool
+  default     = false
+  description = "Should Velero use snapshot backups?"
+
+}
+
 variable "kyverno_chart_version" {
   type        = string
   default     = "v2.4.1"


### PR DESCRIPTION
## Describe your changes
Add variable, so it is possible to use the feature for taking EBS volume snapshots with Velero

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
