### PR TITLE
feat: allow s3 multiregionaccesspoint

### DIFF
--- a/security/org-policies/restrictive.tf
+++ b/security/org-policies/restrictive.tf
@@ -202,7 +202,14 @@ data "aws_iam_policy_document" "restrictive" {
       "notifications:List*",
       "sns:*",
       "resource-explorer-2:*",
-      "dataexchange:*"
+      "dataexchange:*",
+      "s3:CreateMultiRegionAccessPoint",
+      "s3:DeleteMultiRegionAccessPoint",
+      "s3:PutMultiRegionAccessPointPolicy",
+      "s3:GetMultiRegionAccessPointPolicyStatus",
+      "s3:GetMultiRegionAccessPointPolicy",
+      "s3:GetMultiRegionAccessPoint",
+      "s3:DescribeMultiRegionAccessPointOperation"
     ]
     resources = ["*"]
     condition {


### PR DESCRIPTION
## Describe your changes
This PR removes the restriction for making S3 Multi-Region Access Points. As we restrict creation of buckets to our supported regions there is no need for this restriction.

## Issue ticket number and link

## Checklist before requesting a review
- [ N/A ] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
