### PR TITLE
Add GitHub org secret for atlantis

### DIFF
--- a/_sub/compute/helm-atlantis/main.tf
+++ b/_sub/compute/helm-atlantis/main.tf
@@ -150,16 +150,16 @@ resource "github_repository_webhook" "hook" {
 }
 
 resource "github_actions_organization_secret" "atlantis_username" {
-  secret_name     = "${upper(var.environment)}_ATLANTIS_USERNAME"
-  visibility      = "selected"
-  plaintext_value = var.auth_username
+  secret_name             = "${upper(var.environment)}_ATLANTIS_USERNAME"
+  visibility              = "selected"
+  plaintext_value         = var.auth_username
   selected_repository_ids = data.github_repository.repo.*.repo_id
 }
 
 resource "github_actions_organization_secret" "atlantis_password" {
-  secret_name     = "${upper(var.environment)}_ATLANTIS_PASSWORD"
-  visibility      = "selected"
-  plaintext_value = random_password.password.result
+  secret_name             = "${upper(var.environment)}_ATLANTIS_PASSWORD"
+  visibility              = "selected"
+  plaintext_value         = random_password.password.result
   selected_repository_ids = data.github_repository.repo.*.repo_id
 }
 

--- a/_sub/compute/helm-atlantis/main.tf
+++ b/_sub/compute/helm-atlantis/main.tf
@@ -150,14 +150,14 @@ resource "github_repository_webhook" "hook" {
 }
 
 resource "github_actions_organization_secret" "atlantis_username" {
-  secret_name     = "ATLANTIS_USERNAME"
+  secret_name     = "${upper(var.environment)}_ATLANTIS_USERNAME"
   visibility      = "selected"
   plaintext_value = var.auth_username
   selected_repository_ids = data.github_repository.repo.*.repo_id
 }
 
 resource "github_actions_organization_secret" "atlantis_password" {
-  secret_name     = "ATLANTIS_PASSWORD"
+  secret_name     = "${upper(var.environment)}_ATLANTIS_PASSWORD"
   visibility      = "selected"
   plaintext_value = random_password.password.result
   selected_repository_ids = data.github_repository.repo.*.repo_id

--- a/_sub/compute/helm-atlantis/main.tf
+++ b/_sub/compute/helm-atlantis/main.tf
@@ -149,6 +149,21 @@ resource "github_repository_webhook" "hook" {
   events = var.webhook_events
 }
 
+resource "github_actions_organization_secret" "atlantis_username" {
+  secret_name     = "ATLANTIS_USERNAME"
+  visibility      = "selected"
+  plaintext_value = var.auth_username
+  selected_repository_ids = data.github_repository.repo.*.repo_id
+}
+
+resource "github_actions_organization_secret" "atlantis_password" {
+  secret_name     = "ATLANTIS_PASSWORD"
+  visibility      = "selected"
+  plaintext_value = random_password.password.result
+  selected_repository_ids = data.github_repository.repo.*.repo_id
+}
+
+
 ## Kubernetes ##
 
 resource "kubernetes_namespace" "namespace" {

--- a/_sub/compute/helm-atlantis/vars.tf
+++ b/_sub/compute/helm-atlantis/vars.tf
@@ -127,6 +127,6 @@ variable "parallel_pool_size" {
 }
 
 variable "environment" {
-  type = string
+  type        = string
   description = "Environment"
 }

--- a/_sub/compute/helm-atlantis/vars.tf
+++ b/_sub/compute/helm-atlantis/vars.tf
@@ -125,3 +125,8 @@ variable "parallel_pool_size" {
   default     = 50
   description = "The number of concurrent go-routines when running terraform plan"
 }
+
+variable "environment" {
+  type = string
+  description = "Environment"
+}

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -478,6 +478,7 @@ module "atlantis" {
   github_repositories       = var.atlantis_github_repositories
   webhook_url               = var.atlantis_ingress
   webhook_events            = var.atlantis_webhook_events
+  environment               = var.atlantis_environment
 
   environment_variables = local.atlantis_env_vars
 

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -436,17 +436,17 @@ module "aws_node_service" {
 # --------------------------------------------------
 
 module "platform_fluxcd" {
-  source                         = "../../_sub/compute/k8s-fluxcd"
-  release_tag                    = var.fluxcd_version
-  repository_name                = var.fluxcd_bootstrap_repo_name
-  branch                         = var.fluxcd_bootstrap_repo_branch
-  github_owner                   = var.fluxcd_bootstrap_repo_owner
-  overwrite_on_create            = var.fluxcd_bootstrap_overwrite_on_create
-  gitops_apps_repo_url           = local.fluxcd_apps_repo_url
-  gitops_apps_repo_branch        = var.fluxcd_apps_repo_branch
-  cluster_name                   = var.eks_cluster_name
-  kubeconfig_path                = local.kubeconfig_path
-  prune                          = var.fluxcd_prune
+  source                  = "../../_sub/compute/k8s-fluxcd"
+  release_tag             = var.fluxcd_version
+  repository_name         = var.fluxcd_bootstrap_repo_name
+  branch                  = var.fluxcd_bootstrap_repo_branch
+  github_owner            = var.fluxcd_bootstrap_repo_owner
+  overwrite_on_create     = var.fluxcd_bootstrap_overwrite_on_create
+  gitops_apps_repo_url    = local.fluxcd_apps_repo_url
+  gitops_apps_repo_branch = var.fluxcd_apps_repo_branch
+  cluster_name            = var.eks_cluster_name
+  kubeconfig_path         = local.kubeconfig_path
+  prune                   = var.fluxcd_prune
 
   providers = {
     github = github.fluxcd

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -582,6 +582,12 @@ variable "atlantis_data_storage" {
   default     = "5Gi"
 }
 
+variable "atlantis_environment" {
+  type = string
+  description = "Environment for atlantis"
+  default = ""
+}
+
 # --------------------------------------------------
 # Atlantis variables
 # --------------------------------------------------

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -583,9 +583,9 @@ variable "atlantis_data_storage" {
 }
 
 variable "atlantis_environment" {
-  type = string
+  type        = string
   description = "Environment for atlantis"
-  default = ""
+  default     = ""
 }
 
 # --------------------------------------------------

--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -191,6 +191,7 @@ inputs = {
   atlantis_github_owner        = "dfds"
   atlantis_webhook_events      = ["issue_comment", "pull_request", "pull_request_review", "push"]
   atlantis_chart_version       = "4.18.0"
+  environment                  = "qa"
 
   # --------------------------------------------------
   # Blackbox Exporter

--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -191,7 +191,7 @@ inputs = {
   atlantis_github_owner        = "dfds"
   atlantis_webhook_events      = ["issue_comment", "pull_request", "pull_request_review", "push"]
   atlantis_chart_version       = "4.18.0"
-  environment                  = "qa"
+  atlantis_environment         = "qa"
 
   # --------------------------------------------------
   # Blackbox Exporter


### PR DESCRIPTION
## Describe your changes
In order to add synthetic checks for atlantis in grafana cloud, I need to pass the username and password for atlantis. This PR enables creating these as organization secrets on github. 

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
