### PR TITLE
Turn off public access to the EKS cluster API version endpoint

### DIFF
--- a/_sub/security/eks-version-endpoint/main.tf
+++ b/_sub/security/eks-version-endpoint/main.tf
@@ -1,0 +1,5 @@
+resource "null_resource" "this" {
+  provisioner "local-exec" {
+    command = "kubectl --kubeconfig ${var.kubeconfig_path} apply -f ${path.module}/system-public-info-viewer.yaml"
+  }
+}

--- a/_sub/security/eks-version-endpoint/system-public-info-viewer.yaml
+++ b/_sub/security/eks-version-endpoint/system-public-info-viewer.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "false"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: system:public-info-viewer
+rules:
+  - nonResourceURLs:
+      - /healthz
+      - /livez
+      - /readyz
+    verbs:
+      - get

--- a/_sub/security/eks-version-endpoint/vars.tf
+++ b/_sub/security/eks-version-endpoint/vars.tf
@@ -1,0 +1,3 @@
+variable "kubeconfig_path" {
+  type = string
+}

--- a/_sub/security/eks-version-endpoint/versions.tf
+++ b/_sub/security/eks-version-endpoint/versions.tf
@@ -1,0 +1,14 @@
+
+terraform {
+  required_version = ">= 1.3.0, < 1.6.0"
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.5.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2.1"
+    }
+  }
+}

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -333,3 +333,11 @@ module "eks_nvidia_device_plugin" {
   tolerations      = var.nvidia_device_plugin_tolerations
   affinity         = var.nvidia_device_plugin_affinity
 }
+
+
+module "eks_version_endpoint" {
+  count           = var.secure_eks_version_endpoint ? 1 : 0
+  source          = "../../_sub/security/eks-version-endpoint"
+  kubeconfig_path = local.kubeconfig_path
+  depends_on      = [module.eks_heptio]
+}

--- a/compute/eks-ec2/vars.tf
+++ b/compute/eks-ec2/vars.tf
@@ -259,3 +259,9 @@ variable "nvidia_device_plugin_affinity" {
   description = "A list of affinities to apply to the nvidia device plugin deployment"
   default     = []
 }
+
+variable "secure_eks_version_endpoint" {
+  type        = bool
+  default     = true
+  description = "Whether to secure the EKS version endpoint"
+}


### PR DESCRIPTION
## Describe your changes
Turn off public access to the EKS cluster API version endpoint after discussions with @jdsmithit 

## Issue ticket number and link
https://github.com/dfds/cloudplatform/issues/2842

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
