### PR TITLE
feat: allow disabling of vpc endpoints for peering

### DIFF
--- a/_sub/network/vpc-peering-requester/main.tf
+++ b/_sub/network/vpc-peering-requester/main.tf
@@ -118,6 +118,7 @@ resource "aws_vpc_security_group_ingress_rule" "sec_sec" {
 }
 
 resource "aws_vpc_endpoint" "ssm" {
+  count = var.deploy_vpc_peering_endpoints ? 1 : 0
   vpc_id            = aws_vpc.peering.id
   service_name      = "com.amazonaws.${data.aws_region.current.name}.ssm"
   vpc_endpoint_type = "Interface"
@@ -137,6 +138,7 @@ resource "aws_vpc_endpoint" "ssm" {
 }
 
 resource "aws_vpc_endpoint" "ssmmessages" {
+  count = var.deploy_vpc_peering_endpoints ? 1 : 0
   vpc_id            = aws_vpc.peering.id
   service_name      = "com.amazonaws.${data.aws_region.current.name}.ssmmessages"
   vpc_endpoint_type = "Interface"
@@ -156,6 +158,7 @@ resource "aws_vpc_endpoint" "ssmmessages" {
 }
 
 resource "aws_vpc_endpoint" "ec2" {
+  count = var.deploy_vpc_peering_endpoints ? 1 : 0
   vpc_id            = aws_vpc.peering.id
   service_name      = "com.amazonaws.${data.aws_region.current.name}.ec2"
   vpc_endpoint_type = "Interface"
@@ -175,6 +178,7 @@ resource "aws_vpc_endpoint" "ec2" {
 }
 
 resource "aws_vpc_endpoint" "ec2messages" {
+  count = var.deploy_vpc_peering_endpoints ? 1 : 0
   vpc_id            = aws_vpc.peering.id
   service_name      = "com.amazonaws.${data.aws_region.current.name}.ec2messages"
   vpc_endpoint_type = "Interface"

--- a/_sub/network/vpc-peering-requester/vars.tf
+++ b/_sub/network/vpc-peering-requester/vars.tf
@@ -41,3 +41,9 @@ variable "map_public_ip_on_launch" {
   type        = bool
   default     = false
 }
+
+variable "deploy_vpc_peering_endpoints" {
+  description = "Deploy required VPC endpoints for VPC peering SSM connections"
+  type        = bool
+  default     = true
+}

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -392,11 +392,12 @@ module "vpc_peering_capability_eu_west_1" {
   cidr_block_subnet_b = each.value.assigned_cidr_block_subnet_b
   cidr_block_subnet_c = each.value.assigned_cidr_block_subnet_c
 
-  cidr_block_peer         = each.value.cidr_block_peer
-  peer_owner_id           = var.shared_account_id
-  peer_vpc_id             = each.value.peer_vpc_id
-  peer_region             = each.value.peer_region
-  map_public_ip_on_launch = var.vpc_peering_map_public_ip_on_launch
+  cidr_block_peer              = each.value.cidr_block_peer
+  peer_owner_id                = var.shared_account_id
+  peer_vpc_id                  = each.value.peer_vpc_id
+  peer_region                  = each.value.peer_region
+  map_public_ip_on_launch      = var.vpc_peering_map_public_ip_on_launch
+  deploy_vpc_peering_endpoints = var.deploy_vpc_peering_endpoints
 
   tags = local.all_tags
 
@@ -438,7 +439,8 @@ module "vpc_peering_capability_eu_central_1" {
   peer_vpc_id             = each.value.peer_vpc_id
   peer_region             = each.value.peer_region
   map_public_ip_on_launch = var.vpc_peering_map_public_ip_on_launch
-
+  deploy_vpc_peering_endpoints = var.deploy_vpc_peering_endpoints
+  
   tags = local.all_tags
 
   providers = {

--- a/security/org-account-context/vars.tf
+++ b/security/org-account-context/vars.tf
@@ -373,6 +373,12 @@ variable "vpc_peering_map_public_ip_on_launch" {
   default     = false
 }
 
+variable "deploy_vpc_peering_endpoints" {
+  description = "Deploy required VPC endpoints for VPC peering SSM connections"
+  type        = bool
+  default     = true
+}
+
 # --------------------------------------------------
 # IAM role for Grafana Cloud Cloudwatch integration
 # --------------------------------------------------


### PR DESCRIPTION
## Describe your changes
PR allowing us to disable the creation of vpc endpoints for vpc peering if required

Should be backwards compatible as it will automatically move the state from resource to resource[0]

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
