### PR TITLE
All Renovate updates gets treated as patches (requested by rifis) Mass update is happening on Tuesdays for this repo only Patch and Minor updates gets automerged on successful tests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     "config:recommended"
   ],
   "schedule": [
-    "after 6am and before 8am on wednesday"
+    "after 6am and before 8am on tuesday"
   ],
   "branchPrefix": "feature/renovate/",
   "ignorePaths": [
@@ -67,7 +67,7 @@
       "addLabels": [
         "release:patch"
       ],
-      "minimumReleaseAge": "1 day",
+      "minimumReleaseAge": "0 day",
       "automerge": true
     },
     {
@@ -75,19 +75,19 @@
         "minor"
       ],
       "addLabels": [
-        "release:minor"
+        "release:patch"
       ],
-      "minimumReleaseAge": "7 days",
-      "automerge": false
+      "minimumReleaseAge": "1 days",
+      "automerge": true
     },
     {
       "matchUpdateTypes": [
         "major"
       ],
       "addLabels": [
-        "release:major"
+        "release:patch"
       ],
-      "minimumReleaseAge": "14 days",
+      "minimumReleaseAge": "7 days",
       "automerge": false
     }
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -67,7 +67,6 @@
       "addLabels": [
         "release:patch"
       ],
-      "minimumReleaseAge": "0 day",
       "automerge": true
     },
     {
@@ -77,7 +76,6 @@
       "addLabels": [
         "release:patch"
       ],
-      "minimumReleaseAge": "1 days",
       "automerge": true
     },
     {


### PR DESCRIPTION
## Describe your changes
- All Renovate updates gets labeled as patches (requested by @rifisdfds ) 
- Mass update is happening on Tuesdays for this repo only. This is to ensure the infrastructure is updated before its downstream dependant pipelines are updated.
- Patch and Minor updates gets automerged on successful tests

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
