### PR TITLE
feat: add steampipe audit role

### DIFF
--- a/_sub/security/steampipe-audit/main.tf
+++ b/_sub/security/steampipe-audit/main.tf
@@ -1,0 +1,33 @@
+resource "aws_iam_role" "steampipe_audit" {
+  name               = "steampipe-audit"
+  assume_role_policy = data.aws_iam_policy_document.steampipe_audit_assume.json
+}
+
+data "aws_iam_policy_document" "steampipe_audit_assume" {
+  statement {
+    sid    = "assume"
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.allowed_account_id}:root"]
+    }
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:PrincipalArn"
+      values   = ["arn:aws:iam::${var.allowed_account_id}:role/aws-reserved/sso.amazonaws.com/eu-west-1/AWSReservedSSO_${var.allowed_principal_role_name}_*"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "readonly" {
+  role       = aws_iam_role.steampipe_audit.name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "viewonly" {
+  role       = aws_iam_role.steampipe_audit.name
+  policy_arn = "arn:aws:iam::aws:policy/job-function/ViewOnlyAccess"
+}

--- a/_sub/security/steampipe-audit/vars.tf
+++ b/_sub/security/steampipe-audit/vars.tf
@@ -1,0 +1,9 @@
+variable "allowed_account_id" {
+    type = string
+    description = "The account id that is allowed to assume the steampipe-audit role"
+}
+
+variable "allowed_principal_role_name" {
+    type = string
+    description = "The name of the role that is allowed to assume the steampipe-audit role"
+}

--- a/security/legacy-account-context/main.tf
+++ b/security/legacy-account-context/main.tf
@@ -206,3 +206,18 @@ module "grafana_cloud_cloudwatch_integration" {
     aws = aws.workload
   }
 }
+
+# --------------------------------------------------
+# Steampipe
+# --------------------------------------------------
+
+module "steampipe-audit" {
+  source = "../../_sub/security/steampipe-audit"
+
+  allowed_account_id        = var.security_account_id
+  allowed_principal_role_name = var.steampipe_audit_role_name
+
+  providers = {
+    aws = aws.workload
+  }
+}

--- a/security/legacy-account-context/vars.tf
+++ b/security/legacy-account-context/vars.tf
@@ -23,6 +23,11 @@ variable "core_account_id" {
   description = "The AWS account ID of the Organizations Core account"
 }
 
+variable "security_account_id" {
+  type = string
+  description = "The AWS account ID of the Organizations Security account"
+}
+
 variable "access_key_master" {
   type = string
 }
@@ -224,4 +229,14 @@ variable "grafana_cloud_cloudwatch_integration_iam_role" {
   })
   description = "IAM role used for Grafana Cloud IAM CloudWatch access"
   default     = null
+}
+
+# --------------------------------------------------
+# Steampipe
+# --------------------------------------------------
+
+variable "steampipe_audit_role_name" {
+  type = string
+  description = "Name of the IAM role used by Steampipe for reading resources"
+  default = "steampipe-audit"
 }

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -467,3 +467,18 @@ module "vpc_peering_oxygen_eu_central_1" {
     aws = aws.shared_vpc
   }
 }
+
+# --------------------------------------------------
+# Steampipe
+# --------------------------------------------------
+
+module "steampipe-audit" {
+  source = "../../_sub/security/steampipe-audit"
+
+  allowed_account_id        = var.security_account_id
+  allowed_principal_role_name = var.steampipe_audit_role_name
+
+  providers = {
+    aws = aws.workload
+  }
+}

--- a/security/org-account-context/vars.tf
+++ b/security/org-account-context/vars.tf
@@ -25,6 +25,11 @@ variable "shared_account_id" {
   description = "The AWS account ID of the Organizations Shared account (e.g. Oxygen)"
 }
 
+variable "security_account_id" {
+  type = string
+  description = "The AWS account ID of the Organizations Security account"
+}
+
 variable "shared_role_path" {
   type        = string
   description = "The path in which to put the IAM role for access to resources in shared account"
@@ -390,4 +395,14 @@ variable "grafana_cloud_cloudwatch_integration_iam_role" {
   })
   description = "IAM role used for Grafana Cloud IAM CloudWatch access"
   default     = null
+}
+
+# --------------------------------------------------
+# Steampipe
+# --------------------------------------------------
+
+variable "steampipe_audit_role_name" {
+  type = string
+  description = "Name of the IAM role used by Steampipe for reading resources"
+  default = "steampipe-audit"
 }


### PR DESCRIPTION
## Describe your changes
This PR adds a steampipe audit role with view/read only access to accounts using org-account-context and legacy-account-context

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
