### PR TITLE
Add support for Grafana Cloud integration with Cloudwatch for capability, legacy and prime accounts

### DIFF
--- a/_sub/security/grafana-cloud-cloudwatch-integration/main.tf
+++ b/_sub/security/grafana-cloud-cloudwatch-integration/main.tf
@@ -1,0 +1,83 @@
+# --------------------------------------------------
+# IAM role for Grafana Cloud Cloudwatch integration
+# --------------------------------------------------
+
+locals {
+  role_name = "grafana-cloud-cloudwatch-integration"
+}
+
+data "aws_iam_policy_document" "policy" {
+  statement {
+    effect = "Allow"
+    sid    = "CloudWatchReadOnlyAccessPermissions"
+    actions = [
+      "application-autoscaling:DescribeScalingPolicies",
+      "autoscaling:Describe*",
+      "cloudwatch:BatchGet*",
+      "cloudwatch:Describe*",
+      "cloudwatch:GenerateQuery",
+      "cloudwatch:Get*",
+      "cloudwatch:List*",
+      "logs:Get*",
+      "logs:List*",
+      "logs:StartQuery",
+      "logs:StopQuery",
+      "logs:Describe*",
+      "logs:TestMetricFilter",
+      "logs:FilterLogEvents",
+      "logs:StartLiveTail",
+      "logs:StopLiveTail",
+      "oam:ListSinks",
+      "sns:Get*",
+      "sns:List*",
+      "rum:BatchGet*",
+      "rum:Get*",
+      "rum:List*",
+      "synthetics:Describe*",
+      "synthetics:Get*",
+      "synthetics:List*",
+      "xray:BatchGet*",
+      "xray:Get*"
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    sid    = "OAMReadPermissions"
+    actions = [
+      "oam:ListAttachedLinks"
+    ]
+
+    resources = ["arn:aws:oam:*:*:sink/*"]
+  }
+}
+
+data "aws_iam_policy_document" "trust" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "sts:ExternalId"
+
+      values = var.iam_role.stack_ids
+    }
+
+    principals {
+      type        = "AWS"
+      identifiers = [var.iam_role.arn]
+    }
+  }
+}
+
+module "iam_role" {
+  source               = "../iam-role"
+  role_name            = local.role_name
+  role_description     = "Role for Grafana Cloud to read Cloudwatch data"
+  role_policy_name     = local.role_name
+  role_policy_document = data.aws_iam_policy_document.policy.json
+  assume_role_policy   = data.aws_iam_policy_document.trust.json
+}

--- a/_sub/security/grafana-cloud-cloudwatch-integration/outputs.tf
+++ b/_sub/security/grafana-cloud-cloudwatch-integration/outputs.tf
@@ -1,0 +1,3 @@
+output "arn" {
+  value = try(module.iam_role.arn, null)
+}

--- a/_sub/security/grafana-cloud-cloudwatch-integration/vars.tf
+++ b/_sub/security/grafana-cloud-cloudwatch-integration/vars.tf
@@ -1,0 +1,12 @@
+# --------------------------------------------------
+# IAM role for Grafana Cloud Cloudwatch integration
+# --------------------------------------------------
+
+variable "iam_role" {
+  type = object({
+    arn       = string
+    stack_ids = list(string)
+  })
+  description = "IAM role used for Grafana Cloud IAM CloudWatch access"
+  default     = null
+}

--- a/_sub/security/grafana-cloud-cloudwatch-integration/versions.tf
+++ b/_sub/security/grafana-cloud-cloudwatch-integration/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0, < 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.39.0"
+    }
+  }
+}

--- a/security/legacy-account-context/main.tf
+++ b/security/legacy-account-context/main.tf
@@ -173,7 +173,7 @@ module "backup_eu_central_1" {
   kms_key_admins = local.kms_key_admins
   backup_plans   = var.aws_backup_plans
   iam_role_arn   = aws_iam_role.backup[0].arn
-  tags = var.aws_backup_tags
+  tags           = var.aws_backup_tags
 }
 
 module "backup_eu_west_1" {
@@ -190,5 +190,19 @@ module "backup_eu_west_1" {
   kms_key_admins = local.kms_key_admins
   backup_plans   = var.aws_backup_plans
   iam_role_arn   = aws_iam_role.backup[0].arn
-  tags = var.aws_backup_tags
+  tags           = var.aws_backup_tags
+}
+
+# --------------------------------------------------
+# IAM role for Grafana Cloud Cloudwatch integration
+# --------------------------------------------------
+
+module "grafana_cloud_cloudwatch_integration" {
+  count    = var.grafana_cloud_cloudwatch_integration_iam_role != null ? 1 : 0
+  source   = "../../_sub/security/grafana-cloud-cloudwatch-integration"
+  iam_role = var.grafana_cloud_cloudwatch_integration_iam_role
+
+  providers = {
+    aws = aws.workload
+  }
 }

--- a/security/legacy-account-context/outputs.tf
+++ b/security/legacy-account-context/outputs.tf
@@ -18,3 +18,6 @@ output "org_role_arn" {
   value = module.org_account.org_role_arn
 }
 
+output "grafana_cloud_cloudwatch_integration_iam_role_arn" {
+  value = try(module.grafana_cloud_cloudwatch_integration[0].arn, "Not used for this account")
+}

--- a/security/legacy-account-context/vars.tf
+++ b/security/legacy-account-context/vars.tf
@@ -212,3 +212,16 @@ variable "tags" {
   description = "A map of tags to apply to all the resources deployed by the module"
   default     = {}
 }
+
+# --------------------------------------------------
+# IAM role for Grafana Cloud Cloudwatch integration
+# --------------------------------------------------
+
+variable "grafana_cloud_cloudwatch_integration_iam_role" {
+  type = object({
+    arn       = string
+    stack_ids = list(string)
+  })
+  description = "IAM role used for Grafana Cloud IAM CloudWatch access"
+  default     = null
+}

--- a/security/org-account-assume/main.tf
+++ b/security/org-account-assume/main.tf
@@ -172,3 +172,17 @@ resource "aws_resourceexplorer2_index" "eu-west-1" {
 
   provider = aws.workload_2
 }
+
+# --------------------------------------------------
+# IAM role for Grafana Cloud Cloudwatch integration
+# --------------------------------------------------
+
+module "grafana_cloud_cloudwatch_integration" {
+  count    = var.grafana_cloud_cloudwatch_integration_iam_role != null ? 1 : 0
+  source   = "../../_sub/security/grafana-cloud-cloudwatch-integration"
+  iam_role = var.grafana_cloud_cloudwatch_integration_iam_role
+
+  providers = {
+    aws = aws.workload
+  }
+}

--- a/security/org-account-assume/outputs.tf
+++ b/security/org-account-assume/outputs.tf
@@ -18,3 +18,6 @@ output "org_role_arn" {
   value = module.org_account.org_role_arn
 }
 
+output "grafana_cloud_cloudwatch_integration_iam_role_arn" {
+  value = try(module.grafana_cloud_cloudwatch_integration[0].arn, "Not used for this account")
+}

--- a/security/org-account-assume/vars.tf
+++ b/security/org-account-assume/vars.tf
@@ -134,3 +134,16 @@ variable "tags" {
   description = "A map of tags to apply to all the resources deployed by the module"
   default     = {}
 }
+
+# --------------------------------------------------
+# IAM role for Grafana Cloud Cloudwatch integration
+# --------------------------------------------------
+
+variable "grafana_cloud_cloudwatch_integration_iam_role" {
+  type = object({
+    arn       = string
+    stack_ids = list(string)
+  })
+  description = "IAM role used for Grafana Cloud IAM CloudWatch access"
+  default     = null
+}

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -363,3 +363,17 @@ module "backup_eu_west_1" {
   iam_role_arn   = aws_iam_role.backup[0].arn
   tags           = var.aws_backup_tags
 }
+
+# --------------------------------------------------
+# IAM role for Grafana Cloud Cloudwatch integration
+# --------------------------------------------------
+
+module "grafana_cloud_cloudwatch_integration" {
+  count    = var.grafana_cloud_cloudwatch_integration_iam_role != null ? 1 : 0
+  source   = "../../_sub/security/grafana-cloud-cloudwatch-integration"
+  iam_role = var.grafana_cloud_cloudwatch_integration_iam_role
+
+  providers = {
+    aws = aws.workload
+  }
+}

--- a/security/org-account-context/outputs.tf
+++ b/security/org-account-context/outputs.tf
@@ -18,3 +18,6 @@ output "org_role_arn" {
   value = module.org_account.org_role_arn
 }
 
+output "grafana_cloud_cloudwatch_integration_iam_role_arn" {
+  value = try(module.grafana_cloud_cloudwatch_integration[0].arn, "Not used for this account")
+}

--- a/security/org-account-context/vars.tf
+++ b/security/org-account-context/vars.tf
@@ -300,3 +300,16 @@ variable "ssm_param_createdby" {
   type        = string
   description = "The value that will be used for the createdBy key when tagging any SSM parameters"
 }
+
+# --------------------------------------------------
+# IAM role for Grafana Cloud Cloudwatch integration
+# --------------------------------------------------
+
+variable "grafana_cloud_cloudwatch_integration_iam_role" {
+  type = object({
+    arn       = string
+    stack_ids = list(string)
+  })
+  description = "IAM role used for Grafana Cloud IAM CloudWatch access"
+  default     = null
+}


### PR DESCRIPTION
<!--Describe the change here-->
- **Create sub module for create integration between Grafana Cloud and AWS**
- **Add support for Grafana Cloud integration with Cloudwatch in capability accounts**
- **Add support for Grafana Cloud integration with Cloudwatch in legacy accounts**
- **Add support for Grafana Cloud integration with Cloudwatch for prime accounts**

## Issue ticket number and link
https://github.com/dfds/cloudplatform/issues/2599

## Checklist before requesting a review
- [x] I have tested changes in aws-account-manifests, aws-legacy-accounts and prime codebase.
- [ ] ~~I have tested changes in my sandbox~~
- [ ] ~~I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)~~
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
