### PR TITLE
Upgrade QA to use Flux 2.3.0

### DIFF
--- a/_sub/compute/k8s-crossplane-operator/dependencies.tf
+++ b/_sub/compute/k8s-crossplane-operator/dependencies.tf
@@ -33,7 +33,7 @@ locals {
   }
 
   helm_release = {
-    "apiVersion" = "helm.toolkit.fluxcd.io/v2beta1"
+    "apiVersion" = "helm.toolkit.fluxcd.io/v2"
     "kind"       = "HelmRelease"
     "metadata" = {
       "name"      = var.deploy_name

--- a/_sub/compute/k8s-traefik-flux/dependencies.tf
+++ b/_sub/compute/k8s-traefik-flux/dependencies.tf
@@ -70,7 +70,7 @@ locals {
   }
 
   helm_patch = {
-    "apiVersion" = "helm.toolkit.fluxcd.io/v2beta1"
+    "apiVersion" = "helm.toolkit.fluxcd.io/v2"
     "kind"       = "HelmRelease"
     "metadata" = {
       "name"      = var.deploy_name

--- a/_sub/monitoring/blackbox-exporter/values/patch.yaml
+++ b/_sub/monitoring/blackbox-exporter/values/patch.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: prometheus-blackbox-exporter

--- a/_sub/monitoring/helm-exporter/values/patch.yaml
+++ b/_sub/monitoring/helm-exporter/values/patch.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: prometheus-helm-exporter

--- a/_sub/monitoring/metrics-server/dependencies.tf
+++ b/_sub/monitoring/metrics-server/dependencies.tf
@@ -36,7 +36,7 @@ locals {
     YAML
 
   helm_patch = <<YAML
-    apiVersion: helm.toolkit.fluxcd.io/v2beta1
+    apiVersion: helm.toolkit.fluxcd.io/v2
     kind: HelmRelease
     metadata:
       name: ${var.deploy_name}

--- a/_sub/security/external-secrets/dependencies.tf
+++ b/_sub/security/external-secrets/dependencies.tf
@@ -24,7 +24,7 @@ spec:
 
   sourceRef:
     kind: GitRepository
-    name: "flux-system" 
+    name: "flux-system"
   path: "./${local.helm_repo_path}"
   prune: ${var.prune}
 YAML
@@ -39,7 +39,7 @@ patchesStrategicMerge:
 YAML
 
   helm_patch = <<YAML
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: ${var.deploy_name}

--- a/_sub/storage/velero/dependencies.tf
+++ b/_sub/storage/velero/dependencies.tf
@@ -60,7 +60,7 @@ metadata:
   name: ${var.namespace}
 
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: velero

--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -90,14 +90,14 @@ inputs = {
   # Flux CD
   # --------------------------------------------------
 
-  fluxcd_version                    = "v2.1.2"
+  fluxcd_version                    = "v2.3.0"
 
   fluxcd_bootstrap_repo_name        = "platform-manifests-qa"
   fluxcd_bootstrap_repo_branch      = "main"
   fluxcd_bootstrap_repo_owner       = "dfds"
 
   fluxcd_apps_repo_name             = "platform-apps"
-  fluxcd_apps_repo_branch           = "main"
+  fluxcd_apps_repo_branch           = "qa"
   fluxcd_apps_repo_owner            = "dfds"
 
 


### PR DESCRIPTION
## Describe your changes
- Upgrade Flux in QA to use version 2.3.0
- It will also upgrade all CRD API versions used, and is hence a candidate for staging and production afterwards.

## Issue ticket number and link
https://github.com/dfds/cloudplatform/issues/2810

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
