### PR TITLE
Version lock Grafana

### DIFF
--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -276,6 +276,7 @@ inputs = {
   # --------------------------------------------------
 
   grafana_agent_deploy = true
+  grafana_agent_chart_version = "0.10.0"
   grafana_agent_resource_memory_request = "4Gi"
   grafana_agent_resource_memory_limit   = "4Gi"
   grafana_agent_storage_enabled = true


### PR DESCRIPTION
## Describe your changes
To avoid this error:

```
2024-04-17T02:45:10.7830867Z [31m│[0m [0m[1m[31mError: [0m[0m[1mexecution error at (k8s-monitoring/templates/kubernetes-monitoring-telemetry.yaml:1:3): 
2024-04-17T02:45:10.7831694Z [31m│[0m [0m
2024-04-17T02:45:10.7832291Z [31m│[0m [0mAs of k8s-monitoring Chart version 1.0, Grafana Agent has been replaced with Grafana Alloy.
2024-04-17T02:45:10.7832907Z [31m│[0m [0mThese sections in your values file will need to be renamed:
2024-04-17T02:45:10.7833421Z [31m│[0m [0m  grafana-agent          --> alloy
2024-04-17T02:45:10.7833876Z [31m│[0m [0m  grafana-agent-events   --> alloy-events
2024-04-17T02:45:10.7834453Z [31m│[0m [0m  grafana-agent-logs     --> alloy-logs
2024-04-17T02:45:10.7834914Z [31m│[0m [0m  grafana-agent-profiles --> alloy-profiles
2024-04-17T02:45:10.7835470Z [31m│[0m [0m  metrics.agent          --> metrics.alloy
```

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
