### PR TITLE
Replace Grafana agent with alloy

### DIFF
--- a/_sub/monitoring/helm-grafana-agent/main.tf
+++ b/_sub/monitoring/helm-grafana-agent/main.tf
@@ -19,6 +19,7 @@ resource "helm_release" "grafana_agent" {
       tempo_url                     = var.tempo_url,
       tempo_username                = var.tempo_username,
       traces_enabled                = var.traces_enabled,
+      open_cost_enabled             = var.open_cost_enabled
       enable_side_by_side           = var.enable_side_by_side,
       agent_resource_memory_limit   = var.agent_resource_memory_limit,
       agent_resource_memory_request = var.agent_resource_memory_request,

--- a/_sub/monitoring/helm-grafana-agent/values/values.yaml
+++ b/_sub/monitoring/helm-grafana-agent/values/values.yaml
@@ -1,7 +1,7 @@
 cluster:
   name: ${cluster_name}
-grafana-agent:
-  agent:
+alloy:
+  alloy:
 %{ if storage_enabled ~}
     clustering:
       enabled: true
@@ -75,6 +75,7 @@ externalServices:
       username: ${tempo_username}
       password: ${api_token}
 opencost:
+  enabled: ${open_cost_enabled}
   opencost:
     exporter:
       defaultClusterId: ${cluster_name}
@@ -95,5 +96,5 @@ prometheus-node-exporter:
 prometheus-operator-crds:
   enabled: false
 kube-state-metrics:
-  enabled: false  
+  enabled: false
 %{ endif ~}

--- a/_sub/monitoring/helm-grafana-agent/vars.tf
+++ b/_sub/monitoring/helm-grafana-agent/vars.tf
@@ -129,6 +129,12 @@ variable "traces_enabled" {
   description = "Enable traces or not. Default: true"
 }
 
+variable "open_cost_enabled" {
+  type        = bool
+  description = "Enable scraping cost metrics Grafana Cloud Prometheus or not. Default: false"
+  default     = false
+}
+
 variable "enable_side_by_side" {
   type        = bool
   default     = true

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -832,6 +832,7 @@ module "grafana_agent_k8s_monitoring" {
   tempo_url                     = var.grafana_agent_tempo_url
   tempo_username                = var.grafana_agent_tempo_username
   traces_enabled                = var.grafana_agent_traces_enabled
+  open_cost_enabled             = var.grafana_agent_open_cost_enabled
   agent_resource_memory_limit   = var.grafana_agent_resource_memory_limit
   agent_resource_memory_request = var.grafana_agent_resource_memory_request
   affinity                      = var.observability_affinity

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -1256,6 +1256,13 @@ variable "grafana_agent_traces_enabled" {
   description = "Enable traces or not. Default: true"
 }
 
+variable "grafana_agent_open_cost_enabled" {
+  type        = bool
+  default     = false
+  description = "Enable Open Cost or not. Default: false"
+}
+
+
 variable "grafana_agent_resource_memory_limit" {
   type        = string
   default     = "20Gi"

--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -276,7 +276,7 @@ inputs = {
   # --------------------------------------------------
 
   grafana_agent_deploy = true
-  grafana_agent_chart_version = "0.10.0"
+  grafana_agent_chart_version = "1.0.7"
   grafana_agent_resource_memory_request = "4Gi"
   grafana_agent_resource_memory_limit   = "4Gi"
   grafana_agent_storage_enabled = true


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
Grafana k8s chart with alloy configs to prepare for migrating to Alloy. 
Open cost metrics disabled by default

This will require that EKS-pipeline to update the `grafana_agent_chart_version` value to "1.0.7"

## Issue ticket number and link
https://github.com/dfds/cloudplatform/issues/2773

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
