### PR TITLE
Refactor shared-manifests deployment to use GitHub deploy key instead of username and token

### DIFF
--- a/_sub/compute/k8s-shared-manifests/main.tf
+++ b/_sub/compute/k8s-shared-manifests/main.tf
@@ -7,10 +7,39 @@ data "github_repository" "main" {
   full_name = "${var.repo_owner}/${var.repo_name}"
 }
 
+
 locals {
   default_repo_branch = data.github_repository.main.default_branch
   repo_branch         = length(var.repo_branch) > 0 ? var.repo_branch : local.default_repo_branch
   cluster_repo_path   = "clusters/${var.cluster_name}"
+}
+
+resource "tls_private_key" "this" {
+  algorithm = "ED25519"
+}
+
+resource "github_repository_deploy_key" "this" {
+  title      = "Deployment key for ${var.cluster_name} cluster"
+  repository = var.shared_manifests_repo_name
+  key        = tls_private_key.this.public_key_openssh
+  read_only  = false
+}
+
+
+#The known hosts entry is from https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints
+resource "kubernetes_secret" "this" {
+  metadata {
+    name      = "shared-manifests-git"
+    namespace = "flux-system"
+  }
+
+  data = {
+    identity       = tls_private_key.this.private_key_pem
+    "identity.pub" = tls_private_key.this.public_key_openssh
+    known_hosts    = "github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg="
+  }
+
+  type = "Opaque"
 }
 
 resource "github_repository_file" "shared_manifests" {
@@ -21,8 +50,6 @@ resource "github_repository_file" "shared_manifests" {
     shared_manifests_repo_url    = var.shared_manifests_repo_url
     shared_manifests_repo_branch = var.shared_manifests_repo_branch
     overlay_folder               = var.overlay_folder
-    account_id                   = var.account_id
-    role_name                    = var.role_name
     prune                        = var.prune
   })
   overwrite_on_create = var.overwrite_on_create

--- a/_sub/compute/k8s-shared-manifests/values/shared-manifests.yaml
+++ b/_sub/compute/k8s-shared-manifests/values/shared-manifests.yaml
@@ -1,49 +1,4 @@
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: ssm-secrets
-  namespace: flux-system
-  annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::${account_id}:role/${role_name}
-    eks.amazonaws.com/sts-regional-endpoints: "true"
----
-apiVersion: external-secrets.io/v1beta1
-kind: SecretStore
-metadata:
-  name: shared-manifests-git
-  namespace: flux-system
-spec:
-  provider:
-    aws:
-      service: ParameterStore
-      region: eu-west-1
-      auth:
-        jwt:
-          serviceAccountRef:
-            name: ssm-secrets
----
-apiVersion: external-secrets.io/v1beta1
-kind: ExternalSecret
-metadata:
-  name: shared-manifests-git
-  namespace: flux-system
-spec:
-  refreshInterval: 1m
-  secretStoreRef:
-    kind: SecretStore
-    name: shared-manifests-git
-  target:
-    name: shared-manifests-git
-    creationPolicy: Owner
-  data:
-    - secretKey: username
-      remoteRef:
-        key: /github/shared-manifests/owner
-    - secretKey: password
-      remoteRef:
-        key: /github/shared-manifests/token
----
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
@@ -66,6 +21,8 @@ spec:
   interval: 1m0s
   dependsOn:
     - name: flux-system
+    - name: platform-apps-sources
+    - name: platform-apps-external-secrets-helm
   sourceRef:
     kind: GitRepository
     name: shared-manifests-git

--- a/_sub/compute/k8s-shared-manifests/vars.tf
+++ b/_sub/compute/k8s-shared-manifests/vars.tf
@@ -41,16 +41,13 @@ variable "shared_manifests_repo_branch" {
   description = "The default branch for your GitOps manifests"
 }
 
+variable "shared_manifests_repo_name" {
+  type        = string
+  description = "Name of the Github repo to read the shared manifests from"
+}
+
 variable "prune" {
   type        = bool
   default     = true
   description = "Enable Garbage collection"
-}
-
-variable "account_id" {
-  type = string
-}
-
-variable "role_name" {
-  type = string
 }

--- a/_sub/compute/k8s-shared-manifests/versions.tf
+++ b/_sub/compute/k8s-shared-manifests/versions.tf
@@ -6,5 +6,13 @@ terraform {
       source  = "integrations/github"
       version = "~> 6.3.0"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.32.0"
+    }
   }
 }

--- a/_sub/compute/k8s-shared-manifests/versions.tofu
+++ b/_sub/compute/k8s-shared-manifests/versions.tofu
@@ -6,5 +6,13 @@ terraform {
       source  = "integrations/github"
       version = "~> 6.3.0"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.32.0"
+    }
   }
 }

--- a/compute/k8s-services/dependencies.tf
+++ b/compute/k8s-services/dependencies.tf
@@ -261,7 +261,7 @@ locals {
 
 locals {
   fluxcd_apps_repo_url      = "${var.fluxcd_apps_git_provider_url}${var.fluxcd_apps_repo_owner}/${var.fluxcd_apps_repo_name}"
-  shared_manifests_repo_url = "${var.fluxcd_apps_git_provider_url}${var.shared_manifests_repo_owner}/${var.shared_manifests_repo_name}"
+  shared_manifests_repo_url = "ssh://git@github.com/${var.shared_manifests_repo_owner}/${var.shared_manifests_repo_name}.git"
 }
 
 # --------------------------------------------------

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -1002,24 +1002,6 @@ module "github_arc_runners" {
 # other platform teams
 # --------------------------------------------------
 
-module "shared_manifests_git_owner" {
-  source          = "../../_sub/security/ssm-parameter-store"
-  count           = var.shared_manifests_deploy ? 1 : 0
-  key_name        = "/github/shared-manifests/owner"
-  key_description = "Git owner for the shared Flux manifests"
-  key_value       = var.fluxcd_bootstrap_repo_owner
-  tag_createdby   = var.ssm_param_createdby != null ? var.ssm_param_createdby : "k8s-services"
-}
-
-module "shared_manifests_git_token" {
-  source          = "../../_sub/security/ssm-parameter-store"
-  count           = var.shared_manifests_deploy ? 1 : 0
-  key_name        = "/github/shared-manifests/token"
-  key_description = "Git owner's token for the shared Flux manifests"
-  key_value       = var.fluxcd_bootstrap_repo_owner_token
-  tag_createdby   = var.ssm_param_createdby != null ? var.ssm_param_createdby : "k8s-services"
-}
-
 module "shared_manifests" {
   source                       = "../../_sub/compute/k8s-shared-manifests"
   count                        = var.shared_manifests_deploy ? 1 : 0
@@ -1031,16 +1013,13 @@ module "shared_manifests" {
   overwrite_on_create          = var.fluxcd_bootstrap_overwrite_on_create
   shared_manifests_repo_url    = local.shared_manifests_repo_url
   shared_manifests_repo_branch = var.shared_manifests_repo_branch
-  account_id                   = var.aws_workload_account_id
-  role_name                    = var.external_secrets_ssm_iam_role_name
+  shared_manifests_repo_name   = var.shared_manifests_repo_name
 
   providers = {
     github = github.fluxcd
   }
 
   depends_on = [
-    module.shared_manifests_git_owner,
-    module.shared_manifests_git_token,
-    module.external_secrets_ssm
+    module.platform_fluxcd
   ]
 }


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
