### PR TITLE
Add support for excluding resource types from Velero backups

### DIFF
--- a/_sub/storage/velero/main.tf
+++ b/_sub/storage/velero/main.tf
@@ -38,20 +38,21 @@ resource "github_repository_file" "velero_flux_helm_patch_yaml" {
   branch     = data.github_branch.flux_branch.branch
   file       = "${local.helm_repo_path}/patch.yaml"
   content = templatefile("${path.module}/values/patch.yaml", {
-    helm_chart_version                           = var.helm_chart_version
-    helm_repo_name                               = var.helm_repo_name
-    image_tag                                    = var.image_tag
-    snapshots_enabled                            = var.snapshots_enabled
-    plugin_for_aws_version                       = var.plugin_for_aws_version
-    plugin_for_csi_version                       = var.plugin_for_csi_version
-    log_level                                    = var.log_level
-    bucket_name                                  = local.bucket_name
-    bucket_region                                = var.bucket_region
-    velero_role_arn                              = aws_iam_role.velero_role.arn
-    cluster_name                                 = var.cluster_name
-    cron_schedule                                = var.cron_schedule
-    schedules_template_ttl                       = var.schedules_template_ttl
-    schedules_template_include_cluster_resources = var.schedules_template_include_cluster_resources
+    helm_chart_version                  = var.helm_chart_version
+    helm_repo_name                      = var.helm_repo_name
+    image_tag                           = var.image_tag
+    snapshots_enabled                   = var.snapshots_enabled
+    plugin_for_aws_version              = var.plugin_for_aws_version
+    plugin_for_csi_version              = var.plugin_for_csi_version
+    log_level                           = var.log_level
+    bucket_name                         = local.bucket_name
+    bucket_region                       = var.bucket_region
+    velero_role_arn                     = aws_iam_role.velero_role.arn
+    cluster_name                        = var.cluster_name
+    cron_schedule                       = var.cron_schedule
+    schedules_template_ttl              = var.schedules_template_ttl
+    excluded_cluster_scoped_resources   = var.excluded_cluster_scoped_resources
+    excluded_namespace_scoped_resources = var.excluded_namespace_scoped_resources
   })
   overwrite_on_create = var.overwrite_on_create
 }

--- a/_sub/storage/velero/main.tf
+++ b/_sub/storage/velero/main.tf
@@ -43,7 +43,6 @@ resource "github_repository_file" "velero_flux_helm_patch_yaml" {
     image_tag                           = var.image_tag
     snapshots_enabled                   = var.snapshots_enabled
     plugin_for_aws_version              = var.plugin_for_aws_version
-    plugin_for_csi_version              = var.plugin_for_csi_version
     log_level                           = var.log_level
     bucket_name                         = local.bucket_name
     bucket_region                       = var.bucket_region

--- a/_sub/storage/velero/values/patch.yaml
+++ b/_sub/storage/velero/values/patch.yaml
@@ -49,3 +49,5 @@ spec:
           ttl: "${schedules_template_ttl}"
           snapshotVolumes: ${snapshots_enabled}
           includeClusterResources: ${schedules_template_include_cluster_resources}
+          excludedNamespaceScopedResources:
+          excludedClusterScopedResources:

--- a/_sub/storage/velero/values/patch.yaml
+++ b/_sub/storage/velero/values/patch.yaml
@@ -48,6 +48,5 @@ spec:
         template:
           ttl: "${schedules_template_ttl}"
           snapshotVolumes: ${snapshots_enabled}
-          includeClusterResources: ${schedules_template_include_cluster_resources}
-          excludedNamespaceScopedResources:
-          excludedClusterScopedResources:
+          excludedNamespaceScopedResources: ${excluded_namespace_scoped_resources}
+          excludedClusterScopedResources: ${excluded_cluster_scoped_resources}

--- a/_sub/storage/velero/values/patch.yaml
+++ b/_sub/storage/velero/values/patch.yaml
@@ -24,11 +24,6 @@ spec:
         volumeMounts:
           - mountPath: /target
             name: plugins
-      - name: velero-plugin-for-csi
-        image: velero/velero-plugin-for-csi:${plugin_for_csi_version}
-        volumeMounts:
-          - mountPath: /target
-            name: plugins
     configuration:
       logLevel: ${log_level}
       backupStorageLocation:
@@ -48,5 +43,15 @@ spec:
         template:
           ttl: "${schedules_template_ttl}"
           snapshotVolumes: ${snapshots_enabled}
-          excludedNamespaceScopedResources: ${excluded_namespace_scoped_resources}
-          excludedClusterScopedResources: ${excluded_cluster_scoped_resources}
+%{ if length(excluded_namespace_scoped_resources) > 0 ~}
+          excludedNamespaceScopedResources:
+%{ for ex_ns in excluded_namespace_scoped_resources ~}
+            - ${ex_ns}
+%{ endfor ~}
+%{ endif ~}
+%{ if length(excluded_cluster_scoped_resources) > 0 ~}
+          excludedClusterScopedResources:
+%{ for ex_cl in excluded_cluster_scoped_resources ~}
+            - ${ex_cl}
+%{ endfor ~}
+%{ endif ~}

--- a/_sub/storage/velero/vars.tf
+++ b/_sub/storage/velero/vars.tf
@@ -75,7 +75,7 @@ variable "helm_chart_version" {
 
 variable "image_tag" {
   type        = string
-  default     = "v1.12.4"
+  default     = ""
   description = "Override the image tag in the Helm chart with a custom version"
 }
 
@@ -85,15 +85,6 @@ variable "plugin_for_aws_version" {
   validation {
     condition     = can(regex("^v[[:digit:]].[[:digit:]].[[:digit:]]+", var.plugin_for_aws_version))
     error_message = "Velero plugin for AWS must specify a version. The version must start with the letter v and followed by a semantic version number."
-  }
-}
-
-variable "plugin_for_csi_version" {
-  type        = string
-  description = "The version of velero-plugin-for-csi to use as initContainer"
-  validation {
-    condition     = can(regex("^v[[:digit:]].[[:digit:]].[[:digit:]]+", var.plugin_for_csi_version))
-    error_message = "Velero plugin for CSI must specify a version. The version must start with the letter v and followed by a semantic version number."
   }
 }
 

--- a/_sub/storage/velero/vars.tf
+++ b/_sub/storage/velero/vars.tf
@@ -61,12 +61,6 @@ variable "schedules_template_ttl" {
   description = "Time to live for the scheduled backup."
 }
 
-variable "schedules_template_include_cluster_resources" {
-  type        = bool
-  default     = false
-  description = "Should Velero also backup cluster resources?"
-}
-
 variable "helm_repo_name" {
   type        = string
   default     = "vmware-tanzu"
@@ -155,4 +149,16 @@ variable "workload_account_id" {
   type        = string
   default     = null
   description = "The workload account ID."
+}
+
+variable "excluded_cluster_scoped_resources" {
+  type        = list(string)
+  default     = []
+  description = "List of cluster-scoped resources to exclude from backup"
+}
+
+variable "excluded_namespace_scoped_resources" {
+  type        = list(string)
+  default     = []
+  description = "List of namespace-scoped resources to exclude from backup"
 }

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -654,7 +654,6 @@ module "velero" {
   helm_chart_version                  = var.velero_helm_chart_version
   image_tag                           = var.velero_image_tag
   plugin_for_aws_version              = var.velero_plugin_for_aws_version
-  plugin_for_csi_version              = var.velero_plugin_for_csi_version
   snapshots_enabled                   = var.velero_snapshots_enabled
   overwrite_on_create                 = var.fluxcd_bootstrap_overwrite_on_create
   gitops_apps_repo_url                = local.fluxcd_apps_repo_url

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -643,27 +643,29 @@ module "external_snapshotter" {
 # --------------------------------------------------
 
 module "velero" {
-  source                  = "../../_sub/storage/velero"
-  count                   = var.velero_deploy ? 1 : 0
-  cluster_name            = var.eks_cluster_name
-  bucket_arn              = var.velero_bucket_arn
-  cron_schedule           = var.velero_cron_schedule
-  log_level               = var.velero_log_level
-  repo_name               = var.fluxcd_bootstrap_repo_name
-  repo_branch             = var.fluxcd_bootstrap_repo_branch
-  helm_chart_version      = var.velero_helm_chart_version
-  image_tag               = var.velero_image_tag
-  plugin_for_aws_version  = var.velero_plugin_for_aws_version
-  plugin_for_csi_version  = var.velero_plugin_for_csi_version
-  snapshots_enabled       = var.velero_snapshots_enabled
-  overwrite_on_create     = var.fluxcd_bootstrap_overwrite_on_create
-  gitops_apps_repo_url    = local.fluxcd_apps_repo_url
-  gitops_apps_repo_branch = var.fluxcd_apps_repo_branch
-  prune                   = var.fluxcd_prune
-  namespace               = var.velero_namespace
-  service_account         = var.velero_service_account
-  oidc_issuer             = local.oidc_issuer
-  workload_account_id     = var.aws_workload_account_id
+  source                              = "../../_sub/storage/velero"
+  count                               = var.velero_deploy ? 1 : 0
+  cluster_name                        = var.eks_cluster_name
+  bucket_arn                          = var.velero_bucket_arn
+  cron_schedule                       = var.velero_cron_schedule
+  log_level                           = var.velero_log_level
+  repo_name                           = var.fluxcd_bootstrap_repo_name
+  repo_branch                         = var.fluxcd_bootstrap_repo_branch
+  helm_chart_version                  = var.velero_helm_chart_version
+  image_tag                           = var.velero_image_tag
+  plugin_for_aws_version              = var.velero_plugin_for_aws_version
+  plugin_for_csi_version              = var.velero_plugin_for_csi_version
+  snapshots_enabled                   = var.velero_snapshots_enabled
+  overwrite_on_create                 = var.fluxcd_bootstrap_overwrite_on_create
+  gitops_apps_repo_url                = local.fluxcd_apps_repo_url
+  gitops_apps_repo_branch             = var.fluxcd_apps_repo_branch
+  prune                               = var.fluxcd_prune
+  namespace                           = var.velero_namespace
+  service_account                     = var.velero_service_account
+  oidc_issuer                         = local.oidc_issuer
+  workload_account_id                 = var.aws_workload_account_id
+  excluded_cluster_scoped_resources   = var.velero_excluded_cluster_scoped_resources
+  excluded_namespace_scoped_resources = var.velero_excluded_namespace_scoped_resources
 
   providers = {
     github = github.fluxcd

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -897,6 +897,18 @@ variable "velero_bucket_arn" {
   description = "The arn of the S3 bucket that contains the Velero backup. Only used if S3 bucket is in a different account"
 }
 
+variable "velero_excluded_cluster_scoped_resources" {
+  type        = list(string)
+  default     = []
+  description = "List of cluster-scoped resources to exclude from backup"
+}
+
+variable "velero_excluded_namespace_scoped_resources" {
+  type        = list(string)
+  default     = []
+  description = "List of namespace-scoped resources to exclude from backup"
+}
+
 
 # --------------------------------------------------
 # Kyverno
@@ -1442,37 +1454,37 @@ variable "falco_namespace" {
 }
 
 variable "falco_slack_alert_webhook_url" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "Value for slack webhook url. If not provided, slack alerts will not be sent"
 }
 
 variable "falco_slack_alert_channel_name" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "Channel name for slack alerts. Example: #falco-alerts"
 }
 
 variable "falco_slack_alert_minimum_priority" {
-  type = string
-  default = "critical"
+  type        = string
+  default     = "critical"
   description = "Minimum priority level for slack alerts to be sent to Slack"
 }
 
 variable "falco_stream_enabled" {
-  type = bool
-  default = false
+  type        = bool
+  default     = false
   description = "Enable Falco stream output to a specified webhook"
 }
 
 variable "falco_stream_webhook_url" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "Value for webhook url to which to send falco events stream. stream_enabled must be set to true. If not provided, slack stream will not be sent"
 }
 
 variable "falco_stream_channel_name" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "Channel name for falco stream. Example: #falco-stream"
 }

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -849,7 +849,7 @@ variable "velero_helm_chart_version" {
 
 variable "velero_image_tag" {
   type        = string
-  default     = "v1.12.4"
+  default     = ""
   description = "Override the image tag in the Helm chart with a custom version"
 }
 
@@ -860,16 +860,6 @@ variable "velero_plugin_for_aws_version" {
   validation {
     condition     = can(regex("^v[[:digit:]].[[:digit:]].[[:digit:]]+", var.velero_plugin_for_aws_version)) || var.velero_plugin_for_aws_version == ""
     error_message = "Velero plugin for AWS must specify a version. The version must start with the letter v and followed by a semantic version number."
-  }
-}
-
-variable "velero_plugin_for_csi_version" {
-  type        = string
-  default     = "v0.2.0"
-  description = "The version of velero-plugin-for-csi to use as initContainer"
-  validation {
-    condition     = can(regex("^v[[:digit:]].[[:digit:]].[[:digit:]]+", var.velero_plugin_for_csi_version)) || var.velero_plugin_for_csi_version == ""
-    error_message = "Velero plugin for CSI must specify a version. The version must start with the letter v and followed by a semantic version number."
   }
 }
 

--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -240,10 +240,9 @@ inputs = {
   # --------------------------------------------------
 
   velero_deploy                               = true
-  velero_helm_chart_version                   = "7.2.2"
   velero_bucket_arn                           = "arn:aws:s3:::dfds-velero-qa"
+  velero_helm_chart_version                   = "8.1.0"
   velero_plugin_for_aws_version               = "v1.7.0"
-  velero_plugin_for_csi_version               = "v0.5.0"
   velero_excluded_namespace_scoped_resources  = ["secrets"]
 
   # --------------------------------------------------

--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -239,11 +239,12 @@ inputs = {
   # is already applied through Terragrunt.
   # --------------------------------------------------
 
-  velero_deploy                 = true
-  velero_helm_chart_version     = "7.1.0"
-  velero_bucket_arn = "arn:aws:s3:::dfds-velero-qa"
-  velero_plugin_for_aws_version = "v1.7.0"
-  velero_plugin_for_csi_version = "v0.5.0"
+  velero_deploy                               = true
+  velero_helm_chart_version                   = "7.2.2"
+  velero_bucket_arn                           = "arn:aws:s3:::dfds-velero-qa"
+  velero_plugin_for_aws_version               = "v1.7.0"
+  velero_plugin_for_csi_version               = "v0.5.0"
+  velero_excluded_namespace_scoped_resources  = ["secrets"]
 
   # --------------------------------------------------
   # Grafana Agent for Kubernetes monitoring


### PR DESCRIPTION
## Describe your changes
- Add support for excluding certain resource types from backup.
- Remove CSI driver configuration for Velero. It is now included by default.
- Remove hardcoded image tag.
- Upgrade Velero Helm chart in QA

## Issue ticket number and link
https://github.com/dfds/cloudplatform/issues/3083

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
