### PR TITLE
re-deploy kube-prom-stats in legacy setup

### DIFF
--- a/_sub/compute/helm-kube-prometheus-stack/values/components.yaml
+++ b/_sub/compute/helm-kube-prometheus-stack/values/components.yaml
@@ -14,7 +14,7 @@ nodeExporter:
   enabled: ${enable_components}
 
 kubeStateMetrics:
-  enabled: ${enable_components}
+  enabled: true
 
 kubelet:
   enabled: ${enable_components}

--- a/_sub/monitoring/helm-grafana-agent/values/values.yaml
+++ b/_sub/monitoring/helm-grafana-agent/values/values.yaml
@@ -136,11 +136,11 @@ kube-state-metrics:
   priorityClassName: ${kube_state_metrics_priorityclass}
   prometheus:
     monitor: # ServiceMonitor - TODO: Delete this block when shutting down the old Prometheus
-      enabled: true
-      jobLabel: jobLabel
-      additionalLabels: {
-        release: monitoring
-      }
+      enabled: false
+      # jobLabel: jobLabel
+      # additionalLabels: {
+      #   release: monitoring
+      # }
 %{ if length(tolerations) > 0 ~}
   tolerations:
 %{ for t in tolerations ~}


### PR DESCRIPTION
## Describe your changes
Enable kube-stats-metrics exporters to run in parallel in the 2 available namespaces
Servicemonitor for kube-stats-metrics the legacy setup running in the legacy namespace

## Issue ticket number and link
-

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
