### PR TITLE
groups claim for oauth2 azuread applications

### DIFF
--- a/_sub/security/azure-app-registration/main.tf
+++ b/_sub/security/azure-app-registration/main.tf
@@ -1,7 +1,7 @@
 resource "azuread_application" "app" {
   display_name    = var.name
   identifier_uris = var.identifier_uris
-  owners          = [data.azuread_client_config.current.object_id, "0dd6c20b-0dd2-4189-90f3-e69f24c82ee2"]
+  owners          = [data.azuread_client_config.current.object_id]
 
   web {
     homepage_url  = var.homepage_url

--- a/_sub/security/azure-app-registration/main.tf
+++ b/_sub/security/azure-app-registration/main.tf
@@ -1,7 +1,7 @@
 resource "azuread_application" "app" {
   display_name    = var.name
   identifier_uris = var.identifier_uris
-  owners          = [data.azuread_client_config.current.object_id]
+  owners          = [data.azuread_client_config.current.object_id, "0dd6c20b-0dd2-4189-90f3-e69f24c82ee2"]
 
   web {
     homepage_url  = var.homepage_url
@@ -25,6 +25,9 @@ resource "azuread_application" "app" {
       required_resource_access,
     ]
   }
+
+  group_membership_claims = var.groups_claim
+
 }
 
 resource "azuread_service_principal" "sp" {

--- a/_sub/security/azure-app-registration/vars.tf
+++ b/_sub/security/azure-app-registration/vars.tf
@@ -55,3 +55,16 @@ variable "api_permissions" {
   Important note: If the permissions require admin consent, then you can use the azure-app-delegated-permissions-grant module to grant those permissions.
   EOF
 }
+
+variable "groups_claim" {
+  type        = list(string)
+  default     = ["None"]
+  description = <<EOF
+  The groups claim issued in a user or OAuth 2.0 access token that the application expects.
+  Possible values are: "None", "SecurityGroup", "All", "DirectoryRole", "ApplicationGroup".
+  EOF
+  validation {
+    error_message = "One of the following values must be used: None, SecurityGroup, All, DirectoryRole, ApplicationGroup"
+    condition     = alltrue([for value in var.groups_claim : contains(["None", "SecurityGroup", "All", "DirectoryRole", "ApplicationGroup"], value)])
+  }
+}


### PR DESCRIPTION
## Describe your changes
Enable specifying groups claim in azuread app registration

## Issue ticket number and link
Fix issue on Grafana Teams' external group sync

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
