### PR TITLE
Add the ability to prefix name and description of IPAM scope and pools

### DIFF
--- a/network/ipam/main.tf
+++ b/network/ipam/main.tf
@@ -9,7 +9,7 @@ module "ipam" {
 module "ipam_scope" {
   source     = "../../_sub/network/ipam-scope"
   ipam_id    = module.ipam.id
-  scope_name = var.ipam_scope_name
+  scope_name = length(var.ipam_prefix) > 0 ? "${var.ipam_prefix}-${var.ipam_scope_name}" : var.ipam_scope_name
   tags       = var.tags
 }
 
@@ -17,7 +17,7 @@ module "main_pool" {
   source   = "../../_sub/network/ipam-pool"
   scope_id = module.ipam_scope.id
   pool = {
-    name = "main"
+    name = length(var.ipam_prefix) > 0 ? "${var.ipam_prefix}-main" : "main"
     cidr = var.ipam_pools["main"].cidr
   }
   cascade = var.ipam_pools_cascade
@@ -28,7 +28,7 @@ module "platform_pool" {
   source   = "../../_sub/network/ipam-pool"
   scope_id = module.ipam_scope.id
   pool = {
-    name = "platform"
+    name = length(var.ipam_prefix) > 0 ? "${var.ipam_prefix}-platform" : "platform"
     cidr = var.ipam_pools["platform"].cidr
   }
   source_ipam_pool_id = module.main_pool.id
@@ -40,7 +40,7 @@ module "capabilities_pool" {
   source   = "../../_sub/network/ipam-pool"
   scope_id = module.ipam_scope.id
   pool = {
-    name = "capabilities"
+    name = length(var.ipam_prefix) > 0 ? "${var.ipam_prefix}-capabilities" : "capabilities"
     cidr = var.ipam_pools["capabilities"].cidr
   }
   source_ipam_pool_id = module.main_pool.id
@@ -52,7 +52,7 @@ module "unused_pool" {
   source   = "../../_sub/network/ipam-pool"
   scope_id = module.ipam_scope.id
   pool = {
-    name = "unused"
+    name = length(var.ipam_prefix) > 0 ? "${var.ipam_prefix}-unused" : "unused"
     cidr = var.ipam_pools["unused"].cidr
   }
   source_ipam_pool_id = module.main_pool.id
@@ -65,7 +65,7 @@ module "regional_platform_pools" {
   for_each = var.ipam_pools["platform"].sub_pools
   scope_id = module.ipam_scope.id
   pool = {
-    name   = "platform-${each.key}"
+    name   = length(var.ipam_prefix) > 0 ? "${var.ipam_prefix}-platform-${each.key}" : "platform-${each.key}"
     cidr   = each.value.cidr
     locale = each.key
   }
@@ -78,7 +78,7 @@ module "regional_capabilities_pools" {
   for_each = var.ipam_pools["capabilities"].sub_pools
   scope_id = module.ipam_scope.id
   pool = {
-    name   = "capabilities-${each.key}"
+    name   = length(var.ipam_prefix) > 0 ? "${var.ipam_prefix}-capabilities-${each.key}" : "capabilities-${each.key}"
     cidr   = each.value.cidr
     locale = each.key
   }

--- a/network/ipam/vars.tf
+++ b/network/ipam/vars.tf
@@ -70,6 +70,12 @@ variable "ipam_pools" {
 EOF
 }
 
+variable "ipam_prefix" {
+  type        = string
+  description = "Optional prefix to use for the IPAM scope and pools."
+  default     = ""
+}
+
 variable "tags" {
   type        = map(string)
   description = "A map of tags to apply to all the resources deployed by the module"


### PR DESCRIPTION
## Describe your changes
Add optional prefix that can be used to create uniqueness if other teams that create IPAM scopes and pools outside terraform use the same names for their resources as we do.

## Issue ticket number and link
https://github.com/dfds/cloudplatform/issues/2992

## Checklist before requesting a review
- [x] I have tested changes.
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
