### PR TITLE
Add support for creating IAM role for S3 replication in services module

### DIFF
--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -2,6 +2,17 @@
 # ALB access logs S3 bucket
 # --------------------------------------------------
 
+module "alb_access_logs_bucket_replication_role" {
+  source                              = "../../_sub/security/iam-bucket-replication"
+  count                               = var.alb_access_logs_replication_enabled ? 1 : 0
+  replication_source_role_name        = var.alb_access_logs_replication_source_role_name
+  replication_source_bucket_arn       = "arn:aws:s3:::${local.alb_access_log_bucket_name}"
+  replication_destination_bucket_arn  = var.alb_access_logs_replication_destination_bucket_arn
+  replication_source_kms_key_arn      = var.alb_access_logs_replication_source_kms_key_arn
+  replication_destination_kms_key_arn = var.alb_access_logs_replication_destination_kms_key_arn
+  tags                                = var.tags
+}
+
 module "traefik_alb_s3_access_logs" {
   source          = "../../_sub/storage/s3-bucket-lifecycle"
   name            = local.alb_access_log_bucket_name

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -70,6 +70,36 @@ variable "traefik_alb_s3_access_logs_retiontion_days" {
   default = 30
 }
 
+variable "alb_access_logs_replication_enabled" {
+  type        = bool
+  description = "Enable S3 bucket replication."
+  default     = false
+}
+
+variable "alb_access_logs_replication_destination_bucket_arn" {
+  type        = string
+  description = "The ARN of the destination bucket."
+  default     = null
+}
+
+variable "alb_access_logs_replication_source_role_name" {
+  type        = string
+  description = "Name of the role to create"
+  default     = null
+}
+
+variable "alb_access_logs_replication_source_kms_key_arn" {
+  type        = string
+  description = "The ARN of the KMS key to allow decryption of the source bucket"
+  default     = null
+}
+
+variable "alb_access_logs_replication_destination_kms_key_arn" {
+  type        = string
+  description = "The ARN of the KMS key to allow encryption of the destination bucket"
+  default     = null
+}
+
 # --------------------------------------------------
 # Load Balancers in front of Traefik
 # --------------------------------------------------


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
