### PR TITLE
Add support for replication for cloudtrail bucket

### DIFF
--- a/_sub/security/iam-bucket-replication/main.tf
+++ b/_sub/security/iam-bucket-replication/main.tf
@@ -1,0 +1,89 @@
+locals {
+  s3_source_bucket_arns      = concat([var.s3_source_bucket_arn], formatlist("%s/*", var.s3_source_bucket_arn))
+  s3_destination_bucket_arns = concat(formatlist("%s/*", var.s3_destination_bucket_arn))
+}
+
+data "aws_iam_policy_document" "this" {
+  statement {
+    sid    = "SourceBucketPermissions"
+    effect = "Allow"
+
+    resources = local.s3_source_bucket_arns
+
+    actions = [
+      "s3:GetObjectLegalHold",
+      "s3:GetObjectRetention",
+      "s3:GetObjectVersionAcl",
+      "s3:GetObjectVersionForReplication",
+      "s3:GetObjectVersionTagging",
+      "s3:GetReplicationConfiguration",
+      "s3:ListBucket"
+    ]
+  }
+
+  statement {
+    sid       = "DestinationBucketPermissions"
+    effect    = "Allow"
+    resources = local.s3_destination_bucket_arns
+
+    actions = [
+      "s3:GetObjectVersionTagging",
+      "s3:ObjectOwnerOverrideToBucketOwner",
+      "s3:ReplicateDelete",
+      "s3:ReplicateObject",
+      "s3:ReplicateTags"
+    ]
+  }
+
+  statement {
+    sid       = "SourceBucketKMSKey"
+    effect    = "Allow"
+    resources = [var.kms_key_source_arn]
+
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+    ]
+  }
+
+  statement {
+    sid       = "DestinationBucketKMSKey"
+    effect    = "Allow"
+    resources = [var.kms_key_destination_arn]
+
+    actions = [
+      "kms:Encrypt",
+      "kms:GenerateDataKey",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "this" {
+  name   = var.policy_name
+  path   = "/"
+  policy = data.aws_iam_policy_document.this.json
+  tags   = var.tags
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "this" {
+  name               = var.role_name
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "this" {
+  role       = aws_iam_role.this.name
+  policy_arn = aws_iam_policy.this.arn
+}

--- a/_sub/security/iam-bucket-replication/outputs.tf
+++ b/_sub/security/iam-bucket-replication/outputs.tf
@@ -1,0 +1,3 @@
+output "role_arn" {
+  value = aws_iam_role.this.arn
+}

--- a/_sub/security/iam-bucket-replication/vars.tf
+++ b/_sub/security/iam-bucket-replication/vars.tf
@@ -1,29 +1,24 @@
-variable "role_name" {
+variable "replication_source_role_name" {
   type        = string
   description = "Name of the role to create"
 }
 
-variable "policy_name" {
-  type        = string
-  description = "Name of the IAM policy to create"
-}
-
-variable "s3_source_bucket_arn" {
+variable "replication_source_bucket_arn" {
   type        = string
   description = "The ARN of the S3 bucket to allow replication from"
 }
 
-variable "s3_destination_bucket_arn" {
+variable "replication_destination_bucket_arn" {
   type        = string
   description = "The ARN of the S3 bucket to allow replication to"
 }
 
-variable "kms_key_source_arn" {
+variable "replication_source_kms_key_arn" {
   type        = string
   description = "The ARN of the KMS key to allow decryption of the source bucket"
 }
 
-variable "kms_key_destination_arn" {
+variable "replication_destination_kms_key_arn" {
   type        = string
   description = "The ARN of the KMS key to allow encryption of the destination bucket"
 }

--- a/_sub/security/iam-bucket-replication/vars.tf
+++ b/_sub/security/iam-bucket-replication/vars.tf
@@ -1,0 +1,34 @@
+variable "role_name" {
+  type        = string
+  description = "Name of the role to create"
+}
+
+variable "policy_name" {
+  type        = string
+  description = "Name of the IAM policy to create"
+}
+
+variable "s3_source_bucket_arn" {
+  type        = string
+  description = "The ARN of the S3 bucket to allow replication from"
+}
+
+variable "s3_destination_bucket_arn" {
+  type        = string
+  description = "The ARN of the S3 bucket to allow replication to"
+}
+
+variable "kms_key_source_arn" {
+  type        = string
+  description = "The ARN of the KMS key to allow decryption of the source bucket"
+}
+
+variable "kms_key_destination_arn" {
+  type        = string
+  description = "The ARN of the KMS key to allow encryption of the destination bucket"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to apply to the role"
+}

--- a/_sub/security/iam-bucket-replication/versions.tf
+++ b/_sub/security/iam-bucket-replication/versions.tf
@@ -1,0 +1,10 @@
+
+terraform {
+  required_version = ">= 1.3.0, < 1.6.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.75.0"
+    }
+  }
+}

--- a/_sub/security/iam-bucket-replication/versions.tofu
+++ b/_sub/security/iam-bucket-replication/versions.tofu
@@ -1,0 +1,10 @@
+
+terraform {
+  required_version = ">= 1.8.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.75.0"
+    }
+  }
+}

--- a/_sub/storage/s3-cloudtrail-bucket/vars.tf
+++ b/_sub/storage/s3-cloudtrail-bucket/vars.tf
@@ -19,3 +19,39 @@ variable "create_s3_bucket" {
   type    = bool
   default = false
 }
+
+variable "tags" {
+  type        = map(string)
+  description = "A map of tags to apply to all the resources deployed by the module"
+  default     = {}
+}
+
+variable "replication_enabled" {
+  type        = bool
+  description = "Enable S3 bucket replication."
+  default     = false
+}
+
+variable "replication_source_role_arn" {
+  type        = string
+  description = "The ARN of the IAM role to use for S3 bucket replication."
+  default     = null
+}
+
+variable "replication_destination_account_id" {
+  type        = string
+  description = "The account ID of the destination bucket."
+  default     = null
+}
+
+variable "replication_destination_bucket_arn" {
+  type        = string
+  description = "The ARN of the destination bucket."
+  default     = null
+}
+
+variable "replication_destination_kms_key_arn" {
+  type        = string
+  description = "The ARN of the KMS key to use for encryption of the destination bucket."
+  default     = null
+}

--- a/security/org-account/vars.tf
+++ b/security/org-account/vars.tf
@@ -42,7 +42,7 @@ variable "master_account_id" {
 }
 
 variable "security_account_id" {
-  type = string
+  type        = string
   description = "The AWS account ID of the Organizations Security account"
 }
 
@@ -93,7 +93,43 @@ variable "iam_github_oidc_policy_name" {
 }
 
 variable "steampipe_audit_role_name" {
-  type = string
+  type        = string
   description = "Name of the IAM role used by Steampipe for reading resources"
-  default = "steampipe-audit"
+  default     = "steampipe-audit"
+}
+
+variable "cloudtrail_replication_enabled" {
+  type        = bool
+  description = "Enable S3 bucket replication."
+  default     = false
+}
+
+variable "cloudtrail_replication_destination_account_id" {
+  type        = string
+  description = "The account ID of the destination bucket."
+  default     = null
+}
+
+variable "cloudtrail_replication_destination_bucket_arn" {
+  type        = string
+  description = "The ARN of the destination bucket."
+  default     = null
+}
+
+variable "cloudtrail_replication_source_role_name" {
+  type        = string
+  description = "Name of the role to create"
+  default     = null
+}
+
+variable "cloudtrail_replication_source_kms_key_arn" {
+  type        = string
+  description = "The ARN of the KMS key to allow decryption of the source bucket"
+  default     = null
+}
+
+variable "cloudtrail_replication_destination_kms_key_arn" {
+  type        = string
+  description = "The ARN of the KMS key to allow encryption of the destination bucket"
+  default     = null
 }


### PR DESCRIPTION
- **Add sub module to handle S3 bucket to buck replication. Supports cross account replication.**
- **Refactor sub module to make more distinct variable names**
- **Export teh role arn of the newly created role**

## Describe your changes
<!--Describe the change here-->

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
