### PR TITLE
Make usage of azuread provider compliant with version 3 of the provider

### DIFF
--- a/_sub/compute/helm-kube-prometheus-stack/main.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/main.tf
@@ -54,7 +54,7 @@ resource "helm_release" "kube_prometheus_stack" {
       grafana_storage_enabled     = var.grafana_storage_enabled
       grafana_storage_class       = var.grafana_storage_class
       grafana_storage_size        = var.grafana_storage_size
-      grafana_app_id              = try(azuread_application.grafana[0].application_id, "")
+      grafana_app_id              = try(azuread_application.grafana[0].client_id, "")
       grafana_app_secret          = try(azuread_application_password.grafana[0].value, "")
       grafana_azure_tenant_id     = length(var.grafana_azure_tenant_id) == 36 ? var.grafana_azure_tenant_id : ""
       tolerations                 = var.tolerations,

--- a/_sub/compute/helm-kube-prometheus-stack/versions.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/versions.tf
@@ -20,7 +20,7 @@ terraform {
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.53.0"
+      version = "~> 3.0.0"
     }
   }
 }

--- a/_sub/compute/helm-kube-prometheus-stack/versions.tofu
+++ b/_sub/compute/helm-kube-prometheus-stack/versions.tofu
@@ -20,7 +20,7 @@ terraform {
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.53.0"
+      version = "~> 3.0.0"
     }
   }
 }

--- a/_sub/security/azure-app-registration/main.tf
+++ b/_sub/security/azure-app-registration/main.tf
@@ -10,8 +10,8 @@ resource "azuread_application" "app" {
 }
 
 resource "azuread_service_principal" "sp" {
-  client_id = azuread_application.app.application_id
-  owners         = [data.azuread_client_config.current.object_id]
+  client_id = azuread_application.app.client_id
+  owners    = [data.azuread_client_config.current.object_id]
 }
 
 resource "random_password" "password" {

--- a/_sub/security/azure-app-registration/outputs.tf
+++ b/_sub/security/azure-app-registration/outputs.tf
@@ -2,8 +2,8 @@ output "tenant_id" {
   value = data.azuread_client_config.current.tenant_id
 }
 
-output "application_id" {
-  value = azuread_application.app.application_id
+output "client_id" {
+  value = azuread_application.app.client_id
 }
 
 output "application_key" {

--- a/_sub/security/azure-app-registration/versions.tf
+++ b/_sub/security/azure-app-registration/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.53.0"
+      version = "~> 3.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/_sub/security/azure-app-registration/versions.tofu
+++ b/_sub/security/azure-app-registration/versions.tofu
@@ -7,7 +7,7 @@ terraform {
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.53.0"
+      version = "~> 3.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/_sub/security/azuread-group/versions.tf
+++ b/_sub/security/azuread-group/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azuread = {
       source  = "hashicorp/azuread"
-      version = "2.53.1"
+      version = "3.0.1"
     }
   }
 }

--- a/_sub/security/azuread-group/versions.tofu
+++ b/_sub/security/azuread-group/versions.tofu
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azuread = {
       source  = "hashicorp/azuread"
-      version = "2.53.1"
+      version = "3.0.1"
     }
   }
 }

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -98,7 +98,7 @@ module "traefik_alb_auth" {
   alb_certificate_arn   = module.traefik_alb_cert.certificate_arn
   nodes_sg_id           = data.terraform_remote_state.cluster.outputs.eks_cluster_nodes_sg_id
   azure_tenant_id       = try(module.traefik_alb_auth_appreg[0].tenant_id, "")
-  azure_client_id       = try(module.traefik_alb_auth_appreg[0].application_id, "")
+  azure_client_id       = try(module.traefik_alb_auth_appreg[0].client_id, "")
   azure_client_secret   = try(module.traefik_alb_auth_appreg[0].application_key, "")
   access_logs_bucket    = module.traefik_alb_s3_access_logs.name
 

--- a/compute/k8s-services/versions.tf
+++ b/compute/k8s-services/versions.tf
@@ -25,7 +25,7 @@ terraform {
 
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.53.0"
+      version = "~> 3.0.0"
     }
 
     github = {

--- a/compute/k8s-services/versions.tofu
+++ b/compute/k8s-services/versions.tofu
@@ -25,7 +25,7 @@ terraform {
 
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.53.0"
+      version = "~> 3.0.0"
     }
 
     github = {


### PR DESCRIPTION
- **chore(deps): update terraform azuread to v3**
- **Make usage of azuread provider compliant with version 3**

## Describe your changes
Check the upgrade guide for v2 to v3 of azuread provider and change the use of application_id to client_id where applicable.

## Issue ticket number and link
https://github.com/dfds/cloudplatform/issues/3021

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
