### PR TITLE
Added missing inactivity check

### DIFF
--- a/_sub/compute/eks-nodegroup-managed/main.tf
+++ b/_sub/compute/eks-nodegroup-managed/main.tf
@@ -89,7 +89,7 @@ resource "aws_eks_node_group" "group" {
 }
 
 resource "aws_autoscaling_schedule" "eks" {
-  count                  = var.is_sandbox ? signum(var.desired_size_per_subnet) : 0
+  count                  = var.is_sandbox && !var.disable_inactivity_cleanup ? signum(var.desired_size_per_subnet) : 0
   autoscaling_group_name = aws_eks_node_group.group[0].resources[0].autoscaling_groups[0].name
   scheduled_action_name  = "Scale to zero"
   recurrence             = var.scale_to_zero_cron


### PR DESCRIPTION
This pull request includes a change to the `aws_autoscaling_schedule` resource within the EKS node group configuration. The change adds a condition to the `count` attribute to check if `disable_inactivity_cleanup` is set to false before scaling to zero.

* [`_sub/compute/eks-nodegroup-managed/main.tf`](diffhunk://#diff-433c151dbb675a65e04574da2d95430b1cf8c9806eb62ed2adef18b8b6ecd8c2L92-R92): Modified the `count` attribute in the `aws_autoscaling_schedule` resource to include a check for `var.disable_inactivity_cleanup` before scaling to zero.