### PR TITLE
Removing monitoring-grafana.monitoring/api/health from Blacbox explorer.

### DIFF
--- a/compute/k8s-services/dependencies.tf
+++ b/compute/k8s-services/dependencies.tf
@@ -223,12 +223,6 @@ locals {
     "module" = "http_2xx"
   }] : []
 
-  blackbox_exporter_monitoring_grafana = var.monitoring_kube_prometheus_stack_deploy ? [{
-    "name"   = "grafana"
-    "url"    = "http://monitoring-grafana.monitoring/api/health"
-    "module" = "http_2xx"
-  }] : []
-
   blackbox_exporter_monitoring_traefik_blue_variant = var.traefik_blue_variant_deploy ? [{
     "name"   = "traefik-blue-variant"
     "url"    = "http://traefik-blue-variant.traefik-blue-variant:9000/ping"
@@ -244,7 +238,6 @@ locals {
 
   blackbox_exporter_monitoring_targets = concat(
     local.blackbox_exporter_monitoring_atlantis,
-    local.blackbox_exporter_monitoring_grafana,
     local.blackbox_exporter_monitoring_traefik_blue_variant,
     local.blackbox_exporter_monitoring_traefik_green_variant,
     var.blackbox_exporter_monitoring_targets


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
Cleaning up following grafana self-hosted has been disabled.
## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
