### PR TITLE
Set tag dfds.env from environment for postgres

### DIFF
--- a/_sub/database/postgres/main.tf
+++ b/_sub/database/postgres/main.tf
@@ -1,7 +1,7 @@
 locals {
   engine_family     = var.engine_version == null ? "postgres13" : "postgres${substr(var.engine_version, 0, 2)}"
-  rds_instance_tags = merge({ environment = var.environment }, var.rds_instance_tags, var.tags)
-  tags              = merge({ environment = var.environment }, var.tags)
+  rds_instance_tags = merge({ environment = var.environment, "dfds.env" = var.environment }, var.rds_instance_tags, var.tags)
+  tags              = merge({ environment = var.environment, "dfds.env" = var.environment }, var.tags)
 }
 
 #tfsec:ignore:no-public-ingress-sgr tfsec:ignore:aws-vpc-no-public-ingress-sg


### PR DESCRIPTION
## Describe your changes
In the postgres module the tag `dfds.env` is automatically set to `environment`.
`dfds.env` is part of the required tags from DFDS' tagging policy: https://wiki.dfds.cloud/en/playbooks/standards/tagging_policy

## Issue ticket number and link
None.

## Checklist before requesting a review
- [X] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
