### PR TITLE
Removing a change that would delete SG under special circumstances

### DIFF
--- a/_sub/compute/efs-fs/main.tf
+++ b/_sub/compute/efs-fs/main.tf
@@ -9,8 +9,8 @@ resource "aws_efs_file_system" "this" {
 }
 
 resource "aws_security_group" "this" {
-  vpc_id      = var.vpc_id
-  description = "EFS security group"
+  #checkov:skip=CKV_AWS_23: Ensure every security group and rule has a description
+  vpc_id = var.vpc_id
   tags = {
     Name = var.name
   }


### PR DESCRIPTION
## Describe your changes

I found a really nasty bug that wasn't found in QA:

```
module.efs_fs.aws_security_group.this must be replaced
 -/+ resource "aws_security_group" "this" {
       ~ arn                    = "arn:aws:ec2:eu-west-1:589164764316:security-group/sg-093ffbd32ba3ee861" -> (known after apply)
       ~ description            = "Managed by Terraform" -> "EFS security group" # forces replacement
```

This pull request includes a small change to the `_sub/compute/efs-fs/main.tf` file. The change involves adding a comment to skip a specific Checkov security rule and removing the description for an AWS security group.

* [`_sub/compute/efs-fs/main.tf`](diffhunk://#diff-0e9b178171e6d3fdae438fa07f89af84434496df046299e325efe2a4af42dbfaR12-L13): Added a comment to skip Checkov rule CKV_AWS_23 and removed the description for the AWS security group.

## Issue ticket number and link
https://github.com/dfds/cloudplatform/issues/3149

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
