### PR TITLE
Go is no longer a supported runtime for lambdas. It must now run on Amazon Linux

### DIFF
--- a/_sub/security/security-bot/main.tf
+++ b/_sub/security/security-bot/main.tf
@@ -303,7 +303,7 @@ resource "aws_lambda_function" "bot" {
   function_name = aws_iam_role.lambda[0].name
   role          = aws_iam_role.lambda[0].arn
   handler       = "bootstrap"
-  runtime       = "go1.x"
+  runtime       = "provided.al2"
   timeout       = 300
 
   environment {


### PR DESCRIPTION
## Describe your changes
aws-account-manifest is broken. New accounts with `harden = true` will fail to deploy security bot lambda because Go is no longer a supported runtime.

## Issue ticket number and link
https://github.com/dfds/cloudplatform/issues/2784

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
