### PR TITLE
disable kube_state_metrics exporter from grafana agent

### DIFF
--- a/_sub/monitoring/helm-grafana-agent/values/values.yaml
+++ b/_sub/monitoring/helm-grafana-agent/values/values.yaml
@@ -94,4 +94,6 @@ prometheus-node-exporter:
   enabled: false
 prometheus-operator-crds:
   enabled: false
+kube-state-metrics:
+  enabled: false  
 %{ endif ~}


### PR DESCRIPTION
## Describe your changes
Disable auto-deploy of kube_state_metrics exporter in grafana-agent helm because we are getting duplicated metrics. An already running instance of kube_state_metrics exporter is already deployed and running in monitoring namespace

## Issue ticket number and link
https://github.com/dfds/cloudplatform/issues/2722

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
~~- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)~~
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
