### PR TITLE
feat: enable renovate dependency dashboard and schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,9 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+    "config:recommended"
+    ],
+    "schedule": ["after 6am and before 8am every wednesday"],
     "branchPrefix": "feature/renovate/",
     "username": "devex-sa",
     "onboarding": false,


### PR DESCRIPTION
## Describe your changes
This PR should enable the renovate dependency dashboard via the config:recommended preset config with a schedule to automtically raise any PR's once per week.

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
