### PR TITLE
Use Traefik version 34.4.0

### DIFF
--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -51,7 +51,7 @@ inputs = {
   # Blue variant
   traefik_blue_variant_deploy             = true
   traefik_blue_variant_dashboard_deploy   = true
-  traefik_blue_variant_helm_chart_version = "23.1.0"
+  traefik_blue_variant_helm_chart_version = "34.4.0"
   traefik_blue_variant_additional_args = [
     "--metrics.prometheus",
     "--providers.kubernetescrd.allowCrossNamespace=true",
@@ -62,7 +62,7 @@ inputs = {
   # Green variant
   traefik_green_variant_deploy             = false
   traefik_green_variant_dashboard_deploy   = false
-  traefik_green_variant_helm_chart_version = "20.8.0"
+  traefik_green_variant_helm_chart_version = "34.4.0"
   traefik_green_variant_additional_args = [
     "--metrics.prometheus",
     "--providers.kubernetescrd.allowCrossNamespace=true",


### PR DESCRIPTION
## Describe your changes

This pull request includes updates to the `terragrunt.hcl` file in the `test/integration/eu-west-1/k8s-qa/services` directory. The changes involve updating the Helm chart versions for both the blue and green variants of Traefik.

Updates to Helm chart versions:

* Updated `traefik_blue_variant_helm_chart_version` from "23.1.0" to "34.4.0".
* Updated `traefik_green_variant_helm_chart_version` from "20.8.0" to "34.4.0".

## Issue ticket number and link
https://github.com/dfds/cloudplatform/issues/2791

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
