### PR TITLE
For iam-roles-master, make iam_role_trusted_account_root_arn into a list in order to support multiple ARNs

### DIFF
--- a/_sub/security/iam-policies/main.tf
+++ b/_sub/security/iam-policies/main.tf
@@ -200,16 +200,8 @@ data "aws_iam_policy_document" "trusted_account" {
     actions = ["sts:AssumeRole"]
 
     principals {
-      type = "AWS"
-      # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-      # force an interpolation expression to be interpreted as a list by wrapping it
-      # in an extra set of list brackets. That form was supported for compatibility in
-      # v0.11, but is no longer supported in Terraform v0.12.
-      #
-      # If the expression in the following list itself returns a list, remove the
-      # brackets to avoid interpretation as a list of lists. If the expression
-      # returns a single list item then leave it as-is and remove this TODO comment.
-      identifiers = [element(var.iam_role_trusted_account_root_arn, 0)]
+      type        = "AWS"
+      identifiers = var.iam_role_trusted_account_root_arn
     }
   }
 }

--- a/security/iam-roles-master/main.tf
+++ b/security/iam-roles-master/main.tf
@@ -1,7 +1,7 @@
 # Load IAM policy documents from module
 module "iam_policies" {
   source                            = "../../_sub/security/iam-policies"
-  iam_role_trusted_account_root_arn = [var.iam_role_trusted_account_root_arn]
+  iam_role_trusted_account_root_arn = var.iam_role_trusted_account_root_arn
 }
 
 # Create the role for the master account

--- a/security/iam-roles-master/vars.tf
+++ b/security/iam-roles-master/vars.tf
@@ -14,7 +14,7 @@ variable "iam_role_description" {
 
 variable "iam_role_trusted_account_root_arn" {
   description = "The ARN of the account trusted to assume the role"
-  type        = string
+  type        = list(string)
 }
 
 variable "create_org_account_iam_policy_name" {


### PR DESCRIPTION
## Describe your changes
For iam-roles-master, make iam_role_trusted_account_root_arn into a list in order to support multiple ARNs
This is to ensure not the "root" account is trusted, because that means all users, including read-only users.

## Issue ticket number and link
https://github.com/dfds/cloudplatform/issues/1532

## Checklist before requesting a review
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
