### PR TITLE
Add Grafana Agent

### DIFF
--- a/_sub/monitoring/helm-grafana-agent/main.tf
+++ b/_sub/monitoring/helm-grafana-agent/main.tf
@@ -1,0 +1,25 @@
+resource "helm_release" "grafana_agent" {
+  name             = "grafana-k8s-monitoring"
+  repository       = var.helm_repo_url
+  chart            = "k8s-monitoring"
+  version          = var.helm_chart_version
+  namespace        = var.namespace
+  atomic           = var.atomic
+  timeout          = var.timeout
+  create_namespace = var.create_namespace
+
+  values = [
+    templatefile("${path.module}/values/values.yaml", {
+      cluster_name        = var.cluster_name,
+      api_token           = var.api_token,
+      prometheus_url      = var.prometheus_url,
+      prometheus_username = var.prometheus_username,
+      loki_url            = var.loki_url,
+      loki_username       = var.loki_username,
+      tempo_url           = var.tempo_url,
+      tempo_username      = var.tempo_username,
+      traces_enabled      = var.traces_enabled
+      enable_side_by_side = var.enable_side_by_side
+    }),
+  ]
+}

--- a/_sub/monitoring/helm-grafana-agent/main.tf
+++ b/_sub/monitoring/helm-grafana-agent/main.tf
@@ -2,7 +2,7 @@ resource "helm_release" "grafana_agent" {
   name             = "grafana-k8s-monitoring"
   repository       = var.helm_repo_url
   chart            = "k8s-monitoring"
-  version          = var.helm_chart_version
+  version          = var.chart_version
   namespace        = var.namespace
   atomic           = var.atomic
   timeout          = var.timeout

--- a/_sub/monitoring/helm-grafana-agent/values/values.yaml
+++ b/_sub/monitoring/helm-grafana-agent/values/values.yaml
@@ -1,0 +1,39 @@
+cluster:
+  name: ${cluster_name}
+externalServices:
+  prometheus:
+    host: ${prometheus_url}
+    basicAuth:
+      username: "${prometheus_username}"
+      password: ${api_token}
+  loki:
+    host: ${loki_url}
+    basicAuth:
+      username: ${loki_username}
+      password: ${api_token}
+  tempo:
+    host: ${tempo_url}
+    basicAuth:
+      username: ${tempo_username}
+      password: ${api_token}
+opencost:
+  opencost:
+    exporter:
+      defaultClusterId: ${cluster_name}
+    prometheus:
+      external:
+        url: ${prometheus_url}/api/prom
+traces:
+  enabled: ${traces_enabled}
+%{ if enable_side_by_side ~}
+metrics:
+  node-exporter:
+    labelMatchers:
+      app.kubernetes.io/name: prometheus-node-exporter
+    service:
+      isTLS: false
+prometheus-node-exporter:
+  enabled: false
+prometheus-operator-crds:
+  enabled: false
+%{ endif ~}

--- a/_sub/monitoring/helm-grafana-agent/vars.tf
+++ b/_sub/monitoring/helm-grafana-agent/vars.tf
@@ -3,12 +3,12 @@ variable "helm_repo_url" {
   description = "The repository URL for the Grafana Agent Helm chart"
   default     = "https://grafana.github.io/helm-charts"
   validation {
-    condition     = var.helm_repo_url == null || can(regex("^(https:\\/\\/)+", var.helm_repo_url))
+    condition     = var.helm_repo_url != null || can(regex("^(https:\\/\\/)+", var.helm_repo_url))
     error_message = "The value for var.helm_repo_url must start with https://"
   }
 }
 
-variable "helm_chart_version" {
+variable "chart_version" {
   type        = string
   description = "Grafana Agent helm chart version"
   default     = null
@@ -57,7 +57,7 @@ variable "api_token" {
   description = "The token to authenticate request to a Grafana Cloud stack"
   default     = null
   validation {
-    condition     = var.api_token == null || can(regex("^(glc\\_)+", var.api_token))
+    condition     = var.api_token != null || can(regex("^(glc\\_)+", var.api_token))
     error_message = "The value for var.api_token must start with glc_"
   }
 }
@@ -67,7 +67,7 @@ variable "prometheus_url" {
   description = "The Prometheus URL in a Grafana Cloud stack"
   default     = null
   validation {
-    condition     = var.prometheus_url == null || can(regex("^(https:\\/\\/)+", var.prometheus_url))
+    condition     = var.prometheus_url != null || can(regex("^(https:\\/\\/)+", var.prometheus_url))
     error_message = "The value for var.prometheus_url must start with https://"
   }
 }
@@ -77,8 +77,8 @@ variable "prometheus_username" {
   description = "The username for Prometheus in a Grafana Cloud stack"
   default     = null
   validation {
-    condition     = var.prometheus_username == null
-    error_message = "The value for var.prometheus_username must not be undefined"
+    condition     = var.prometheus_username != null || length(var.prometheus_username) > 0
+    error_message = "The value for var.prometheus_username must be defined"
   }
 }
 
@@ -87,7 +87,7 @@ variable "loki_url" {
   description = "The Loki URL in a Grafana Cloud stack"
   default     = null
   validation {
-    condition     = var.loki_url == null || can(regex("^(https:\\/\\/)+", var.loki_url))
+    condition     = var.loki_url != null || can(regex("^(https:\\/\\/)+", var.loki_url))
     error_message = "The value for var.loki_url must start with https://"
   }
 }
@@ -97,8 +97,8 @@ variable "loki_username" {
   description = "The username for Loki in a Grafana Cloud stack"
   default     = null
   validation {
-    condition     = var.loki_username == null
-    error_message = "The value for var.loki_username must not be undefined"
+    condition     = var.loki_username != null || length(var.loki_username) > 0
+    error_message = "The value for var.loki_username must be defined"
   }
 }
 
@@ -107,7 +107,7 @@ variable "tempo_url" {
   description = "The Tempo URL in a Grafana Cloud stack"
   default     = null
   validation {
-    condition     = var.tempo_url == null || can(regex("^(https:\\/\\/)+", var.tempo_url))
+    condition     = var.tempo_url != null || can(regex("^(https:\\/\\/)+", var.tempo_url))
     error_message = "The value for var.tempo_url must start with https://"
   }
 }
@@ -117,8 +117,8 @@ variable "tempo_username" {
   description = "The username for Tempo in a Grafana Cloud stack"
   default     = null
   validation {
-    condition     = var.tempo_username == null
-    error_message = "The value for var.tempo_username must not be undefined"
+    condition     = var.tempo_username != null || length(var.tempo_username) > 0
+    error_message = "The value for var.tempo_username must be defined"
   }
 }
 

--- a/_sub/monitoring/helm-grafana-agent/vars.tf
+++ b/_sub/monitoring/helm-grafana-agent/vars.tf
@@ -56,6 +56,7 @@ variable "api_token" {
   type        = string
   description = "The token to authenticate request to a Grafana Cloud stack"
   default     = null
+  sensitive   = true
   validation {
     condition     = var.api_token != null || can(regex("^(glc\\_)+", var.api_token))
     error_message = "The value for var.api_token must start with glc_"

--- a/_sub/monitoring/helm-grafana-agent/vars.tf
+++ b/_sub/monitoring/helm-grafana-agent/vars.tf
@@ -1,0 +1,136 @@
+variable "helm_repo_url" {
+  type        = string
+  description = "The repository URL for the Grafana Agent Helm chart"
+  default     = "https://grafana.github.io/helm-charts"
+  validation {
+    condition     = var.helm_repo_url == null || can(regex("^(https:\\/\\/)+", var.helm_repo_url))
+    error_message = "The value for var.helm_repo_url must start with https://"
+  }
+}
+
+variable "helm_chart_version" {
+  type        = string
+  description = "Grafana Agent helm chart version"
+  default     = null
+}
+
+variable "namespace" {
+  type        = string
+  description = "Namespace to apply Grafana Agent in"
+  default     = "grafana-agent"
+  validation {
+    condition     = can(regex("[a-z]+", var.namespace))
+    error_message = "Namespace must contain at least one letter."
+  }
+}
+
+variable "create_namespace" {
+  type        = bool
+  default     = true
+  description = "Create the namespace if it does not yet exist. Default: true"
+}
+
+variable "atomic" {
+  type        = bool
+  default     = true
+  description = "Installation process purges chart on fail. The wait flag will be set automatically if atomic is used. Default: true"
+}
+
+variable "timeout" {
+  type        = number
+  default     = 120
+  description = "Time in seconds to wait for any individual kubernetes operation (like Jobs for hooks). Default: 120"
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "Kubernetes cluster to install the Grafana Agent in"
+  default     = "grafana-agent"
+  validation {
+    condition     = can(regex("[a-z]+", var.cluster_name))
+    error_message = "Cluster name must contain at least one letter."
+  }
+}
+
+variable "api_token" {
+  type        = string
+  description = "The token to authenticate request to a Grafana Cloud stack"
+  default     = null
+  validation {
+    condition     = var.api_token == null || can(regex("^(glc\\_)+", var.api_token))
+    error_message = "The value for var.api_token must start with glc_"
+  }
+}
+
+variable "prometheus_url" {
+  type        = string
+  description = "The Prometheus URL in a Grafana Cloud stack"
+  default     = null
+  validation {
+    condition     = var.prometheus_url == null || can(regex("^(https:\\/\\/)+", var.prometheus_url))
+    error_message = "The value for var.prometheus_url must start with https://"
+  }
+}
+
+variable "prometheus_username" {
+  type        = string
+  description = "The username for Prometheus in a Grafana Cloud stack"
+  default     = null
+  validation {
+    condition     = var.prometheus_username == null
+    error_message = "The value for var.prometheus_username must not be undefined"
+  }
+}
+
+variable "loki_url" {
+  type        = string
+  description = "The Loki URL in a Grafana Cloud stack"
+  default     = null
+  validation {
+    condition     = var.loki_url == null || can(regex("^(https:\\/\\/)+", var.loki_url))
+    error_message = "The value for var.loki_url must start with https://"
+  }
+}
+
+variable "loki_username" {
+  type        = string
+  description = "The username for Loki in a Grafana Cloud stack"
+  default     = null
+  validation {
+    condition     = var.loki_username == null
+    error_message = "The value for var.loki_username must not be undefined"
+  }
+}
+
+variable "tempo_url" {
+  type        = string
+  description = "The Tempo URL in a Grafana Cloud stack"
+  default     = null
+  validation {
+    condition     = var.tempo_url == null || can(regex("^(https:\\/\\/)+", var.tempo_url))
+    error_message = "The value for var.tempo_url must start with https://"
+  }
+}
+
+variable "tempo_username" {
+  type        = string
+  description = "The username for Tempo in a Grafana Cloud stack"
+  default     = null
+  validation {
+    condition     = var.tempo_username == null
+    error_message = "The value for var.tempo_username must not be undefined"
+  }
+}
+
+variable "traces_enabled" {
+  type        = bool
+  default     = true
+  description = "Enable traces or not. Default: true"
+}
+
+variable "enable_side_by_side" {
+  type        = bool
+  default     = true
+  description = "Allow Grafana Agent to be installed side by side with kube-prometheus-stack and use its CRDs and its node-exporter. Default: true"
+}
+

--- a/_sub/monitoring/helm-grafana-agent/versions.tf
+++ b/_sub/monitoring/helm-grafana-agent/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.3.0, < 1.6.0"
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.12.0"
+    }
+  }
+}

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -28,6 +28,13 @@ resources:
         TF_VAR_crossplane_provider_confluent_email: $(CROSSPLANE_PROVIDER_CONFLUENT_EMAIL)
         TF_VAR_crossplane_provider_confluent_password: $(CROSSPLANE_PROVIDER_CONFLUENT_PASSWORD)
         TF_VAR_monitoring_kube_prometheus_stack_azure_tenant_id: $(ARM_TENANT_ID)
+        TF_VAR_grafana_agent_api_token: $(TF_VAR_grafana_agent_api_token)
+        TF_VAR_grafana_agent_prometheus_url: $(TF_VAR_grafana_agent_prometheus_url)
+        TF_VAR_grafana_agent_prometheus_username: $(TF_VAR_grafana_agent_prometheus_username)
+        TF_VAR_grafana_agent_loki_url: $(TF_VAR_grafana_agent_loki_url)
+        TF_VAR_grafana_agent_loki_username: $(TF_VAR_grafana_agent_loki_username)
+        TF_VAR_grafana_agent_tempo_url: $(TF_VAR_grafana_agent_tempo_url)
+        TF_VAR_grafana_agent_tempo_username: $(TF_VAR_grafana_agent_tempo_username)
     - container: aws-nuke
       image: dfdsdk/aws-nuke:0.0.19
       env:

--- a/compute/k8s-services/dependencies.tf
+++ b/compute/k8s-services/dependencies.tf
@@ -300,6 +300,20 @@ locals {
     PRODUCTION_AWS_ACCOUNT_MANIFESTS_HARDENED_MONITORING_SLACK_TOKEN    = var.aws_account_manifests_hardened_monitoring_slack_token
     CONFLUENT_KAFKA_PROD_PROMETHEUS_METRICS_EXPORTER_HELLMAN_API_KEY    = var.monitoring_kube_prometheus_stack_prometheus_confluent_metrics_api_key
     CONFLUENT_KAFKA_PROD_PROMETHEUS_METRICS_EXPORTER_HELLMAN_API_SECRET = var.monitoring_kube_prometheus_stack_prometheus_confluent_metrics_api_secret
+    PRODUCTION_GRAFANA_AGENT_API_TOKEN                                  = var.grafana_agent_api_token
+    PRODUCTION_GRAFANA_AGENT_PROMETHEUS_URL                             = var.grafana_agent_prometheus_url
+    PRODUCTION_GRAFANA_AGENT_PROMETHEUS_USERNAME                        = var.grafana_agent_prometheus_username
+    PRODUCTION_GRAFANA_AGENT_LOKI_URL                                   = var.grafana_agent_loki_url
+    PRODUCTION_GRAFANA_AGENT_LOKI_USERNAME                              = var.grafana_agent_loki_username
+    PRODUCTION_GRAFANA_AGENT_TEMPO_URL                                  = var.grafana_agent_tempo_url
+    PRODUCTION_GRAFANA_AGENT_TEMPO_USERNAME                             = var.grafana_agent_tempo_username
+    STAGING_GRAFANA_AGENT_API_TOKEN                                     = var.staging_grafana_agent_api_token
+    STAGING_GRAFANA_AGENT_PROMETHEUS_URL                                = var.staging_grafana_agent_prometheus_url
+    STAGING_GRAFANA_AGENT_PROMETHEUS_USERNAME                           = var.staging_grafana_agent_prometheus_username
+    STAGING_GRAFANA_AGENT_LOKI_URL                                      = var.staging_grafana_agent_loki_url
+    STAGING_GRAFANA_AGENT_LOKI_USERNAME                                 = var.staging_grafana_agent_loki_username
+    STAGING_GRAFANA_AGENT_TEMPO_URL                                     = var.staging_grafana_agent_tempo_url
+    STAGING_GRAFANA_AGENT_TEMPO_USERNAME                                = var.staging_grafana_agent_tempo_username
   }
 
   atlantis_env_vars = var.crossplane_deploy ? merge(local.atlantis_env_vars_default, local.confluent_env_vars_for_atlantis) : local.atlantis_env_vars_default

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -802,3 +802,23 @@ module "elb_inactivity_cleanup_auth" {
   elb_name             = module.traefik_alb_auth.alb_name
   elb_arn              = module.traefik_alb_auth.alb_arn
 }
+
+
+# --------------------------------------------------
+# Grafana Agent for Kubernetes monitoring
+# --------------------------------------------------
+
+module "grafana_agent_k8s_monitoring" {
+  source              = "../../_sub/monitoring/helm-grafana-agent"
+  count               = var.grafana_agent_deploy ? 1 : 0
+  chart_version       = var.grafana_agent_chart_version
+  cluster_name        = var.eks_cluster_name
+  api_token           = var.grafana_agent_api_token
+  prometheus_url      = var.grafana_agent_prometheus_url
+  prometheus_username = var.grafana_agent_prometheus_username
+  loki_url            = var.grafana_agent_loki_url
+  loki_username       = var.grafana_agent_loki_username
+  tempo_url           = var.grafana_agent_tempo_url
+  tempo_username      = var.grafana_agent_tempo_username
+  traces_enabled      = var.grafana_agent_traces_enabled
+}

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -1180,3 +1180,94 @@ variable "disable_inactivity_cleanup" {
   default     = false
   description = "Disables automated clean up of ELB resources based on inactivity. Only applicable to sandboxes."
 }
+
+# --------------------------------------------------
+# Grafana Agent for Kubernetes monitoring
+# --------------------------------------------------
+
+variable "grafana_agent_deploy" {
+  type        = string
+  default     = false
+  description = "Feature toggle for Grafana Agent module"
+}
+
+variable "grafana_agent_chart_version" {
+  type        = string
+  description = "Grafana Agent helm chart version"
+  default     = null
+}
+
+variable "grafana_agent_api_token" {
+  type        = string
+  description = "The token to authenticate request to a Grafana Cloud stack"
+  default     = null
+  validation {
+    condition     = var.grafana_agent_api_token != null || can(regex("^(glc\\_)+", var.grafana_agent_api_token))
+    error_message = "The value for var.grafana_agent_api_token must start with glc_"
+  }
+}
+
+variable "grafana_agent_prometheus_url" {
+  type        = string
+  description = "The Prometheus URL in a Grafana Cloud stack"
+  default     = null
+  validation {
+    condition     = var.grafana_agent_prometheus_url != null || can(regex("^(https:\\/\\/)+", var.grafana_agent_prometheus_url))
+    error_message = "The value for var.grafana_agent_prometheus_url must start with https://"
+  }
+}
+
+variable "grafana_agent_prometheus_username" {
+  type        = string
+  description = "The username for Prometheus in a Grafana Cloud stack"
+  validation {
+    condition     = var.grafana_agent_prometheus_username != null || length(var.grafana_agent_prometheus_username) > 0
+    error_message = "The value for var.grafana_agent_prometheus_username must be defined"
+  }
+}
+
+variable "grafana_agent_loki_url" {
+  type        = string
+  description = "The Loki URL in a Grafana Cloud stack"
+  default     = null
+  validation {
+    condition     = var.grafana_agent_loki_url != null || can(regex("^(https:\\/\\/)+", var.grafana_agent_loki_url))
+    error_message = "The value for var.grafana_agent_loki_url must start with https://"
+  }
+}
+
+variable "grafana_agent_loki_username" {
+  type        = string
+  description = "The username for Loki in a Grafana Cloud stack"
+  default     = null
+  validation {
+    condition     = var.grafana_agent_loki_username != null || length(var.grafana_agent_loki_username) > 0
+    error_message = "The value for var.grafana_agent_loki_username must be defined"
+  }
+}
+
+variable "grafana_agent_tempo_url" {
+  type        = string
+  description = "The Tempo URL in a Grafana Cloud stack"
+  default     = null
+  validation {
+    condition     = var.grafana_agent_tempo_url != null || can(regex("^(https:\\/\\/)+", var.grafana_agent_tempo_url))
+    error_message = "The value for var.grafana_agent_tempo_url must start with https://"
+  }
+}
+
+variable "grafana_agent_tempo_username" {
+  type        = string
+  description = "The username for Tempo in a Grafana Cloud stack"
+  default     = null
+  validation {
+    condition     = var.grafana_agent_tempo_username != null || length(var.grafana_agent_tempo_username) > 0
+    error_message = "The value for var.grafana_agent_tempo_username must be defined"
+  }
+}
+
+variable "grafana_agent_traces_enabled" {
+  type        = bool
+  default     = true
+  description = "Enable traces or not. Default: true"
+}

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -1276,42 +1276,42 @@ variable "grafana_agent_traces_enabled" {
 variable "staging_grafana_agent_api_token" {
   type        = string
   description = "The token to authenticate request to a Grafana Cloud stack"
-  default     = null
+  default     = ""
   sensitive   = true
 }
 
 variable "staging_grafana_agent_prometheus_url" {
   type        = string
   description = "The Prometheus URL in a Grafana Cloud stack"
-  default     = null
+  default     = ""
 }
 
 variable "staging_grafana_agent_prometheus_username" {
   type        = string
   description = "The username for Prometheus in a Grafana Cloud stack"
-  default     = null
+  default     = ""
 }
 
 variable "staging_grafana_agent_loki_url" {
   type        = string
   description = "The Loki URL in a Grafana Cloud stack"
-  default     = null
+  default     = ""
 }
 
 variable "staging_grafana_agent_loki_username" {
   type        = string
   description = "The username for Loki in a Grafana Cloud stack"
-  default     = null
+  default     = ""
 }
 
 variable "staging_grafana_agent_tempo_url" {
   type        = string
   description = "The Tempo URL in a Grafana Cloud stack"
-  default     = null
+  default     = ""
 }
 
 variable "staging_grafana_agent_tempo_username" {
   type        = string
   description = "The username for Tempo in a Grafana Cloud stack"
-  default     = null
+  default     = ""
 }

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -1201,6 +1201,7 @@ variable "grafana_agent_api_token" {
   type        = string
   description = "The token to authenticate request to a Grafana Cloud stack"
   default     = null
+  sensitive   = true
   validation {
     condition     = var.grafana_agent_api_token != null || can(regex("^(glc\\_)+", var.grafana_agent_api_token))
     error_message = "The value for var.grafana_agent_api_token must start with glc_"

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -1272,3 +1272,46 @@ variable "grafana_agent_traces_enabled" {
   default     = true
   description = "Enable traces or not. Default: true"
 }
+
+variable "staging_grafana_agent_api_token" {
+  type        = string
+  description = "The token to authenticate request to a Grafana Cloud stack"
+  default     = null
+  sensitive   = true
+}
+
+variable "staging_grafana_agent_prometheus_url" {
+  type        = string
+  description = "The Prometheus URL in a Grafana Cloud stack"
+  default     = null
+}
+
+variable "staging_grafana_agent_prometheus_username" {
+  type        = string
+  description = "The username for Prometheus in a Grafana Cloud stack"
+  default     = null
+}
+
+variable "staging_grafana_agent_loki_url" {
+  type        = string
+  description = "The Loki URL in a Grafana Cloud stack"
+  default     = null
+}
+
+variable "staging_grafana_agent_loki_username" {
+  type        = string
+  description = "The username for Loki in a Grafana Cloud stack"
+  default     = null
+}
+
+variable "staging_grafana_agent_tempo_url" {
+  type        = string
+  description = "The Tempo URL in a Grafana Cloud stack"
+  default     = null
+}
+
+variable "staging_grafana_agent_tempo_username" {
+  type        = string
+  description = "The username for Tempo in a Grafana Cloud stack"
+  default     = null
+}

--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -269,4 +269,10 @@ inputs = {
   velero_plugin_for_aws_version = "v1.7.0"
   velero_plugin_for_csi_version = "v0.5.0"
 
+  # --------------------------------------------------
+  # Grafana Agent for Kubernetes monitoring
+  # --------------------------------------------------
+
+  grafana_agent_deploy = true
+
 }


### PR DESCRIPTION
- Add sub module for installing Grafana Agent in Kubernetes using Helm.
- Install Grafana Agent in Kubernetes using Helm
- Mark the Grafana Cloud API token variable as sensitive
- Enable Grafana Agent in QA

## Describe your changes
<!--Describe the change here-->

## Issue ticket number and link
https://github.com/dfds/cloudplatform/issues/2502

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
