### PR TITLE
Add feature toggle for enabling/disabling Grafana in kube-prometheus-stack

### DIFF
--- a/_sub/compute/helm-kube-prometheus-stack/main.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/main.tf
@@ -44,6 +44,7 @@ resource "helm_release" "kube_prometheus_stack" {
     }),
 
     templatefile("${path.module}/values/grafana.yaml", {
+      grafana_enabled             = var.grafana_enabled
       grafana_admin_password      = var.grafana_admin_password != "" ? var.grafana_admin_password : random_password.grafana_password.result
       grafana_priorityclass       = var.priority_class
       grafana_ingress_path        = var.grafana_ingress_path
@@ -114,6 +115,7 @@ resource "helm_release" "kube_prometheus_stack" {
 }
 
 resource "github_repository_file" "grafana_config_path" {
+  count               = var.grafana_enabled ? 1 : 0
   repository          = var.repo_name
   branch              = local.repo_branch
   file                = "${local.cluster_repo_path}/${local.grafana_platform_apps_name}-config.yaml"
@@ -122,6 +124,7 @@ resource "github_repository_file" "grafana_config_path" {
 }
 
 resource "github_repository_file" "grafana_config_middleware" {
+  count               = var.grafana_enabled ? 1 : 0
   repository          = var.repo_name
   branch              = local.repo_branch
   file                = "${local.config_repo_path}/middleware.yaml"
@@ -130,6 +133,7 @@ resource "github_repository_file" "grafana_config_middleware" {
 }
 
 resource "github_repository_file" "grafana_config_ingressroute" {
+  count               = var.grafana_enabled ? 1 : 0
   repository          = var.repo_name
   branch              = local.repo_branch
   file                = "${local.config_repo_path}/ingressroute.yaml"
@@ -138,6 +142,7 @@ resource "github_repository_file" "grafana_config_ingressroute" {
 }
 
 resource "github_repository_file" "grafana_config_alert_config" {
+  count               = var.grafana_enabled ? 1 : 0
   repository          = var.repo_name
   branch              = local.repo_branch
   file                = "${local.config_repo_path}/alert-config.yaml"
@@ -146,6 +151,7 @@ resource "github_repository_file" "grafana_config_alert_config" {
 }
 
 resource "github_repository_file" "grafana_config_init" {
+  count               = var.grafana_enabled ? 1 : 0
   repository          = var.repo_name
   branch              = local.repo_branch
   file                = "${local.config_repo_path}/kustomization.yaml"

--- a/_sub/compute/helm-kube-prometheus-stack/outputs.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/outputs.tf
@@ -1,3 +1,3 @@
 output "grafana_admin_password" {
-  value = "This value is stored in the AWS SSM Parameter Store at ${aws_ssm_parameter.param_grafana_password.name}"
+  value = var.grafana_enabled ? "This value is stored in the AWS SSM Parameter Store at ${aws_ssm_parameter.param_grafana_password.name}" : ""
 }

--- a/_sub/compute/helm-kube-prometheus-stack/values/grafana.yaml
+++ b/_sub/compute/helm-kube-prometheus-stack/values/grafana.yaml
@@ -1,6 +1,7 @@
 etcd:
   enabled: true
 grafana:
+  enabled: ${grafana_enabled}
 %{ if length(grafana_slack_webhook) > 0 ~}
   alerting:
     contactpoints.yaml:

--- a/_sub/compute/helm-kube-prometheus-stack/vars.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/vars.tf
@@ -24,6 +24,12 @@ variable "priority_class" {
   description = "Name of priority class to apply"
 }
 
+variable "grafana_enabled" {
+  type        = bool
+  description = "Feature toogle for Grafana deployment or not"
+  default     = true
+}
+
 variable "grafana_admin_password" {
   type        = string
   description = "Grafana admin password"

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -379,6 +379,7 @@ module "monitoring_kube_prometheus_stack" {
   chart_version                                       = var.monitoring_kube_prometheus_stack_chart_version
   namespace                                           = module.monitoring_namespace[0].name
   priority_class                                      = var.monitoring_kube_prometheus_stack_priority_class
+  grafana_enabled                                     = var.monitoring_kube_prometheus_stack_grafana_enabled
   grafana_admin_password                              = var.monitoring_kube_prometheus_stack_grafana_admin_password
   grafana_ingress_path                                = var.monitoring_kube_prometheus_stack_grafana_ingress_path
   grafana_host                                        = "grafana.${var.eks_cluster_name}.${var.workload_dns_zone_name}"

--- a/compute/k8s-services/outputs.tf
+++ b/compute/k8s-services/outputs.tf
@@ -2,9 +2,14 @@
 # Prometheus Stack
 # --------------------------------------------------
 
-output "prometheus_grafana_admin_password" {
-  value = try(module.monitoring_kube_prometheus_stack[0].grafana_admin_password, "")
+output "grafana_admin_password" {
+  value = var.monitoring_kube_prometheus_stack_deploy && var.monitoring_kube_prometheus_stack_grafana_enabled ? try(module.monitoring_kube_prometheus_stack[0].grafana_admin_password, "") : "Not enabled in service configuration."
 }
+
+output "grafana_url" {
+  value = var.monitoring_kube_prometheus_stack_deploy && var.monitoring_kube_prometheus_stack_grafana_enabled ? "https://grafana.${var.eks_cluster_name}.${var.workload_dns_zone_name}${var.monitoring_kube_prometheus_stack_grafana_ingress_path}" : "Not enabled in service configuration."
+}
+
 
 # --------------------------------------------------
 # Traefik
@@ -20,8 +25,4 @@ output "traefik_blue_variant_dashboard_url" {
 
 output "traefik_green_variant_dashboard_url" {
   value = var.traefik_green_variant_deploy ? "https://traefik-green-variant.${var.eks_cluster_name}.${var.workload_dns_zone_name}/dashboard/" : "Not enabled in service configuration."
-}
-
-output "grafana_url" {
-  value = var.monitoring_kube_prometheus_stack_deploy ? "https://grafana.${var.eks_cluster_name}.${var.workload_dns_zone_name}${var.monitoring_kube_prometheus_stack_grafana_ingress_path}" : "Not enabled in service configuration."
 }

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -267,6 +267,12 @@ variable "monitoring_kube_prometheus_stack_priority_class" {
   default     = "cluster-monitoring"
 }
 
+variable "monitoring_kube_prometheus_stack_grafana_enabled" {
+  type        = bool
+  description = "Feature toogle for Grafana deployment or not"
+  default     = true
+}
+
 variable "monitoring_kube_prometheus_stack_grafana_admin_password" {
   type        = string
   description = "Grafana admin password"
@@ -1480,7 +1486,7 @@ variable "falco_stream_channel_name" {
 }
 
 variable "falco_custom_rules" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "Custom rules to be added to the falco config"
 }

--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -138,6 +138,7 @@ inputs = {
   monitoring_kube_prometheus_stack_prometheus_request_cpu            = "500m"
   monitoring_kube_prometheus_stack_prometheus_limit_memory           = "2Gi"
   monitoring_kube_prometheus_stack_prometheus_limit_cpu              = "1000m"
+  monitoring_kube_prometheus_stack_grafana_enabled                   = false
   monitoring_kube_prometheus_stack_grafana_storage_enabled           = false
   monitoring_kube_prometheus_stack_grafana_storage_size              = "5Gi"
   monitoring_kube_prometheus_stack_grafana_storageclass              = "gp2"


### PR DESCRIPTION
## Describe your changes
In order to simplify the sunsetting of kube prometheus stack in our Kubernetes cluster, this PR adds a feature toggle for Grafana, so that the Grafana instance that comes with kube prometheus stack can be toggle off prior to sunsetting kube prometheus stack.

This pull request introduces a feature toggle for enabling or disabling Grafana deployment in the `helm-kube-prometheus-stack` module. The most important changes include the addition of the `grafana_enabled` variable, conditional logic based on this variable, and updates to outputs.

### Feature Toggle for Grafana Deployment:

* Added `grafana_enabled` variable to control the deployment of Grafana. (`_sub/compute/helm-kube-prometheus-stack/vars.tf`, `compute/k8s-services/vars.tf`) [[1]](diffhunk://#diff-5398bbac0a94b58e045747e9ac757eaca71e4c1c9ed5b948adc6b6697433ffe9R27-R32) [[2]](diffhunk://#diff-83380a112934c41699d826a5e1a07c6ee2d0729366db765c2d9c40fd2967c45bR270-R275)
* Updated `helm_release` resource to include `grafana_enabled` in the `templatefile` function. (`_sub/compute/helm-kube-prometheus-stack/main.tf`)
* Added conditional `count` attributes to `github_repository_file` resources to create files only if Grafana is enabled. (`_sub/compute/helm-kube-prometheus-stack/main.tf`) [[1]](diffhunk://#diff-a1b1f48f0f21865ec2dcbc54a84c60f3c7d3c7d32f6b8d1c9d45066189b4e25fR118) [[2]](diffhunk://#diff-a1b1f48f0f21865ec2dcbc54a84c60f3c7d3c7d32f6b8d1c9d45066189b4e25fR127) [[3]](diffhunk://#diff-a1b1f48f0f21865ec2dcbc54a84c60f3c7d3c7d32f6b8d1c9d45066189b4e25fR136) [[4]](diffhunk://#diff-a1b1f48f0f21865ec2dcbc54a84c60f3c7d3c7d32f6b8d1c9d45066189b4e25fR145) [[5]](diffhunk://#diff-a1b1f48f0f21865ec2dcbc54a84c60f3c7d3c7d32f6b8d1c9d45066189b4e25fR154)

### Updates to Outputs:

* Modified the `grafana_admin_password` output to return an empty string if Grafana is not enabled. (`_sub/compute/helm-kube-prometheus-stack/outputs.tf`)
* Added conditional logic to the `grafana_admin_password` and `grafana_url` outputs to handle cases where Grafana is not enabled. (`compute/k8s-services/outputs.tf`) [[1]](diffhunk://#diff-bc45b74008d78bb9e9e9d39d76d50e6d90cf589132ae54a1e79cb87647727339L5-R13) [[2]](diffhunk://#diff-bc45b74008d78bb9e9e9d39d76d50e6d90cf589132ae54a1e79cb87647727339L24-L27)

### Configuration Changes:

* Updated `grafana.yaml` to include the `grafana_enabled` variable. (`_sub/compute/helm-kube-prometheus-stack/values/grafana.yaml`)
* Set `monitoring_kube_prometheus_stack_grafana_enabled` to `false` in the Terragrunt configuration for the QA environment. (`test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl`)

These changes introduce a flexible way to enable or disable Grafana deployment based on the `grafana_enabled` variable, making the deployment process more configurable and adaptable to different environments.

## Issue ticket number and link
https://github.com/dfds/cloudplatform/issues/2814

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
