### PR TITLE
Fix problem with missing dependencies between Flux manifests in shared-manifests

### DIFF
--- a/_sub/compute/k8s-shared-manifests/values/shared-manifests.yaml
+++ b/_sub/compute/k8s-shared-manifests/values/shared-manifests.yaml
@@ -60,7 +60,7 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: shared-manifests
+  name: shared-manifests-druid-operator
   namespace: flux-system
 spec:
   interval: 1m0s
@@ -69,5 +69,20 @@ spec:
   sourceRef:
     kind: GitRepository
     name: shared-manifests-git
-  path: ./infrastructure/${overlay_folder}
+  path: ./infrastructure/${overlay_folder}/druid-operator
+  prune: ${prune}
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: shared-manifests-tiny-cluster
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  dependsOn:
+    - name: shared-manifests-druid-operator
+  sourceRef:
+    kind: GitRepository
+    name: shared-manifests-git
+  path: ./infrastructure/${overlay_folder}/tiny-cluster
   prune: ${prune}


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
