### PR TITLE
Add policies and trust for reading vpc information

### DIFF
--- a/_sub/security/iam-policies/main.tf
+++ b/_sub/security/iam-policies/main.tf
@@ -189,6 +189,21 @@ data "aws_iam_policy_document" "ssoreader" {
   }
 }
 
+# VPCReader
+data "aws_iam_policy_document" "vpcreader" {
+  statement {
+    sid    = "VpcReaderTf"
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeVpcs",
+      "ec2:DescribeTags"
+    ]
+    resources = [
+      "*"
+    ]
+  }
+}
+
 # ------------------------------------------------------------------------------
 # Trusted Account
 # ------------------------------------------------------------------------------

--- a/_sub/security/iam-policies/outputs.tf
+++ b/_sub/security/iam-policies/outputs.tf
@@ -6,6 +6,10 @@ output "ssoreader" {
   value = data.aws_iam_policy_document.ssoreader.json
 }
 
+output "vpcreader" {
+  value = data.aws_iam_policy_document.vpcreader.json
+}
+
 output "push_to_ecr" {
   value = data.aws_iam_policy_document.push_to_ecr.json
 }

--- a/security/org-account-context/dependencies.tf
+++ b/security/org-account-context/dependencies.tf
@@ -24,6 +24,17 @@ data "aws_iam_policy_document" "assume_role_policy_selfservice" {
   }
 }
 
+data "aws_iam_policy_document" "assume_role_policy_selfservice_api" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.shared_account_id}:role/selfservice-api"]
+    }
+  }
+}
+
 // Gives access to role through the individual Capability account
 data "aws_iam_policy_document" "shared_role_cap_acc" {
   statement {

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -68,6 +68,20 @@ module "iam_role_sso_reader" {
   }
 }
 
+module "iam_role_vpc_reader" {
+  source               = "../../_sub/security/iam-role"
+  role_name            = "vpc-reader"
+  role_description     = "Reads VPC and VPC tags"
+  max_session_duration = 28800 # 8 hours
+  assume_role_policy   = data.aws_iam_policy_document.assume_role_policy_selfservice_api.json
+  role_policy_name     = "VpcRead"
+  role_policy_document = module.iam_policies.vpcreader
+
+  providers = {
+    aws = aws.workload
+  }
+}
+
 module "iam_role_ecr_push" {
   source               = "../../_sub/security/iam-role"
   role_name            = "ecr-push"


### PR DESCRIPTION
## Describe your changes
Each account receives a role for reading VPCs and Tags.
This is assumable by the self-service API to present this information to GUI and CLI

## Issue ticket number and link
2924
https://github.com/dfds/cloudplatform/issues/2924

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
