### PR TITLE
fix: remove unused flux repo and vars accidentally left in

### DIFF
--- a/_sub/compute/k8s-fluxcd/dependencies.tf
+++ b/_sub/compute/k8s-fluxcd/dependencies.tf
@@ -56,17 +56,6 @@ spec:
     branch: ${var.gitops_apps_repo_branch}
   url: ${var.gitops_apps_repo_url}
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: GitRepository
-metadata:
-  name: flux-apps-git
-  namespace: flux-system
-spec:
-  interval: 1m0s
-  ref:
-    branch: ${var.gitops_custom_apps_repo_branch}
-  url: ${var.gitops_custom_apps_repo_url}
----
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/_sub/compute/k8s-fluxcd/vars.tf
+++ b/_sub/compute/k8s-fluxcd/vars.tf
@@ -39,18 +39,6 @@ variable "gitops_apps_repo_branch" {
   description = "The default branch for your GitOps manifests"
 }
 
-variable "gitops_custom_apps_repo_branch" {
-  type        = string
-  default     = "main"
-  description = "The default branch for your Custom apps GitOps manifests"
-}
-
-variable "gitops_custom_apps_repo_url" {
-  type        = string
-  default     = ""
-  description = "The https url for your Custom apps GitOps manifests"
-}
-
 variable "kubeconfig_path" {
   type    = string
   default = null

--- a/compute/k8s-services/dependencies.tf
+++ b/compute/k8s-services/dependencies.tf
@@ -261,8 +261,6 @@ locals {
 
 locals {
   fluxcd_apps_repo_url = "${var.fluxcd_apps_git_provider_url}${var.fluxcd_apps_repo_owner}/${var.fluxcd_apps_repo_name}"
-  fluxcd_custom_apps_repo_url = "${var.fluxcd_apps_git_provider_url}${var.fluxcd_apps_repo_owner}/${var.fluxcd_custom_apps_repo_name}"
-
 }
 
 # --------------------------------------------------

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -444,8 +444,6 @@ module "platform_fluxcd" {
   overwrite_on_create            = var.fluxcd_bootstrap_overwrite_on_create
   gitops_apps_repo_url           = local.fluxcd_apps_repo_url
   gitops_apps_repo_branch        = var.fluxcd_apps_repo_branch
-  gitops_custom_apps_repo_url    = local.fluxcd_custom_apps_repo_url
-  gitops_custom_apps_repo_branch = var.fluxcd_custom_apps_repo_branch
   cluster_name                   = var.eks_cluster_name
   kubeconfig_path                = local.kubeconfig_path
   prune                          = var.fluxcd_prune

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -488,18 +488,6 @@ variable "fluxcd_apps_repo_branch" {
   description = "The default branch for your GitOps manifests"
 }
 
-variable "fluxcd_custom_apps_repo_name" {
-  type        = string
-  default     = ""
-  description = "The repo name for your Custom GitOps manifests"
-}
-
-variable "fluxcd_custom_apps_repo_branch" {
-  type        = string
-  default     = "main"
-  description = "The default branch for your Custom GitOps manifests"
-}
-
 variable "fluxcd_apps_repo_owner" {
   type        = string
   default     = "main"


### PR DESCRIPTION
## Describe your changes
Remove some variables and flux git repository accidentally left in the flux module

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
