### PR TITLE
Use the new traefik.io/v1alpha1 apiVersion

### DIFF
--- a/_sub/compute/helm-kube-prometheus-stack/dependencies.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/dependencies.tf
@@ -32,7 +32,7 @@ locals {
   }
 
   grafana_config_middleware = {
-    "apiVersion" = "traefik.containo.us/v1alpha1"
+    "apiVersion" = "traefik.io/v1alpha1"
     "kind"       = "Middleware"
     "metadata" = {
       "name"      = local.grafana_middleware_name
@@ -47,7 +47,7 @@ locals {
   }
 
   grafana_config_ingressroute = {
-    "apiVersion" = "traefik.containo.us/v1alpha1"
+    "apiVersion" = "traefik.io/v1alpha1"
     "kind"       = "IngressRoute"
     "metadata" = {
       "name"      = local.grafana_ingressroute_name

--- a/_sub/compute/k8s-atlantis-flux-config/dependencies.tf
+++ b/_sub/compute/k8s-atlantis-flux-config/dependencies.tf
@@ -42,7 +42,7 @@ locals {
 
 
   config_ingressroute = {
-    "apiVersion" = "traefik.containo.us/v1alpha1"
+    "apiVersion" = "traefik.io/v1alpha1"
     "kind"       = "IngressRoute"
     "metadata" = {
       "name"      = local.ingressroute_name
@@ -73,7 +73,7 @@ locals {
   }
 
   config_middleware = {
-    "apiVersion" = "traefik.containo.us/v1alpha1"
+    "apiVersion" = "traefik.io/v1alpha1"
     "kind"       = "Middleware"
     "metadata" = {
       "name"      = local.ingressroute_basic_auth_middleware_name

--- a/_sub/compute/k8s-traefik-flux/dependencies.tf
+++ b/_sub/compute/k8s-traefik-flux/dependencies.tf
@@ -108,7 +108,7 @@ locals {
   }
 
   config_dashboard_ingressroute = {
-    "apiVersion" = "traefik.containo.us/v1alpha1"
+    "apiVersion" = "traefik.io/v1alpha1"
     "kind"       = "IngressRoute"
     "metadata" = {
       "name"      = "${var.deploy_name}-dashboard"


### PR DESCRIPTION
## Describe your changes
Traefik CRDs has changed FQDN in the apiVersion. 
Old domain name is still supported. 
Dashboard only works with new name.

This should take care of Traefik Dashboard reporting 404.

## Issue ticket number and link
https://github.com/dfds/cloudplatform/issues/2382

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
