### PR TITLE
Removed iam:*SAMLProvider deny actions

### DIFF
--- a/security/org-policies/restrictive.tf
+++ b/security/org-policies/restrictive.tf
@@ -55,13 +55,11 @@ data "aws_iam_policy_document" "restrictive" {
       "iam:CreateAccountAlias",
       "iam:CreateGroup",
       "iam:CreateLoginProfile",
-      "iam:CreateSAMLProvider",
       "iam:CreateUser",
       "iam:DeleteAccountAlias",
       "iam:DeleteAccountPasswordPolicy",
       "iam:DeleteGroup",
       "iam:DeleteGroupPolicy",
-      "iam:DeleteSAMLProvider",
       "iam:DetachGroupPolicy",
       "iam:PutGroupPolicy",
       "iam:PutUserPermissionsBoundary",
@@ -69,7 +67,6 @@ data "aws_iam_policy_document" "restrictive" {
       "iam:UpdateAccountPasswordPolicy",
       "iam:UpdateGroup",
       "iam:UpdateLoginProfile",
-      "iam:UpdateSAMLProvider",
       "iam:UpdateUser",
     ]
     resources = ["*"]


### PR DESCRIPTION
We have a team that needs to be able to create identity providers in their account for setting up SSO with Redshift. We've previously denied these IAM actions because of legacy reasons(our use of ADFS), but I no longer see any reason to deny them. We don't deny creation of OIDC providers.