### PR TITLE
fix: ensure efs mount targets are in all subnets

### DIFF
--- a/_sub/compute/efs-fs/main.tf
+++ b/_sub/compute/efs-fs/main.tf
@@ -24,7 +24,7 @@ resource "aws_security_group_rule" "this" {
 }
 
 resource "aws_efs_mount_target" "this" {
-  for_each        = { for k, v in var.vpc_subnet_ids : k => v[0] }
+  for_each = { for idx, subnet_id in flatten([for k, v in var.vpc_subnet_ids : v]) : idx => subnet_id }
   file_system_id  = aws_efs_file_system.this.id
   subnet_id       = each.value
   security_groups = [aws_security_group.this.id]


### PR DESCRIPTION
## Describe your changes
Ensures that EFS Mount Targets are in all subnets rather than 1

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
