### PR TITLE
Use m6a instance family for regular workloads. Only use GPU nodes in one region to save cost

### DIFF
--- a/test/integration/eu-west-1/k8s-qa/cluster/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/cluster/terragrunt.hcl
@@ -89,7 +89,7 @@ inputs = {
   # aws ssm get-parameter --name /aws/service/eks/optimized-ami/1.27/amazon-linux-2/recommended/image_id --region eu-west-1 --query "Parameter.Value" --output text
   eks_managed_nodegroups = {
     "general" = {
-      instance_types          = ["m5a.xlarge"]
+      instance_types          = ["m6a.xlarge"]
       disk_type               = "gp3"
       desired_size_per_subnet = 1
       # This comment configures the renovate bot to automatically update this variable:
@@ -100,7 +100,7 @@ inputs = {
       max_unavailable_percentage = 50
     }
     "monitoring" = {
-      instance_types          = ["m5a.xlarge"]
+      instance_types          = ["m6a.xlarge"]
       disk_type               = "gp3"
       desired_size_per_subnet = 1
       # This comment configures the renovate bot to automatically update this variable:
@@ -123,7 +123,7 @@ inputs = {
     "gpu" = {
       instance_types = ["g4dn.2xlarge"]
       desired_size_per_subnet = 1
-      availability_zones      = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+      availability_zones      = ["eu-west-1a"]
       max_unavailable         = 1
       ami_id = "ami-0d09ad178e7e780d1"
       taints = [

--- a/test/integration/suite/ebs_csi_driver_test.go
+++ b/test/integration/suite/ebs_csi_driver_test.go
@@ -11,5 +11,5 @@ func TestEbsCsiDriverDeployment(t *testing.T) {
 func TestEbsCsiDriverDaemonSet(t *testing.T) {
 	t.Parallel()
 	clientset := NewK8sClientSet(t)
-	AssertK8sDaemonSet(t, clientset, "kube-system", "ebs-csi-node", 7)
+	AssertK8sDaemonSet(t, clientset, "kube-system", "ebs-csi-node", 5)
 }

--- a/test/integration/suite/fluentd_test.go
+++ b/test/integration/suite/fluentd_test.go
@@ -5,5 +5,5 @@ import "testing"
 func TestFluentdDaemonSet(t *testing.T) {
 	t.Parallel()
 	clientset := NewK8sClientSet(t)
-	AssertK8sDaemonSet(t, clientset, "fluentd", "fluentd-cloudwatch", 7)
+	AssertK8sDaemonSet(t, clientset, "fluentd", "fluentd-cloudwatch", 5)
 }

--- a/test/integration/suite/kube_proxy_test.go
+++ b/test/integration/suite/kube_proxy_test.go
@@ -5,5 +5,5 @@ import "testing"
 func TestKubeProxyDaemonSet(t *testing.T) {
 	t.Parallel()
 	clientset := NewK8sClientSet(t)
-	AssertK8sDaemonSet(t, clientset, "kube-system", "kube-proxy", 7)
+	AssertK8sDaemonSet(t, clientset, "kube-system", "kube-proxy", 5)
 }

--- a/test/integration/suite/vpc_cni_driver_test.go
+++ b/test/integration/suite/vpc_cni_driver_test.go
@@ -5,5 +5,5 @@ import "testing"
 func TestVpcCniDriverDaemonSet(t *testing.T) {
 	t.Parallel()
 	clientset := NewK8sClientSet(t)
-	AssertK8sDaemonSet(t, clientset, "kube-system", "aws-node", 7)
+	AssertK8sDaemonSet(t, clientset, "kube-system", "aws-node", 5)
 }


### PR DESCRIPTION
## Describe your changes
Upgrading from m5a to m6a is now super cheap with only a 0.0012 increase in cost per hour. 
At the same time, I have limited GPU nodes to 1 region instead of 3 in order to save cost in QA.

## Issue ticket number and link
TopDesk: https://dfds.topdesk.net/tas/secure/mango/window/3?t=1699871544465

## Checklist before requesting a review
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
