### PR TITLE
Fixed deprecation

### DIFF
--- a/_sub/compute/helm-kube-prometheus-stack/main.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/main.tf
@@ -201,5 +201,5 @@ resource "azuread_application" "grafana" {
 
 resource "azuread_application_password" "grafana" {
   count                 = length(var.grafana_azure_tenant_id) == 36 ? 1 : 0
-  application_object_id = azuread_application.grafana[0].object_id
+  application_id = azuread_application.grafana[0].object_id
 }

--- a/_sub/compute/helm-kube-prometheus-stack/main.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/main.tf
@@ -201,5 +201,5 @@ resource "azuread_application" "grafana" {
 
 resource "azuread_application_password" "grafana" {
   count                 = length(var.grafana_azure_tenant_id) == 36 ? 1 : 0
-  application_id = azuread_application.grafana[0].object_id
+  application_id = "/applications/${azuread_application.grafana[0].object_id}"
 }

--- a/_sub/security/azure-app-registration/main.tf
+++ b/_sub/security/azure-app-registration/main.tf
@@ -10,7 +10,7 @@ resource "azuread_application" "app" {
 }
 
 resource "azuread_service_principal" "sp" {
-  application_id = azuread_application.app.application_id
+  client_id = azuread_application.app.application_id
   owners         = [data.azuread_client_config.current.object_id]
 }
 


### PR DESCRIPTION
## Describe your changes
Update application_object_id to application_id to comply with changes in the provider.

`The 'application_object_id' property has been replaced with the
'application_id' property and will be removed in version 3.0 of the AzureAD
provider`
