### PR TITLE
This is to allow accounts to be deleted using root on capability deletion process.

### DIFF
--- a/security/org-policies/restrictive.tf
+++ b/security/org-policies/restrictive.tf
@@ -136,7 +136,6 @@ data "aws_iam_policy_document" "restrictive" {
     effect = "Deny"
     not_actions = [
       "access-analyzer:*",
-      "account:CloseAccount",
       "account:Get*",
       "account:List*",
       "account:PutAlternateContact",
@@ -261,6 +260,28 @@ data "aws_iam_policy_document" "restrictive" {
         "arn:aws:iam::*:role/OrgRole",
         "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_CloudAdmin_*",
         "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_Billing_*",
+      ]
+      variable = "aws:PrincipalArn"
+    }
+  }
+
+  statement {
+    sid    = "DenyCloseAccountForNonRoot"
+    effect = "Deny"
+    actions = "account:CloseAccount"
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "AllowCloseAccountForRoot"
+    effect = "Allow"
+    actions = "account:CloseAccount"
+    resources = ["*"]
+
+    condition {
+      test = "StringLike"
+      values = [
+        "arn:aws:iam::*:root"
       ]
       variable = "aws:PrincipalArn"
     }

--- a/security/org-policies/restrictive.tf
+++ b/security/org-policies/restrictive.tf
@@ -136,6 +136,7 @@ data "aws_iam_policy_document" "restrictive" {
     effect = "Deny"
     not_actions = [
       "access-analyzer:*",
+      "account:CloseAccount",
       "account:Get*",
       "account:List*",
       "account:PutAlternateContact",
@@ -270,16 +271,9 @@ data "aws_iam_policy_document" "restrictive" {
     effect = "Deny"
     actions = "account:CloseAccount"
     resources = ["*"]
-  }
-
-  statement {
-    sid    = "AllowCloseAccountForRoot"
-    effect = "Allow"
-    actions = "account:CloseAccount"
-    resources = ["*"]
-
+  
     condition {
-      test = "StringLike"
+      test = "StringNotLike"
       values = [
         "arn:aws:iam::*:root"
       ]

--- a/security/org-policies/restrictive.tf
+++ b/security/org-policies/restrictive.tf
@@ -136,6 +136,7 @@ data "aws_iam_policy_document" "restrictive" {
     effect = "Deny"
     not_actions = [
       "access-analyzer:*",
+      "account:CloseAccount",
       "account:Get*",
       "account:List*",
       "account:PutAlternateContact",


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
During a capability deletion process I identified that a policy change was needed in order to be able to delete the AWS account using the root account.

## Issue ticket number and link


## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
