### PR TITLE
Version lock Velero in QA to avoid runtime errors

### DIFF
--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -240,6 +240,7 @@ inputs = {
   # --------------------------------------------------
 
   velero_deploy                 = true
+  velero_helm_chart_version     = "7.1.0"
   velero_bucket_arn = "arn:aws:s3:::dfds-velero-qa"
   velero_plugin_for_aws_version = "v1.7.0"
   velero_plugin_for_csi_version = "v0.5.0"


### PR DESCRIPTION
Velero is currently not working in QA