### PR TITLE
Removing ckms and old dfds-vault in AWS Backup.

### DIFF
--- a/_sub/security/aws-backup/vars.tf
+++ b/_sub/security/aws-backup/vars.tf
@@ -5,18 +5,6 @@ variable "new_vault_name" {
   default     = null
 }
 
-variable "vault_name" {
-  type        = string
-  description = "The name of the vault we created initially. This vault will eventually be removed."
-  default     = null
-}
-
-variable "deploy_kms_key" {
-  type        = bool
-  description = "Indicates whether a KMS key should be deployed."
-  default     = true
-}
-
 variable "kms_key_arn" {
   type        = string
   description = "The ARN of a the KMS key."

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -282,7 +282,7 @@ module "github_oidc_provider" {
 # --------------------------------------------------
 
 locals {
-  deploy_kms_key = true
+  deploy_kms_key = false
   kms_key_admins = [module.org_account.org_role_arn]
   }
 
@@ -318,9 +318,7 @@ module "backup_eu_central_1" {
   settings_resource_type_opt_in_preference = var.aws_backup_settings_resource_type_opt_in_preference
   resource_type_management_preference      = var.aws_backup_resource_type_management_preference
 
-  vault_name     = var.aws_backup_vault_name
   new_vault_name = var.aws_backup_vault_name_new
-  deploy_kms_key = local.deploy_kms_key
   kms_key_admins = local.kms_key_admins
   backup_plans   = var.aws_backup_plans
   iam_role_arn   = aws_iam_role.backup[0].arn
@@ -337,9 +335,7 @@ module "backup_eu_west_1" {
   settings_resource_type_opt_in_preference = var.aws_backup_settings_resource_type_opt_in_preference
   resource_type_management_preference      = var.aws_backup_resource_type_management_preference
 
-  vault_name     = var.aws_backup_vault_name
   new_vault_name = var.aws_backup_vault_name_new
-  deploy_kms_key = local.deploy_kms_key
   kms_key_admins = local.kms_key_admins
   backup_plans   = var.aws_backup_plans
   iam_role_arn   = aws_iam_role.backup[0].arn


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
As the last retore points are expiring from the old dfds-vault for AWS Backup, changing our code to remove the kms and old vault.
## Issue ticket number and link
<!--#issue number here -->

https://github.com/dfds/cloudplatform/issues/2240

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
