### PR TITLE
Feature/increase eks alb idletimeout limit raised again

### DIFF
--- a/_sub/compute/eks-alb-auth/main.tf
+++ b/_sub/compute/eks-alb-auth/main.tf
@@ -22,7 +22,7 @@ resource "aws_lb" "traefik_auth" {
   }
 
   drop_invalid_header_fields = true
-  idle_timeout = 120
+  idle_timeout = 300
 }
 
 resource "aws_lb_target_group" "traefik_auth_blue_variant" {

--- a/_sub/compute/eks-alb/main.tf
+++ b/_sub/compute/eks-alb/main.tf
@@ -22,7 +22,7 @@ resource "aws_lb" "traefik" {
   }
 
   drop_invalid_header_fields = true
-  idle_timeout = 120
+  idle_timeout = 300
 }
 
 resource "aws_lb_target_group" "traefik_blue_variant" {


### PR DESCRIPTION
## Describe your changes
Developers have their apps failing if they take more than 1 minute to respond. Context in topdesk and slack. Now it is set to 5 minutes after feedback from teams

## Issue ticket number and link
Topdesk 24049681

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
~~- [] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)~~
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
