### PR TITLE
feat: support custom flux deployments

### DIFF
--- a/_sub/compute/k8s-fluxcd/dependencies.tf
+++ b/_sub/compute/k8s-fluxcd/dependencies.tf
@@ -56,6 +56,17 @@ spec:
     branch: ${var.gitops_apps_repo_branch}
   url: ${var.gitops_apps_repo_url}
 ---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: flux-apps-git
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  ref:
+    branch: ${var.gitops_custom_apps_repo_branch}
+  url: ${var.gitops_custom_apps_repo_url}
+---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -71,4 +82,26 @@ spec:
   path: ./sources
   prune: ${var.prune}
   YAML
+
+  custom_kustomization_yaml = <<YAML
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: custom
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  path: ./platform-apps/${var.cluster_name}/custom
+  prune: ${var.prune}
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  YAML
+
+  custom_folder_readme = <<EOT
+Place custom manifests in here. Make sure to place them in a folder named after the application
+  EOT
 }
+
+  

--- a/_sub/compute/k8s-fluxcd/main.tf
+++ b/_sub/compute/k8s-fluxcd/main.tf
@@ -54,3 +54,19 @@ resource "github_repository_file" "platform_apps_init" {
   content             = local.platform_apps_yaml
   overwrite_on_create = var.overwrite_on_create
 }
+
+resource "github_repository_file" "custom_kustomization" {
+  repository          = var.repository_name
+  branch              = data.github_branch.flux_branch.branch
+  file                = "${local.cluster_target_path}/custom.yaml"
+  content             = local.custom_kustomization_yaml
+  overwrite_on_create = var.overwrite_on_create
+}
+
+resource "github_repository_file" "custom_folder" {
+  repository          = var.repository_name
+  branch              = data.github_branch.flux_branch.branch
+  file                = "platform-apps/${var.cluster_name}/custom/README.md"
+  content             = local.custom_folder_readme
+  overwrite_on_create = var.overwrite_on_create
+}

--- a/_sub/compute/k8s-fluxcd/vars.tf
+++ b/_sub/compute/k8s-fluxcd/vars.tf
@@ -39,6 +39,18 @@ variable "gitops_apps_repo_branch" {
   description = "The default branch for your GitOps manifests"
 }
 
+variable "gitops_custom_apps_repo_branch" {
+  type        = string
+  default     = "main"
+  description = "The default branch for your Custom apps GitOps manifests"
+}
+
+variable "gitops_custom_apps_repo_url" {
+  type        = string
+  default     = ""
+  description = "The https url for your Custom apps GitOps manifests"
+}
+
 variable "kubeconfig_path" {
   type    = string
   default = null

--- a/compute/k8s-services/dependencies.tf
+++ b/compute/k8s-services/dependencies.tf
@@ -261,6 +261,8 @@ locals {
 
 locals {
   fluxcd_apps_repo_url = "${var.fluxcd_apps_git_provider_url}${var.fluxcd_apps_repo_owner}/${var.fluxcd_apps_repo_name}"
+  fluxcd_custom_apps_repo_url = "${var.fluxcd_apps_git_provider_url}${var.fluxcd_apps_repo_owner}/${var.fluxcd_custom_apps_repo_name}"
+
 }
 
 # --------------------------------------------------

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -436,17 +436,19 @@ module "aws_node_service" {
 # --------------------------------------------------
 
 module "platform_fluxcd" {
-  source                  = "../../_sub/compute/k8s-fluxcd"
-  release_tag             = var.fluxcd_version
-  repository_name         = var.fluxcd_bootstrap_repo_name
-  branch                  = var.fluxcd_bootstrap_repo_branch
-  github_owner            = var.fluxcd_bootstrap_repo_owner
-  overwrite_on_create     = var.fluxcd_bootstrap_overwrite_on_create
-  gitops_apps_repo_url    = local.fluxcd_apps_repo_url
-  gitops_apps_repo_branch = var.fluxcd_apps_repo_branch
-  cluster_name            = var.eks_cluster_name
-  kubeconfig_path         = local.kubeconfig_path
-  prune                   = var.fluxcd_prune
+  source                         = "../../_sub/compute/k8s-fluxcd"
+  release_tag                    = var.fluxcd_version
+  repository_name                = var.fluxcd_bootstrap_repo_name
+  branch                         = var.fluxcd_bootstrap_repo_branch
+  github_owner                   = var.fluxcd_bootstrap_repo_owner
+  overwrite_on_create            = var.fluxcd_bootstrap_overwrite_on_create
+  gitops_apps_repo_url           = local.fluxcd_apps_repo_url
+  gitops_apps_repo_branch        = var.fluxcd_apps_repo_branch
+  gitops_custom_apps_repo_url    = local.fluxcd_custom_apps_repo_url
+  gitops_custom_apps_repo_branch = var.fluxcd_custom_apps_repo_branch
+  cluster_name                   = var.eks_cluster_name
+  kubeconfig_path                = local.kubeconfig_path
+  prune                          = var.fluxcd_prune
 
   providers = {
     github = github.fluxcd

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -488,6 +488,18 @@ variable "fluxcd_apps_repo_branch" {
   description = "The default branch for your GitOps manifests"
 }
 
+variable "fluxcd_custom_apps_repo_name" {
+  type        = string
+  default     = ""
+  description = "The repo name for your Custom GitOps manifests"
+}
+
+variable "fluxcd_custom_apps_repo_branch" {
+  type        = string
+  default     = "main"
+  description = "The default branch for your Custom GitOps manifests"
+}
+
 variable "fluxcd_apps_repo_owner" {
   type        = string
   default     = "main"


### PR DESCRIPTION
## Describe your changes
This PR will allow for application deployments via PR's into a "custom" folder inside our flux manifests repository per cluster.

Simply create a folder inside your "platform-apps/[cluster-name]/custom" folder with some Kubernetes manifests and they will be automatically deployed.

I.e to deploy an application called "test-app" into the "cluster1" k8s cluster, in the flux mainfests repo create a folder at "platform-apps/cluster1/custom/test-app" and in there place your "deployment.yaml"

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
