### PR TITLE
Remove version locking of Velero in QA

### DIFF
--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -243,7 +243,6 @@ inputs = {
 
   velero_deploy                 = true
   velero_bucket_arn = "arn:aws:s3:::dfds-velero-qa"
-  velero_helm_chart_version     = "7.0.0"
   velero_plugin_for_aws_version = "v1.7.0"
   velero_plugin_for_csi_version = "v0.5.0"
 


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->

## Issue ticket number and link
https://github.com/dfds/cloudplatform/issues/2889

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
