### PR TITLE
Find route tables for VPC peering based on tags or filters

### DIFF
--- a/_sub/network/vpc-peering-accepter/main.tf
+++ b/_sub/network/vpc-peering-accepter/main.tf
@@ -1,11 +1,43 @@
-data "aws_vpc" "peering" {
-  id = var.vpc_id
-}
-
 data "aws_region" "current" {}
 
+data "aws_route_tables" "preferred" {
+  vpc_id = var.vpc_id
+  tags = {
+    "vpc.peering.actor" = "accepter"
+  }
+}
+
+data "aws_route_tables" "alternate" {
+  vpc_id = var.vpc_id
+  filter {
+    name   = "association.main"
+    values = ["false"]
+  }
+  filter {
+    name   = "route.gateway-id"
+    values = ["local"]
+  }
+  filter {
+    name   = "tag:Name"
+    values = ["eks-*-sub*"]
+  }
+}
+
+locals {
+  len     = length(data.aws_route_tables.preferred.ids)
+  alt_len = length(data.aws_route_tables.alternate.ids)
+}
+
+# If the preferred route table has routes, use it. Otherwise, use the alternate route table.
+# If neither have routes, create a route in the main route table based on the var.route_table_id
 resource "aws_route" "peer" {
-  route_table_id            = var.route_table_id
+  count = local.len > 0 ? local.len : local.alt_len > 0 ? local.alt_len : 1
+  route_table_id = try(
+    try(
+      data.aws_route_tables.preferred.ids[count.index],
+      data.aws_route_tables.alternate.ids[count.index]
+    ), var.route_table_id
+  )
   destination_cidr_block    = var.destination_cidr_block
   vpc_peering_connection_id = var.peering_connection_id
 }

--- a/_sub/network/vpc-peering-accepter/vars.tf
+++ b/_sub/network/vpc-peering-accepter/vars.tf
@@ -16,6 +16,8 @@ variable "peering_connection_id" {
 
 variable "route_table_id" {
   description = "The ID of the route table"
+  type        = string
+  default     = ""
 }
 
 variable "tags" {


### PR DESCRIPTION
## Describe your changes

This pull request makes significant changes to the VPC peering accepter module to improve route table selection logic and ensure better flexibility. The key updates include replacing the `aws_vpc` data source with `aws_route_tables`, adding logic to select preferred or alternate route tables, and updating the `route_table_id` variable.

Changes to route table selection:

* [`_sub/network/vpc-peering-accepter/main.tf`](diffhunk://#diff-e20c94f5b3d396ae3b54981dea98d7df5621903ae9bb85c63dbbc8b0182d79ceL1-R40): Replaced the `aws_vpc` data source with `aws_route_tables` for both preferred and alternate route tables, added filters to select appropriate route tables based on tags and other criteria, and introduced local variables to determine the length of route table IDs. The `aws_route` resource now dynamically selects the route table ID based on the availability of preferred or alternate route tables.

Updates to variable definitions:

* [`_sub/network/vpc-peering-accepter/vars.tf`](diffhunk://#diff-f28a2fbe9bd5acb346acd2043ae01d29f8dcace22397d17c6b9619f33b0db956R19-R20): Updated the `route_table_id` variable to include a default empty string and explicitly define its type as `string`.

## Issue ticket number and link

https://github.com/dfds/cloudplatform/issues/3175

## Checklist before requesting a review
- [x] I have tested changes with my sandbox account that has VPC peering configured
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
