### PR TITLE
Add support for multiple roles to assume when requesting CIDR range from IPAM

### DIFF
--- a/network/ipam/main.tf
+++ b/network/ipam/main.tf
@@ -107,6 +107,8 @@ module "ram_share_with_capabilities" {
   resource_arns = [
     for pool in values(module.regional_capabilities_pools) : pool.arn
   ]
-  principals = formatlist(var.ipam_role_pattern, module.org-account-query.account_ids, var.ipam_role_name)
-  tags       = var.tags
+  principals = flatten([
+    for pattern in var.ipam_role_patterns : formatlist(pattern, module.org-account-query.account_ids)
+  ])
+  tags = var.tags
 }

--- a/network/ipam/vars.tf
+++ b/network/ipam/vars.tf
@@ -87,20 +87,14 @@ variable "ipam_ou_id" {
   description = "The ID of the AWS Organization OU that you want to query for accounts. This is used for sharing access to the IPAM pools."
 }
 
-variable "ipam_role_name" {
-  type        = string
-  description = "The name of an IAM role in each AWS Organization account that is allowed to request IP addresses from the IPAM pools."
-  default     = "AWSServiceRoleForIPAM"
-}
-
-variable "ipam_role_pattern" {
-  type        = string
+variable "ipam_role_patterns" {
+  type        = list(string)
   description = <<EOF
-    The pattern of a role ARN that is allowed to request IP addresses from the IPAM pools.
-    The %s placeholders will be replaced with the AWS account ID from var.ipam_ou_id
-    and the value of var.ipam_role_name within this module.
+    The pattern of a role ARNs that are1 allowed to request IP addresses from the IPAM pools.
+    The %s placeholders will be replaced with the AWS account ID from accounts under
+    the OU specified by var.ipam_ou_id.
 EOF
-  default     = "arn:aws:iam::%s:role/aws-service-role/ipam.amazonaws.com/%s"
+  default     = ["arn:aws:iam::%s:role/aws-service-role/ipam.amazonaws.com/AWSServiceRoleForIPAM"]
 }
 
 variable "tags" {


### PR DESCRIPTION
## Describe your changes
We need to support different pipelines that uses IPAM. Some can use the native IPAM roles. Others can't because they are already in a different context.

It's a major release because the changing type of a variable breaks the only implementation we have of it.

## Issue ticket number and link
https://github.com/dfds/cloudplatform/issues/2997

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
