### PR TITLE
Use connection data from Kubernetes data source instead of kubeconfig

### DIFF
--- a/_sub/compute/k8s-fluxcd/providers.tf
+++ b/_sub/compute/k8s-fluxcd/providers.tf
@@ -1,6 +1,8 @@
 provider "flux" {
   kubernetes = {
-    config_path = var.kubeconfig_path
+    host                   = var.endpoint
+    token                  = var.token
+    cluster_ca_certificate = var.cluster_ca_certificate
   }
   git = {
     url = "ssh://git@github.com/${data.github_repository.main.full_name}.git"

--- a/_sub/compute/k8s-fluxcd/vars.tf
+++ b/_sub/compute/k8s-fluxcd/vars.tf
@@ -39,11 +39,6 @@ variable "gitops_apps_repo_branch" {
   description = "The default branch for your GitOps manifests"
 }
 
-variable "kubeconfig_path" {
-  type    = string
-  default = null
-}
-
 variable "overwrite_on_create" {
   type        = bool
   default     = true
@@ -54,4 +49,16 @@ variable "prune" {
   type        = bool
   default     = true
   description = "Enable Garbage collection"
+}
+
+variable "endpoint" {
+  type = string
+}
+
+variable "token" {
+  type = string
+}
+
+variable "cluster_ca_certificate" {
+  type = string
 }

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -455,8 +455,10 @@ module "platform_fluxcd" {
   gitops_apps_repo_url    = local.fluxcd_apps_repo_url
   gitops_apps_repo_branch = var.fluxcd_apps_repo_branch
   cluster_name            = var.eks_cluster_name
-  kubeconfig_path         = local.kubeconfig_path
   prune                   = var.fluxcd_prune
+  endpoint                = data.aws_eks_cluster.eks.endpoint
+  token                   = data.aws_eks_cluster_auth.eks.token
+  cluster_ca_certificate  = base64decode(data.aws_eks_cluster.eks.certificate_authority[0].data)
 
   providers = {
     github = github.fluxcd


### PR DESCRIPTION
## Describe your changes
Use connection data from Kubernetes data source instead of kubeconfig

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
