### PR TITLE
Added IMDSv1 Preventive Policies

### DIFF
--- a/security/org-policies/preventive.tf
+++ b/security/org-policies/preventive.tf
@@ -250,4 +250,50 @@ data "aws_iam_policy_document" "preventive" {
       values   = ["AWS_IAM"]
     }
   }
+
+  statement {
+    sid       = "RequireAllEc2RolesToUseV2"
+    effect    = "Deny"
+    resources = ["*"]
+    actions   = ["*"]
+
+    condition {
+      test     = "NumericLessThan"
+      variable = "ec2:RoleDelivery"
+      values   = ["2.0"]
+    }
+  }
+
+  statement {
+    sid       = "RequireImdsV2"
+    effect    = "Deny"
+    resources = ["arn:aws:ec2:*:*:instance/*"]
+    actions   = ["ec2:RunInstances"]
+
+    condition {
+      test     = "StringNotEquals"
+      variable = "ec2:MetadataHttpTokens"
+      values   = ["required"]
+    }
+  }
+
+  statement {
+    sid       = ""
+    effect    = "Deny"
+    resources = ["*"]
+    actions   = ["ec2:ModifyInstanceMetadataOptions"]
+  }
+
+  statement {
+    sid       = "MaxImdsHopLimit"
+    effect    = "Deny"
+    resources = ["arn:aws:ec2:*:*:instance/*"]
+    actions   = ["ec2:RunInstances"]
+
+    condition {
+      test     = "NumericGreaterThan"
+      variable = "ec2:MetadataHttpPutResponseHopLimit"
+      values   = ["2"]
+    }
+  }
 }


### PR DESCRIPTION
## Describe your changes
Added policies to prevent users from using the old v1 of the metadata service API.

## Issue ticket number and link
[#2991](https://github.com/dfds/cloudplatform/issues/2991)

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
