### PR TITLE
job config for scraping confluent cloud prometheus metrics added

### DIFF
--- a/_sub/compute/helm-kube-prometheus-stack/main.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/main.tf
@@ -64,18 +64,24 @@ resource "helm_release" "kube_prometheus_stack" {
     }),
 
     templatefile("${path.module}/values/prometheus.yaml", {
-      prometheus_priorityclass  = var.priority_class
-      prometheus_storageclass   = var.prometheus_storageclass
-      prometheus_storage_size   = var.prometheus_storage_size
-      prometheus_retention      = var.prometheus_retention
-      prometheus_request_memory = var.prometheus_request_memory
-      prometheus_request_cpu    = var.prometheus_request_cpu
-      prometheus_limit_memory   = var.prometheus_limit_memory
-      prometheus_limit_cpu      = var.prometheus_limit_cpu
-      query_log_file_enabled    = var.query_log_file_enabled
-      enable_features           = var.enable_features
-      tolerations               = var.tolerations,
-      affinity                  = var.affinity,
+      prometheus_priorityclass                            = var.priority_class
+      prometheus_storageclass                             = var.prometheus_storageclass
+      prometheus_storage_size                             = var.prometheus_storage_size
+      prometheus_retention                                = var.prometheus_retention
+      prometheus_request_memory                           = var.prometheus_request_memory
+      prometheus_request_cpu                              = var.prometheus_request_cpu
+      prometheus_limit_memory                             = var.prometheus_limit_memory
+      prometheus_limit_cpu                                = var.prometheus_limit_cpu
+      query_log_file_enabled                              = var.query_log_file_enabled
+      enable_features                                     = var.enable_features
+      tolerations                                         = var.tolerations,
+      affinity                                            = var.affinity,
+      prometheus_confluent_metrics_scrape_enabled         = var.prometheus_confluent_metrics_scrape_enabled,
+      prometheus_confluent_metrics_api_key                = var.prometheus_confluent_metrics_api_key,
+      prometheus_confluent_metrics_api_secret             = var.prometheus_confluent_metrics_api_secret,
+      prometheus_confluent_metrics_scrape_interval        = var.prometheus_confluent_metrics_scrape_interval,
+      prometheus_confluent_metrics_scrape_timeout         = var.prometheus_confluent_metrics_scrape_timeout,
+      prometheus_confluent_metrics_resource_kafka_id_list = var.prometheus_confluent_metrics_resource_kafka_id_list,
     }),
 
     length(var.slack_webhook) > 0 ? templatefile("${path.module}/values/alertmanager-slack.yaml", {
@@ -131,7 +137,7 @@ resource "github_repository_file" "grafana_config_ingressroute" {
 }
 
 resource "github_repository_file" "grafana_config_alert_config" {
-repository          = var.repo_name
+  repository          = var.repo_name
   branch              = local.repo_branch
   file                = "${local.config_repo_path}/alert-config.yaml"
   content             = jsonencode(local.grafana_config_alert_config)

--- a/_sub/compute/helm-kube-prometheus-stack/values/prometheus.yaml
+++ b/_sub/compute/helm-kube-prometheus-stack/values/prometheus.yaml
@@ -17,6 +17,28 @@ prometheus:
         - path: /metrics
           port: http
   prometheusSpec:
+%{ if prometheus_confluent_metrics_scrape_enabled ~}
+    queryLogFile: "/dev/stdout"
+    additionalScrapeConfigs:
+      - job_name: confluent-cloud
+        scrape_interval: ${prometheus_confluent_metrics_scrape_interval}
+        scrape_timeout:  ${prometheus_confluent_metrics_scrape_timeout}
+        honor_timestamps: true
+        static_configs:
+          - targets:
+            - api.telemetry.confluent.cloud
+        scheme: https
+        basic_auth:
+          username: ${prometheus_confluent_metrics_api_key}
+          password: ${prometheus_confluent_metrics_api_secret}
+        metrics_path: /v2/metrics/cloud/export
+        params:
+          "resource.kafka.id":
+%{ for f in prometheus_confluent_metrics_resource_kafka_id_list ~}
+            - ${f}
+%{ endfor ~}
+%{ endif ~}
+
     enableAdminAPI: false
 %{ if query_log_file_enabled ~}
     queryLogFile: "/dev/stdout"

--- a/_sub/compute/helm-kube-prometheus-stack/vars.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/vars.tf
@@ -149,6 +149,39 @@ variable "prometheus_limit_cpu" {
   default     = "1000m"
 }
 
+variable "prometheus_confluent_metrics_scrape_enabled" {
+  type        = bool
+  default     = false
+  description = "Enable scraping of Confluent Cloud metrics"
+}
+
+variable "prometheus_confluent_metrics_scrape_interval" {
+  type        = string
+  default     = "1m"
+  description = "Interval to scrape Confluent Cloud metrics"
+}
+
+variable "prometheus_confluent_metrics_scrape_timeout" {
+  type        = string
+  default     = "10s"
+  description = "Timeout to scrape Confluent Cloud metrics"
+}
+
+variable "prometheus_confluent_metrics_api_key" {
+  type        = string
+  description = "value of the Confluent Cloud API key"
+}
+
+variable "prometheus_confluent_metrics_api_secret" {
+  type        = string
+  description = "value of the Confluent Cloud API secret"
+}
+
+variable "prometheus_confluent_metrics_resource_kafka_id_list" {
+  type        = list(string)
+  description = "List of Kafka cluster IDs to scrape metrics from"
+}
+
 variable "overwrite_on_create" {
   type        = bool
   default     = true

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -357,43 +357,48 @@ module "monitoring_goldpinger" {
 # --------------------------------------------------
 
 module "monitoring_kube_prometheus_stack" {
-  source                      = "../../_sub/compute/helm-kube-prometheus-stack"
-  count                       = var.monitoring_kube_prometheus_stack_deploy ? 1 : 0
-  cluster_name                = var.eks_cluster_name
-  chart_version               = var.monitoring_kube_prometheus_stack_chart_version
-  namespace                   = module.monitoring_namespace[0].name
-  priority_class              = var.monitoring_kube_prometheus_stack_priority_class
-  grafana_admin_password      = var.monitoring_kube_prometheus_stack_grafana_admin_password
-  grafana_ingress_path        = var.monitoring_kube_prometheus_stack_grafana_ingress_path
-  grafana_host                = "grafana.${var.eks_cluster_name}.${var.workload_dns_zone_name}"
-  grafana_notifier_name       = "${var.eks_cluster_name}-alerting"
-  grafana_iam_role_arn        = local.grafana_iam_role_arn
-  grafana_serviceaccount_name = var.monitoring_kube_prometheus_stack_grafana_serviceaccount_name
-  grafana_storage_enabled     = var.monitoring_kube_prometheus_stack_grafana_storage_enabled
-  grafana_storage_class       = var.monitoring_kube_prometheus_stack_grafana_storageclass
-  grafana_storage_size        = var.monitoring_kube_prometheus_stack_grafana_storage_size
-  grafana_serve_from_sub_path = var.monitoring_kube_prometheus_stack_grafana_serve_from_sub_path
-  grafana_azure_tenant_id     = var.monitoring_kube_prometheus_stack_azure_tenant_id != "" ? var.monitoring_kube_prometheus_stack_azure_tenant_id : var.atlantis_arm_tenant_id
-  slack_webhook               = var.monitoring_kube_prometheus_stack_slack_webhook
-  prometheus_storageclass     = var.monitoring_kube_prometheus_stack_prometheus_storageclass
-  prometheus_storage_size     = var.monitoring_kube_prometheus_stack_prometheus_storage_size
-  prometheus_retention        = var.monitoring_kube_prometheus_stack_prometheus_retention
-  slack_channel               = var.monitoring_kube_prometheus_stack_slack_channel
-  target_namespaces           = var.monitoring_kube_prometheus_stack_target_namespaces
-  github_owner                = var.fluxcd_bootstrap_repo_owner
-  repo_name                   = var.fluxcd_bootstrap_repo_name
-  repo_branch                 = var.fluxcd_bootstrap_repo_branch
-  prometheus_request_memory   = var.monitoring_kube_prometheus_stack_prometheus_request_memory
-  prometheus_request_cpu      = var.monitoring_kube_prometheus_stack_prometheus_request_cpu
-  prometheus_limit_memory     = var.monitoring_kube_prometheus_stack_prometheus_limit_memory
-  prometheus_limit_cpu        = var.monitoring_kube_prometheus_stack_prometheus_limit_cpu
-  query_log_file_enabled      = var.monitoring_kube_prometheus_stack_prometheus_query_log_file_enabled
-  enable_features             = var.monitoring_kube_prometheus_stack_prometheus_enable_features
-  overwrite_on_create         = var.fluxcd_bootstrap_overwrite_on_create
-  tolerations                 = var.monitoring_tolerations
-  affinity                    = var.monitoring_affinity
-  prune                       = var.fluxcd_prune
-
+  source                                              = "../../_sub/compute/helm-kube-prometheus-stack"
+  count                                               = var.monitoring_kube_prometheus_stack_deploy ? 1 : 0
+  cluster_name                                        = var.eks_cluster_name
+  chart_version                                       = var.monitoring_kube_prometheus_stack_chart_version
+  namespace                                           = module.monitoring_namespace[0].name
+  priority_class                                      = var.monitoring_kube_prometheus_stack_priority_class
+  grafana_admin_password                              = var.monitoring_kube_prometheus_stack_grafana_admin_password
+  grafana_ingress_path                                = var.monitoring_kube_prometheus_stack_grafana_ingress_path
+  grafana_host                                        = "grafana.${var.eks_cluster_name}.${var.workload_dns_zone_name}"
+  grafana_notifier_name                               = "${var.eks_cluster_name}-alerting"
+  grafana_iam_role_arn                                = local.grafana_iam_role_arn
+  grafana_serviceaccount_name                         = var.monitoring_kube_prometheus_stack_grafana_serviceaccount_name
+  grafana_storage_enabled                             = var.monitoring_kube_prometheus_stack_grafana_storage_enabled
+  grafana_storage_class                               = var.monitoring_kube_prometheus_stack_grafana_storageclass
+  grafana_storage_size                                = var.monitoring_kube_prometheus_stack_grafana_storage_size
+  grafana_serve_from_sub_path                         = var.monitoring_kube_prometheus_stack_grafana_serve_from_sub_path
+  grafana_azure_tenant_id                             = var.monitoring_kube_prometheus_stack_azure_tenant_id != "" ? var.monitoring_kube_prometheus_stack_azure_tenant_id : var.atlantis_arm_tenant_id
+  slack_webhook                                       = var.monitoring_kube_prometheus_stack_slack_webhook
+  prometheus_storageclass                             = var.monitoring_kube_prometheus_stack_prometheus_storageclass
+  prometheus_storage_size                             = var.monitoring_kube_prometheus_stack_prometheus_storage_size
+  prometheus_retention                                = var.monitoring_kube_prometheus_stack_prometheus_retention
+  prometheus_confluent_metrics_scrape_enabled         = var.monitoring_kube_prometheus_stack_prometheus_confluent_metrics_scrape_enabled
+  prometheus_confluent_metrics_api_key                = var.monitoring_kube_prometheus_stack_prometheus_confluent_metrics_api_key
+  prometheus_confluent_metrics_api_secret             = var.monitoring_kube_prometheus_stack_prometheus_confluent_metrics_api_secret
+  prometheus_confluent_metrics_scrape_interval        = var.monitoring_kube_prometheus_stack_prometheus_confluent_metrics_scrape_interval
+  prometheus_confluent_metrics_scrape_timeout         = var.monitoring_kube_prometheus_stack_prometheus_confluent_metrics_scrape_timeout
+  prometheus_confluent_metrics_resource_kafka_id_list = var.monitoring_kube_prometheus_stack_prometheus_confluent_metrics_resource_kafka_id_list
+  slack_channel                                       = var.monitoring_kube_prometheus_stack_slack_channel
+  target_namespaces                                   = var.monitoring_kube_prometheus_stack_target_namespaces
+  github_owner                                        = var.fluxcd_bootstrap_repo_owner
+  repo_name                                           = var.fluxcd_bootstrap_repo_name
+  repo_branch                                         = var.fluxcd_bootstrap_repo_branch
+  prometheus_request_memory                           = var.monitoring_kube_prometheus_stack_prometheus_request_memory
+  prometheus_request_cpu                              = var.monitoring_kube_prometheus_stack_prometheus_request_cpu
+  prometheus_limit_memory                             = var.monitoring_kube_prometheus_stack_prometheus_limit_memory
+  prometheus_limit_cpu                                = var.monitoring_kube_prometheus_stack_prometheus_limit_cpu
+  query_log_file_enabled                              = var.monitoring_kube_prometheus_stack_prometheus_query_log_file_enabled
+  enable_features                                     = var.monitoring_kube_prometheus_stack_prometheus_enable_features
+  overwrite_on_create                                 = var.fluxcd_bootstrap_overwrite_on_create
+  tolerations                                         = var.monitoring_tolerations
+  affinity                                            = var.monitoring_affinity
+  prune                                               = var.fluxcd_prune
   providers = {
     github = github.fluxcd
   }

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -362,6 +362,40 @@ variable "monitoring_kube_prometheus_stack_prometheus_enable_features" {
   default     = []
 }
 
+variable "monitoring_kube_prometheus_stack_prometheus_confluent_metrics_scrape_enabled" {
+  type        = string
+  description = "Whether to enable scraping of Confluent metrics in Prometheus."
+  default     = false
+}
+variable "monitoring_kube_prometheus_stack_prometheus_confluent_metrics_api_key" {
+  type        = string
+  description = "Confluent metrics API key."
+  default     = null
+}
+
+variable "monitoring_kube_prometheus_stack_prometheus_confluent_metrics_api_secret" {
+  type        = string
+  description = "Confluent metrics API secret."
+  default     = null
+}
+
+variable "monitoring_kube_prometheus_stack_prometheus_confluent_metrics_scrape_interval" {
+  type        = string
+  description = "Confluent metrics scrape interval."
+  default     = "1m"
+}
+
+variable "monitoring_kube_prometheus_stack_prometheus_confluent_metrics_scrape_timeout" {
+  type        = string
+  description = "Confluent metrics scrape timeout."
+  default     = "1m"
+}
+
+variable "monitoring_kube_prometheus_stack_prometheus_confluent_metrics_resource_kafka_id_list" {
+  type        = list(string)
+  description = "List of Kafka cluster IDs to scrape metrics from"
+  default     = []
+}
 # --------------------------------------------------
 # Metrics-Server
 # --------------------------------------------------

--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -141,7 +141,7 @@ inputs = {
   monitoring_kube_prometheus_stack_grafana_storageclass              = "gp2"
   monitoring_kube_prometheus_stack_prometheus_query_log_file_enabled = true
   monitoring_kube_prometheus_stack_prometheus_enable_features        = ["memory-snapshot-on-shutdown"]
-
+  monitoring_kube_prometheus_stack_prometheus_confluent_metrics_scrape_enabled = false
 
   # --------------------------------------------------
   # Goldpinger

--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -141,7 +141,9 @@ inputs = {
   monitoring_kube_prometheus_stack_grafana_storageclass              = "gp2"
   monitoring_kube_prometheus_stack_prometheus_query_log_file_enabled = true
   monitoring_kube_prometheus_stack_prometheus_enable_features        = ["memory-snapshot-on-shutdown"]
-  monitoring_kube_prometheus_stack_prometheus_confluent_metrics_scrape_enabled = false
+  monitoring_kube_prometheus_stack_prometheus_confluent_metrics_scrape_enabled = true
+  monitoring_kube_prometheus_stack_prometheus_confluent_metrics_api_key="fake"
+  monitoring_kube_prometheus_stack_prometheus_confluent_metrics_api_secret="fake"
 
   # --------------------------------------------------
   # Goldpinger


### PR DESCRIPTION
## Describe your changes
Enable adding config for job in prometheus to scrape metrics from confluent cloud.

Job can be configured with the followings:
- Flag to enable/disable scraping from metrics endpoint on Confluent Cloud
- Supply credentials
- List of Kafka resorces (clusters)
- Scrape interval
- Scrape timeout 

## Issue ticket number and link
https://github.com/dfds/cloudplatform/issues/2353

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
