### PR TITLE
fix: set correct aws workload for steampipe-audit org-account-assume

### DIFF
--- a/security/org-account-assume/main.tf
+++ b/security/org-account-assume/main.tf
@@ -197,5 +197,8 @@ module "steampipe-audit" {
   allowed_account_id        = var.security_account_id
   allowed_principal_role_name = var.steampipe_audit_role_name
 
-
+  providers = {
+    aws = aws.workload
+  }
+  
 }


### PR DESCRIPTION
## Describe your changes
Sets the correct AWS workload for org-account-assume's use of steampipe submodule

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
