### PR TITLE
Add atlantis vars for grafana cloud app registration

### DIFF
--- a/compute/k8s-services/dependencies.tf
+++ b/compute/k8s-services/dependencies.tf
@@ -315,6 +315,9 @@ locals {
     STAGING_GRAFANA_AGENT_TEMPO_URL                                     = var.staging_grafana_agent_tempo_url
     STAGING_GRAFANA_AGENT_TEMPO_USERNAME                                = var.staging_grafana_agent_tempo_username
     PRODUCTION_GRAFANA_CLOUD_API_KEY                                    = var.atlantis_grafana_cloud_api_key
+    PRODUCTION_GRAFANA_CLOUD_ARM_CLIENT_ID                              = var.atlantis_grafana_cloud_arm_client_id
+    PRODUCTION_GRAFANA_CLOUD_ARM_CLIENT_SECRET                          = var.atlantis_grafana_cloud_arm_client_secret
+    PRODUCTION_GRAFANA_CLOUD_ARM_TENANT_ID                              = var.atlantis_grafana_cloud_arm_tenant_id
   }
 
   atlantis_env_vars = var.crossplane_deploy ? merge(local.atlantis_env_vars_default, local.confluent_env_vars_for_atlantis) : local.atlantis_env_vars_default

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -723,6 +723,25 @@ variable "atlantis_grafana_cloud_api_key" {
   sensitive   = true
 }
 
+variable "atlantis_grafana_cloud_arm_client_id" {
+  type        = string
+  default     = "" #tfsec:ignore:general-secrets-sensitive-in-variable
+  description = "Grafana cloud app registration client ID"
+}
+
+variable "atlantis_grafana_cloud_arm_tenant_id" {
+  type        = string
+  default     = "" #tfsec:ignore:general-secrets-sensitive-in-variable
+  description = "Grafana cloud app registration tenant ID"
+}
+
+variable "atlantis_grafana_cloud_arm_client_secret" {
+  type        = string
+  default     = "" #tfsec:ignore:general-secrets-sensitive-in-variable
+  description = "Grafana cloud app registration client secret"
+  sensitive   = true
+}
+
 # --------------------------------------------------
 # Crossplane
 # --------------------------------------------------


### PR DESCRIPTION
## Describe your changes
Adds atlantis env vars needed for grafana cloud environments. Part of: https://github.com/dfds/cloudplatform/issues/2756

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
