### PR TITLE
Support Atlantis deployments for sandbox repos that are on a personal account instead of an organization account

### DIFF
--- a/_sub/compute/helm-atlantis/main.tf
+++ b/_sub/compute/helm-atlantis/main.tf
@@ -151,6 +151,7 @@ resource "github_repository_webhook" "hook" {
 }
 
 resource "github_actions_organization_secret" "atlantis_username" {
+  count                   = var.enable_github_secrets ? 1 : 0
   secret_name             = "${upper(var.environment)}_ATLANTIS_USERNAME"
   visibility              = "selected"
   plaintext_value         = var.auth_username
@@ -158,6 +159,7 @@ resource "github_actions_organization_secret" "atlantis_username" {
 }
 
 resource "github_actions_organization_secret" "atlantis_password" {
+  count                   = var.enable_github_secrets ? 1 : 0
   secret_name             = "${upper(var.environment)}_ATLANTIS_PASSWORD"
   visibility              = "selected"
   plaintext_value         = random_password.password.result

--- a/_sub/compute/helm-atlantis/vars.tf
+++ b/_sub/compute/helm-atlantis/vars.tf
@@ -136,3 +136,9 @@ variable "add_secret_volumes" {
   default     = false
   description = "Add secret volumes to the Atlantis deployment. Requires a secret deployed named 'kubeconfigs'"
 }
+
+variable "enable_github_secrets" {
+  type        = bool
+  default     = true
+  description = "Enable Github secrets for Atlantis"
+}

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -501,6 +501,7 @@ module "atlantis" {
   webhook_events            = var.atlantis_webhook_events
   environment               = var.atlantis_environment
   add_secret_volumes        = var.atlantis_add_secret_volumes
+  enable_github_secrets     = var.atlantis_enable_github_secrets
 
   environment_variables = local.atlantis_env_vars
 

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -591,6 +591,12 @@ variable "atlantis_environment" {
   default     = ""
 }
 
+variable "atlantis_enable_github_secrets" {
+  type        = bool
+  default     = true
+  description = "Enable Github secrets for Atlantis"
+}
+
 # --------------------------------------------------
 # Atlantis variables
 # --------------------------------------------------


### PR DESCRIPTION
## Describe your changes
If you are using a personal token to use Atlantis with a personal repo, it would previously fail because the sub module also attempts to add the Atlantis username and password as organizational secrets. With this fix, this becomes optional, but will still be enable dby default to ensure backward compability.

## Issue ticket number and link
None, found this bug on relevant testing.

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] ~~I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)~~
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
