### PR TITLE
add parameter store item for oidc provider

### DIFF
--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -136,6 +136,17 @@ module "aws_iam_oidc_provider" {
   }
 }
 
+module "aws_iam_oidc_provider_ssm" { # Add SSM parameter for OIDC provider URL TODO: Test!
+  source = "../../_sub/security/ssm-parameter-store"
+  providers = {
+    aws = aws.workload
+  }
+  key_name        = "/managed/cluster/oidc-provider"
+  key_description = "OIDC Provider URL for EKS cluster"
+  key_value       = var.oidc_provider_url
+  tag_createdby   = var.ssm_param_createdby
+}
+
 # --------------------------------------------------
 # aws_context_account_created event
 # --------------------------------------------------
@@ -284,7 +295,7 @@ module "github_oidc_provider" {
 locals {
   deploy_kms_key = false
   kms_key_admins = [module.org_account.org_role_arn]
-  }
+}
 
 resource "aws_iam_role" "backup" {
   provider = aws.workload
@@ -322,7 +333,7 @@ module "backup_eu_central_1" {
   kms_key_admins = local.kms_key_admins
   backup_plans   = var.aws_backup_plans
   iam_role_arn   = aws_iam_role.backup[0].arn
-  tags = var.aws_backup_tags
+  tags           = var.aws_backup_tags
 }
 
 module "backup_eu_west_1" {
@@ -339,5 +350,5 @@ module "backup_eu_west_1" {
   kms_key_admins = local.kms_key_admins
   backup_plans   = var.aws_backup_plans
   iam_role_arn   = aws_iam_role.backup[0].arn
-  tags = var.aws_backup_tags
+  tags           = var.aws_backup_tags
 }

--- a/security/org-account-context/vars.tf
+++ b/security/org-account-context/vars.tf
@@ -294,3 +294,11 @@ variable "tags" {
   description = "A map of tags to apply to all the resources deployed by the module"
   default     = {}
 }
+
+# Optional
+# --------------------------------------------------
+
+variable "ssm_param_createdby" {
+  type        = string
+  description = "The value that will be used for the createdBy key when tagging any SSM parameters"
+}

--- a/security/org-account-context/vars.tf
+++ b/security/org-account-context/vars.tf
@@ -295,8 +295,6 @@ variable "tags" {
   default     = {}
 }
 
-# Optional
-# --------------------------------------------------
 
 variable "ssm_param_createdby" {
   type        = string


### PR DESCRIPTION
## Describe your changes
This change populates OIDC URL info in the parameter store and thus enables automation

## Issue ticket number and link
none but related PR from https://github.com/dfds/aws-modules-rds is mentioned below 

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
