### PR TITLE
feat: optionally mount kubeconfigs secret to atlantis

### DIFF
--- a/_sub/compute/helm-atlantis/main.tf
+++ b/_sub/compute/helm-atlantis/main.tf
@@ -111,6 +111,7 @@ resource "helm_release" "atlantis" {
       resources_requests_memory = var.resources_requests_memory
       resources_limits_cpu      = local.resources_limits_cpu
       resources_limits_memory   = local.resources_limits_memory
+      add_secret_volumes        = var.add_secret_volumes
     }),
     yamlencode({
       environmentSecrets = [

--- a/_sub/compute/helm-atlantis/values/values.yaml
+++ b/_sub/compute/helm-atlantis/values/values.yaml
@@ -43,3 +43,16 @@ repoConfig: |
   - id: "/.*/"
     allowed_overrides: [workflow]
     allow_custom_workflows: true
+
+%{ if add_secret_volumes ~}
+extraVolumes:
+  - name: kubeconfigs
+    secret:
+      secretName: kubeconfigs
+      defaultMode: 0644
+
+extraVolumeMounts:
+  - name: kubeconfigs
+    readOnly: true
+    mountPath: "/kubeconfigs"
+%{ endif ~}

--- a/_sub/compute/helm-atlantis/vars.tf
+++ b/_sub/compute/helm-atlantis/vars.tf
@@ -130,3 +130,9 @@ variable "environment" {
   type        = string
   description = "Environment"
 }
+
+variable "add_secret_volumes" {
+  type        = bool
+  default     = false
+  description = "Add secret volumes to the Atlantis deployment. Requires a secret deployed named 'kubeconfigs'"
+}

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -500,6 +500,7 @@ module "atlantis" {
   webhook_url               = var.atlantis_ingress
   webhook_events            = var.atlantis_webhook_events
   environment               = var.atlantis_environment
+  add_secret_volumes        = var.atlantis_add_secret_volumes
 
   environment_variables = local.atlantis_env_vars
 

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -768,6 +768,13 @@ variable "atlantis_grafana_cloud_sso_saml_idp_metadata" {
   description = "The SAML IDP metadata for SSO integration"
   sensitive   = true
 }
+
+variable "atlantis_add_secret_volumes" {
+  type        = bool
+  default     = false
+  description = "Add secret volumes to the Atlantis deployment"
+
+}
 # --------------------------------------------------
 # Crossplane
 # --------------------------------------------------

--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -145,6 +145,7 @@ inputs = {
   monitoring_kube_prometheus_stack_prometheus_confluent_metrics_api_key = "fake"
   monitoring_kube_prometheus_stack_prometheus_confluent_metrics_api_secret = "fake"
 
+
   # --------------------------------------------------
   # Goldpinger
   # --------------------------------------------------
@@ -170,6 +171,7 @@ inputs = {
   atlantis_chart_version       = "4.25.0"
   atlantis_environment         = "qa"
   atlantis_image_tag           = "0.0.50"
+  atlantis_add_secret_volumes  = true
 
   # --------------------------------------------------
   # Blackbox Exporter


### PR DESCRIPTION
## Describe your changes
Adds a toggle to optionally mount volumes into Atlantis. One is predefined, must have a secret existing called kubeconfigs

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
