### PR TITLE
Add support for OIDC trust with GitHub for Terraform/Terragrunt

### DIFF
--- a/_sub/security/iam-github-oidc-provider/main.tf
+++ b/_sub/security/iam-github-oidc-provider/main.tf
@@ -1,14 +1,14 @@
 resource "aws_iam_openid_connect_provider" "github" {
-  client_id_list  = ["sts.amazonaws.com"]
+  client_id_list = ["sts.amazonaws.com"]
   thumbprint_list = [
     "6938fd4d98bab03faadb97b34396831e3780aea1",
     "1c58a3a8518e8759bf075b76b750d4f2df264fcd"
   ]
-  url             = "https://token.actions.githubusercontent.com"
+  url = "https://token.actions.githubusercontent.com"
 }
 
 resource "aws_iam_role" "this" {
-  name               = "oidc-role"
+  name               = var.oidc_role_name
   assume_role_policy = data.aws_iam_policy_document.trust.json
 }
 
@@ -34,7 +34,7 @@ data "aws_iam_policy_document" "trust" {
 }
 
 resource "aws_iam_role_policy" "this" {
-  name   = "oidc-access"
+  name   = var.oidc_policy_name
   policy = data.aws_iam_policy_document.oidc_access.json
   role   = aws_iam_role.this.id
 }

--- a/_sub/security/iam-github-oidc-provider/vars.tf
+++ b/_sub/security/iam-github-oidc-provider/vars.tf
@@ -27,5 +27,5 @@ variable "oidc_role_name" {
 variable "oidc_policy_name" {
   type        = string
   default     = "oidc-access"
-  description = "Name of the role to create"
+  description = "Name of the policy to create"
 }

--- a/_sub/security/iam-github-oidc-provider/vars.tf
+++ b/_sub/security/iam-github-oidc-provider/vars.tf
@@ -5,7 +5,7 @@ variable "repositories" {
   }))
   description = "List of repositories to authenticate to AWS from. Each object contains repository name and list of git refs that should be allowed to deploy from"
   validation {
-    condition = alltrue([ for v in flatten(values({ for repo in var.repositories : repo.repository_name => repo.refs })) : startswith(v, "refs/heads/") || startswith(v, "refs/tags/") ])
+    condition     = alltrue([for v in flatten(values({ for repo in var.repositories : repo.repository_name => repo.refs })) : startswith(v, "refs/heads/") || startswith(v, "refs/tags/")])
     error_message = "The ref needs to start with `refs/heads/` for branches and `refs/tags/` for tags."
   }
 }
@@ -16,4 +16,16 @@ variable "oidc_role_access" {
     resources = list(string)
   }))
   description = "List of allowed actions for the oidc-role"
+}
+
+variable "oidc_role_name" {
+  type        = string
+  default     = "oidc-role"
+  description = "Name of the role to create"
+}
+
+variable "oidc_policy_name" {
+  type        = string
+  default     = "oidc-access"
+  description = "Name of the role to create"
 }

--- a/security/org-account/main.tf
+++ b/security/org-account/main.tf
@@ -111,3 +111,17 @@ resource "aws_resourceexplorer2_index" "eu-west-1" {
 
   provider = aws.workload_eu-west-1
 }
+
+module "iam_github_oidc_provider" {
+  count  = var.iam_github_oidc_enabled ? 1 : 0
+  source = "../../_sub/security/iam-github-oidc-provider"
+
+  repositories     = var.iam_github_oidc_repositories
+  oidc_role_access = var.iam_github_oidc_policy_json
+  oidc_role_name   = var.iam_github_oidc_role_name
+  oidc_policy_name = var.iam_github_oidc_policy_name
+
+  providers = {
+    aws = aws.workload
+  }
+}

--- a/security/org-account/vars.tf
+++ b/security/org-account/vars.tf
@@ -60,7 +60,7 @@ variable "iam_github_oidc_repositories" {
   }))
   description = "List of repositories to authenticate to AWS from. Each object contains repository name and list of git refs that should be allowed to deploy from"
   validation {
-    condition     = alltrue([for v in flatten(values({ for repo in var.repositories : repo.repository_name => repo.refs })) : startswith(v, "refs/heads/") || startswith(v, "refs/tags/")])
+    condition     = alltrue([for v in flatten(values({ for repo in var.iam_github_oidc_repositories : repo.repository_name => repo.refs })) : startswith(v, "refs/heads/") || startswith(v, "refs/tags/")])
     error_message = "The ref needs to start with `refs/heads/` for branches and `refs/tags/` for tags."
   }
 }

--- a/security/org-account/vars.tf
+++ b/security/org-account/vars.tf
@@ -46,3 +46,41 @@ variable "tags" {
   description = "A map of tags to apply to all the resources deployed by the module"
   default     = {}
 }
+
+variable "iam_github_oidc_enabled" {
+  type        = bool
+  description = "Enable or disable the creation of the IAM role for GitHub OIDC"
+  default     = false
+}
+
+variable "iam_github_oidc_repositories" {
+  type = list(object({
+    repository_name = string
+    refs            = list(string)
+  }))
+  description = "List of repositories to authenticate to AWS from. Each object contains repository name and list of git refs that should be allowed to deploy from"
+  validation {
+    condition     = alltrue([for v in flatten(values({ for repo in var.repositories : repo.repository_name => repo.refs })) : startswith(v, "refs/heads/") || startswith(v, "refs/tags/")])
+    error_message = "The ref needs to start with `refs/heads/` for branches and `refs/tags/` for tags."
+  }
+}
+
+variable "iam_github_oidc_policy_json" {
+  type = list(object({
+    actions   = list(string)
+    resources = list(string)
+  }))
+  description = "List of allowed actions for the oidc-role"
+}
+
+variable "iam_github_oidc_role_name" {
+  type        = string
+  default     = "oidc-role"
+  description = "Name of the role to create"
+}
+
+variable "iam_github_oidc_policy_name" {
+  type        = string
+  default     = "oidc-access"
+  description = "Name of the role to create"
+}

--- a/security/org-account/vars.tf
+++ b/security/org-account/vars.tf
@@ -82,5 +82,5 @@ variable "iam_github_oidc_role_name" {
 variable "iam_github_oidc_policy_name" {
   type        = string
   default     = "oidc-access"
-  description = "Name of the role to create"
+  description = "Name of the policy to create"
 }


### PR DESCRIPTION
## Describe your changes
This feature will create an OIDC provider for Github, an IAM policy and an IAM role that can be used to trust between AWS and GitHub Actions, so Terraform/Terragrunt on GitHub Actions can save state and locks on AWS.

## Issue ticket number and link
https://github.com/dfds/cloudplatform/issues/2626

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
