### PR TITLE
Add label norelease to changes in the test/integration directory

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -84,6 +84,15 @@
       ],
       "minimumReleaseAge": "7 days",
       "automerge": false
+    },
+    {
+      "description": "Group dependencies affecting the QA environment and it's test resources.",
+      "matchFileNames": [
+        "test/integration/**"
+      ],
+      "addLabels": [
+        "norelease"
+      ]
     }
   ],
   "azure-pipelines": {


### PR DESCRIPTION
## Describe your changes

This pull request includes a change to the `renovate.json` file to better manage dependencies affecting the QA environment and its test resources.

Dependency management improvements:

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R87-R95): Added a new group for dependencies affecting the QA environment, including a description, matching file names, and a label to prevent release.

## Issue ticket number and link
https://github.com/dfds/cloudplatform/issues/3049

## Checklist before requesting a review
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
