### PR TITLE
fix: amended inconsistent conditional in vpc requester optional c sub…

### DIFF
--- a/_sub/network/vpc-peering-requester/main.tf
+++ b/_sub/network/vpc-peering-requester/main.tf
@@ -124,7 +124,7 @@ resource "aws_vpc_endpoint" "ssm" {
 
   private_dns_enabled = true
 
-  subnet_ids = flatten([aws_subnet.a.id, aws_subnet.b.id, var.cidr_block_subnet_c != "" ? aws_subnet.c[0].id : []])
+  subnet_ids = flatten([aws_subnet.a.id, aws_subnet.b.id, var.cidr_block_subnet_c != "" ? aws_subnet.c[0].id : ""])
 
   security_group_ids = [
     aws_security_group.ssm.id,
@@ -141,7 +141,7 @@ resource "aws_vpc_endpoint" "ssmmessages" {
 
   private_dns_enabled = true
 
-  subnet_ids = flatten([aws_subnet.a.id, aws_subnet.b.id, var.cidr_block_subnet_c != "" ? aws_subnet.c[0].id : []])
+  subnet_ids = flatten([aws_subnet.a.id, aws_subnet.b.id, var.cidr_block_subnet_c != "" ? aws_subnet.c[0].id : ""])
 
   security_group_ids = [
     aws_security_group.ssm.id,
@@ -158,7 +158,7 @@ resource "aws_vpc_endpoint" "ec2" {
 
   private_dns_enabled = true
 
-  subnet_ids = flatten([aws_subnet.a.id, aws_subnet.b.id, var.cidr_block_subnet_c != "" ? aws_subnet.c[0].id : []])
+  subnet_ids = flatten([aws_subnet.a.id, aws_subnet.b.id, var.cidr_block_subnet_c != "" ? aws_subnet.c[0].id : ""])
 
   security_group_ids = [
     aws_security_group.ssm.id,
@@ -175,7 +175,7 @@ resource "aws_vpc_endpoint" "ec2messages" {
 
   private_dns_enabled = true
 
-  subnet_ids = flatten([aws_subnet.a.id, aws_subnet.b.id, var.cidr_block_subnet_c != "" ? aws_subnet.c[0].id : []])
+  subnet_ids = flatten([aws_subnet.a.id, aws_subnet.b.id, var.cidr_block_subnet_c != "" ? aws_subnet.c[0].id : ""])
 
   security_group_ids = [
     aws_security_group.ssm.id,
@@ -238,7 +238,7 @@ resource "aws_vpc_security_group_ingress_rule" "redis" {
 
 resource "aws_db_subnet_group" "peering" {
   name       = "peering"
-  subnet_ids = flatten([aws_subnet.a.id, aws_subnet.b.id, var.cidr_block_subnet_c != "" ? aws_subnet.c[0].id : []])
+  subnet_ids = flatten([aws_subnet.a.id, aws_subnet.b.id, var.cidr_block_subnet_c != "" ? aws_subnet.c[0].id : ""])
 
   tags = {
     Name = "peering"


### PR DESCRIPTION
…nets

## Describe your changes
Fixes an error when adding an optional C subnet due to inconsistent conditional result types of string and tuple by making the tuple a string

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
