### PR TITLE
Add support for overriding EKS addon version for EFS. Plus formatting

### DIFF
--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -133,8 +133,8 @@ module "eks_managed_workers_node_group" {
     for sn in module.eks_managed_workers_subnet.subnets : sn.id if contains(each.value.availability_zones, sn.availability_zone)
   ]
   max_pods = each.value.max_pods
-  cpu = each.value.cpu
-  memory = each.value.memory
+  cpu      = each.value.cpu
+  memory   = each.value.memory
 }
 
 # --------------------------------------------------
@@ -163,10 +163,10 @@ module "eks_heptio" {
 }
 
 module "efs_fs" {
-  source = "../../_sub/compute/efs-fs"
-  name   = "eks-${var.eks_cluster_name}-efs"
-  vpc_id = module.eks_cluster.vpc_id
-  vpc_subnet_ids = module.eks_managed_workers_subnet.subnet_ids
+  source                   = "../../_sub/compute/efs-fs"
+  name                     = "eks-${var.eks_cluster_name}-efs"
+  vpc_id                   = module.eks_cluster.vpc_id
+  vpc_subnet_ids           = module.eks_managed_workers_subnet.subnet_ids
   automated_backup_enabled = var.efs_automated_backup_enabled
 }
 
@@ -179,6 +179,7 @@ module "eks_addons" {
   vpccni_version_override          = var.eks_addon_vpccni_version_override
   vpccni_prefix_delegation_enabled = var.eks_addon_vpccni_prefix_delegation_enabled
   awsebscsidriver_version_override = var.eks_addon_awsebscsidriver_version_override
+  awsefscsidriver_version_override = var.eks_addon_awsefscsidriver_version_override
   most_recent                      = var.eks_addon_most_recent
   cluster_version                  = var.eks_cluster_version
   eks_openid_connect_provider_url  = module.eks_cluster.eks_openid_connect_provider_url

--- a/compute/eks-ec2/vars.tf
+++ b/compute/eks-ec2/vars.tf
@@ -118,6 +118,11 @@ variable "eks_addon_awsebscsidriver_version_override" {
   default = ""
 }
 
+variable "eks_addon_awsefscsidriver_version_override" {
+  type    = string
+  default = ""
+}
+
 variable "eks_addon_most_recent" {
   type        = bool
   default     = false
@@ -156,10 +161,10 @@ variable "eks_managed_nodegroups" {
       value  = optional(string),
       effect = string
     })), [])
-    labels = optional(map(string), {})
+    labels   = optional(map(string), {})
     max_pods = optional(number, 110)
-    cpu = optional(string, null)
-    memory = optional(string, null)
+    cpu      = optional(string, null)
+    memory   = optional(string, null)
   }))
   default = {}
 }


### PR DESCRIPTION
## Describe your changes

This pull request includes changes to the `compute/eks-ec2` module to add support for overriding the version of the AWS EFS CSI driver. The most important changes include adding a new variable for the EFS CSI driver version override and updating the EKS addons configuration.

Enhancements to EKS addons configuration:

* [`compute/eks-ec2/main.tf`](diffhunk://#diff-377519e7ca2d872af5e1381cb6c57e93942c12625344ff8fc8a970e19a400742R182): Added support for `awsefscsidriver_version_override` to allow specifying a custom version for the AWS EFS CSI driver.

New variable addition:

* [`compute/eks-ec2/vars.tf`](diffhunk://#diff-b18f8354ea8f3932f1be0681155c6e70c457a10798e9be3a07994adfea3d16b3R121-R125): Introduced a new variable `eks_addon_awsefscsidriver_version_override` to hold the version override for the AWS EFS CSI driver.

## Issue ticket number and link
https://github.com/dfds/cloudplatform/issues/3063

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
