### PR TITLE
fix: re-enable master test

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -203,10 +203,10 @@ stages:
                 - download: current
                   displayName: "Download test binary"
                   artifact: test-master
-                # - bash: ./src/qa-test-eks.sh test-run eu-west-1 qa $(Pipeline.Workspace)/test-master/test-master.bin
-                #   workingDirectory: $(Agent.BuildDirectory)/source
-                #   displayName: "Run tests"
-                #   timeoutInMinutes: 15
+                - bash: ./src/qa-test-eks.sh test-run eu-west-1 qa $(Pipeline.Workspace)/test-master/test-master.bin
+                  workingDirectory: $(Agent.BuildDirectory)/source
+                  displayName: "Run tests"
+                  timeoutInMinutes: 15
 
       - deployment: apply
         displayName: Apply from feature branch


### PR DESCRIPTION
## Describe your changes
Re-enabled the test on master branch now it is unbroken

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
