### PR TITLE
allow lists for kube-stats and cadvisor metrics updated

### DIFF
--- a/_sub/monitoring/helm-grafana-agent/values/values.yaml
+++ b/_sub/monitoring/helm-grafana-agent/values/values.yaml
@@ -123,7 +123,12 @@ metrics:
         operator = "NotIn"
         values = ["monitoring"]
       }
-
+  kube-state-metrics:
+    metricsTuning:
+      useDefaultAllowList: false
+  cadvisor:
+    metricsTuning:
+      useDefaultAllowList: false
 ### Prometheus Operator components
 kube-state-metrics:
   enabled: true


### PR DESCRIPTION
## Describe your changes
Enable full list of metrics for kube-stats and cadvisor

## Issue ticket number and link
https://github.com/dfds/cloudplatform/issues/2838

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
