### PR TITLE
Let true be true, and false be false

### DIFF
--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -322,7 +322,7 @@ resource "aws_cloudwatch_metric_alarm" "inactivity" {
 }
 
 module "eks_inactivity_cleanup" {
-  count                = var.eks_is_sandbox && !var.disable_inactivity_cleanup ? 1 : 0
+  count                = var.eks_is_sandbox && var.enable_inactivity_cleanup
   source               = "../../_sub/compute/eks-inactivity-cleanup"
   eks_cluster_name     = var.eks_cluster_name
   eks_cluster_arn      = module.eks_cluster.eks_cluster_arn

--- a/compute/eks-ec2/vars.tf
+++ b/compute/eks-ec2/vars.tf
@@ -207,10 +207,10 @@ variable "eks_worker_cur_bucket_arn" {
 # Inactivity based clean up for sandboxes
 # --------------------------------------------------
 
-variable "disable_inactivity_cleanup" {
+variable "enable_inactivity_cleanup" {
   type        = bool
   default     = false
-  description = "Disables automated clean up of EKS resources based on inactivity. Only applicable to sandboxes."
+  description = "Enables automated clean up of EKS resources based on inactivity. Only applicable to sandboxes."
 }
 
 # --------------------------------------------------

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -713,7 +713,7 @@ module "kyverno" {
 # --------------------------------------------------
 
 module "elb_inactivity_cleanup_anon" {
-  count                = data.terraform_remote_state.cluster.outputs.eks_is_sandbox && !var.disable_inactivity_cleanup && var.traefik_alb_anon_deploy && (var.traefik_blue_variant_deploy || var.traefik_green_variant_deploy) ? 1 : 0
+  count                = data.terraform_remote_state.cluster.outputs.eks_is_sandbox && var.enable_inactivity_cleanup && var.traefik_alb_anon_deploy && (var.traefik_blue_variant_deploy || var.traefik_green_variant_deploy) ? 1 : 0
   source               = "../../_sub/compute/elb-inactivity-cleanup"
   inactivity_alarm_arn = data.terraform_remote_state.cluster.outputs.eks_inactivity_alarm_arn
   elb_name             = module.traefik_alb_anon.alb_name
@@ -721,7 +721,7 @@ module "elb_inactivity_cleanup_anon" {
 }
 
 module "elb_inactivity_cleanup_auth" {
-  count                = data.terraform_remote_state.cluster.outputs.eks_is_sandbox && !var.disable_inactivity_cleanup && var.traefik_alb_auth_deploy && (var.traefik_blue_variant_deploy || var.traefik_green_variant_deploy) ? 1 : 0
+  count                = data.terraform_remote_state.cluster.outputs.eks_is_sandbox && var.enable_inactivity_cleanup && var.traefik_alb_auth_deploy && (var.traefik_blue_variant_deploy || var.traefik_green_variant_deploy) ? 1 : 0
   source               = "../../_sub/compute/elb-inactivity-cleanup"
   inactivity_alarm_arn = data.terraform_remote_state.cluster.outputs.eks_inactivity_alarm_arn
   elb_name             = module.traefik_alb_auth.alb_name

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -953,10 +953,10 @@ variable "subnet_exporter_iam_role_name" {
 # Inactivity based clean up for sandboxes
 # --------------------------------------------------
 
-variable "disable_inactivity_cleanup" {
+variable "enable_inactivity_cleanup" {
   type        = bool
   default     = false
-  description = "Disables automated clean up of ELB resources based on inactivity. Only applicable to sandboxes."
+  description = "Enables automated clean up of ELB resources based on inactivity. Only applicable to sandboxes."
 }
 
 # --------------------------------------------------

--- a/test/integration/eu-west-1/k8s-qa/cluster/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/cluster/terragrunt.hcl
@@ -34,7 +34,7 @@ inputs = {
   # Since rebooting the cluster after inactivity at the moment requires first
   # running `terragrunt apply -target=module.eks_cluster` the QA cluster is
   # excluded from the inactivity clean up on this step.
-  disable_inactivity_cleanup = true
+  enable_inactivity_cleanup = true
 
   # --------------------------------------------------
   # Managed nodes


### PR DESCRIPTION
;TLDR
Removing confusing syntax of flipping false to be true. If this is accepted, it requires us to add a single line to our sandboxes hcl and update the sandbox-template repo.

This pull request focuses on changing the variable from `disable_inactivity_cleanup` to `enable_inactivity_cleanup` across multiple Terraform files. This change improves readability and aligns with the positive logic convention. The most important changes include updates to the variable names and descriptions, as well as adjustments to the conditions that determine the count of certain modules.

Changes to variable names and descriptions:

* [`compute/eks-ec2/vars.tf`](diffhunk://#diff-b18f8354ea8f3932f1be0681155c6e70c457a10798e9be3a07994adfea3d16b3L210-R213): Renamed `disable_inactivity_cleanup` to `enable_inactivity_cleanup` and updated the description to reflect the new variable name.
* [`compute/k8s-services/vars.tf`](diffhunk://#diff-83380a112934c41699d826a5e1a07c6ee2d0729366db765c2d9c40fd2967c45bL956-R959): Renamed `disable_inactivity_cleanup` to `enable_inactivity_cleanup` and updated the description to reflect the new variable name.

Adjustments to module counts:

* [`compute/eks-ec2/main.tf`](diffhunk://#diff-377519e7ca2d872af5e1381cb6c57e93942c12625344ff8fc8a970e19a400742L325-R325): Modified the condition for the `count` parameter in the `eks_inactivity_cleanup` module to use `enable_inactivity_cleanup` instead of `disable_inactivity_cleanup`.
* [`compute/k8s-services/main.tf`](diffhunk://#diff-9dcb2b34c331c83c7b15b8785fc38080f22e765d3119f854acc7848e7f669485L716-R724): Updated the conditions for the `count` parameter in the `elb_inactivity_cleanup_anon` and `elb_inactivity_cleanup_auth` modules to use `enable_inactivity_cleanup` instead of `disable_inactivity_cleanup`.

Updates to integration test configurations:

* [`test/integration/eu-west-1/k8s-qa/cluster/terragrunt.hcl`](diffhunk://#diff-7f7aa824ffca7a437c5189aec8a5adb01c34e18ca80309a31f4c11d09b90617fL37-R37): Changed the variable from `disable_inactivity_cleanup` to `enable_inactivity_cleanup` for the QA cluster.