### PR TITLE
Use latest pipeline image and Atlantis image

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -24,7 +24,7 @@ pr:
 resources:
   containers:
     - container: prime
-      image: dfdsdk/prime-pipeline:2.1.1
+      image: dfdsdk/prime-pipeline:2.1.2
       env:
         AWS_DEFAULT_REGION: eu-west-1
         AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)

--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -173,7 +173,7 @@ inputs = {
   atlantis_webhook_events      = ["issue_comment", "pull_request", "pull_request_review", "push"]
   atlantis_chart_version       = "5.7.0"
   atlantis_environment         = "qa"
-  atlantis_image_tag           = "2.0.2"
+  atlantis_image_tag           = "2.0.4"
   atlantis_add_secret_volumes  = true
 
   # --------------------------------------------------


### PR DESCRIPTION
## Describe your changes

This pull request includes updates to the container image versions used in the pipeline and the Atlantis image tag in the Terragrunt configuration file.

Updates to container image versions:

* [`azure-pipelines.yaml`](diffhunk://#diff-9eedc1d7d657ddb36b1105a0fffb4852f6d34e26454371f27b6e0ad1391f290eL27-R27): Updated the `prime` container image from `dfdsdk/prime-pipeline:2.1.1` to `dfdsdk/prime-pipeline:2.1.2`.

Updates to Atlantis configuration:

* [`test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl`](diffhunk://#diff-23bdbeb0d3e57bc3139b318801dda0b1c266354c34072dffc2a1932f1df0cc11L176-R176): Updated the `atlantis_image_tag` from `2.0.2` to `2.0.4`.

## Issue ticket number and link
https://github.com/dfds/cloudplatform/issues/3142

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
