### PR TITLE
velero plugin for aws version bumped

### DIFF
--- a/_sub/storage/velero/vars.tf
+++ b/_sub/storage/velero/vars.tf
@@ -83,7 +83,7 @@ variable "plugin_for_aws_version" {
   type        = string
   description = "The version of velero-plugin-for-aws to use as initContainer"
   validation {
-    condition     = can(regex("^v[[:digit:]].[[:digit:]].[[:digit:]]+", var.plugin_for_aws_version))
+    condition     = can(regex("^v(\\d+\\.\\d+)(\\.\\d+)?(-rc\\.\\d+|-beta\\.\\d+)?$", var.plugin_for_aws_version))
     error_message = "Velero plugin for AWS must specify a version. The version must start with the letter v and followed by a semantic version number."
   }
 }

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -861,10 +861,10 @@ variable "velero_image_tag" {
 
 variable "velero_plugin_for_aws_version" {
   type        = string
-  default     = "v1.4.1"
+  default     = "v1.14.1"
   description = "The version of velero-plugin-for-aws to use as initContainer"
   validation {
-    condition     = can(regex("^v[[:digit:]].[[:digit:]].[[:digit:]]+", var.velero_plugin_for_aws_version)) || var.velero_plugin_for_aws_version == ""
+    condition     = can(regex("^v(\\d+\\.\\d+)(\\.\\d+)?(-rc\\.\\d+|-beta\\.\\d+)?$", var.velero_plugin_for_aws_version)) || var.velero_plugin_for_aws_version == ""
     error_message = "Velero plugin for AWS must specify a version. The version must start with the letter v and followed by a semantic version number."
   }
 }

--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -243,7 +243,7 @@ inputs = {
   velero_deploy                               = true
   velero_bucket_arn                           = "arn:aws:s3:::dfds-velero-qa"
   velero_helm_chart_version                   = "8.1.0"
-  velero_plugin_for_aws_version               = "v1.7.0"
+  velero_plugin_for_aws_version               = "v1.11.1"
   velero_excluded_namespace_scoped_resources  = ["secrets"]
 
   # --------------------------------------------------


### PR DESCRIPTION
## Describe your changes
Update velero plugin version for AWS 
Fix the validation

## Issue ticket number and link
[#3046](https://github.com/dfds/cloudplatform/issues/3046)

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
