### PR TITLE
Remove unused variable velero_bucket_name

### DIFF
--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -1020,12 +1020,6 @@ variable "velero_deploy" {
   description = "Should Velero Helm chart be deployed?"
 }
 
-variable "velero_bucket_name" {
-  type        = string
-  default     = null
-  description = "The name of the S3 bucket that contains the Velero backup"
-}
-
 variable "velero_cron_schedule" {
   type        = string
   default     = "0 0 * * *"


### PR DESCRIPTION
## Describe your changes
terraform-cleaner found that velero_bucket_name is no longer used in computer/k8s-services after Velero refactoring

## Issue ticket number and link
None

## Checklist before requesting a review
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
