### PR TITLE
Remove duplicate tags variable declaration for postgres

### DIFF
--- a/database/postgres/vars.tf
+++ b/database/postgres/vars.tf
@@ -99,12 +99,6 @@ variable "db_publicly_accessible" {
   description = "Should the database be public accessible?"
 }
 
-variable "tags" {
-  type        = map(string)
-  description = "A map of tags to apply to all the resources deployed by the module"
-  default     = {}
-}
-
 variable "data_tags" {
   type        = map(string)
   description = "A map of tags to apply to all the data and/or storage deployed by the module"


### PR DESCRIPTION
## Describe your changes
As the `tags` variable was defined multiple times for the postgres module, using the module would fail with the error `Duplicate variable declaration`.

## Issue ticket number and link
None.

## Checklist before requesting a review
- [X] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
   - **I don't have permissions to see this guide - is this something internal for Cloud Engineering?**
- [X] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
    **- This could go into a `patch` release. `release:patch` is not a valid git tag name. So can't tag my branch with this.. Is this a GitHub label instead?** 
