### PR TITLE
fix: migrate from inline default route to individual route resource

### DIFF
--- a/_sub/network/route-table/main.tf
+++ b/_sub/network/route-table/main.tf
@@ -1,18 +1,14 @@
 resource "aws_route_table" "table" {
   vpc_id = var.vpc_id
 
-  route {
-    cidr_block = "0.0.0.0/0"
-    gateway_id = var.gateway_id
-  }
-
-  lifecycle {
-    ignore_changes = [route]
-  }
-
   tags = {
     Name = var.name
   }
 
 }
 
+resource "aws_route" "default" {
+  route_table_id         = aws_route_table.table.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = var.gateway_id
+}


### PR DESCRIPTION
## Describe your changes
We need to replace the inline route list on the route table with use of the route resource instead so we can add routes via the vpc peering automation where required.

See the note on https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table about why using the inline route and route resource together is a conflict

I have tested with my sandbox and this results in a straight swap/adoption of the only record (default route) by the new resource. As there was a lifecycle rule to ignore_changes no other routes are managed by state so are left alone.

I cannot see the route-table module being used elsewhere where this might have an undesired effect but would appreciate another set of eyes to confirm

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
