### PR TITLE
Update Ingress host from Atlantis in QA

### DIFF
--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -55,7 +55,6 @@ inputs = {
   traefik_blue_variant_additional_args = [
     "--metrics.prometheus",
     "--providers.kubernetescrd.allowCrossNamespace=true",
-    "--providers.kubernetesingress=true",
   ]
   traefik_blue_variant_weight = 1
 
@@ -66,7 +65,6 @@ inputs = {
   traefik_green_variant_additional_args = [
     "--metrics.prometheus",
     "--providers.kubernetescrd.allowCrossNamespace=true",
-    "--providers.kubernetesingress=true",
   ]
   traefik_green_variant_weight = 0
 


### PR DESCRIPTION
## Describe your changes

This pull request includes a small change to the `test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl` file. The change updates the `atlantis_ingress` value to a new URL.

* [`test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl`](diffhunk://#diff-23bdbeb0d3e57bc3139b318801dda0b1c266354c34072dffc2a1932f1df0cc11L163-R163): Updated the `atlantis_ingress` value from `"atlantis.qa-alias1.dfds.cloud"` to `"atlantis.qa.qa.dfds.cloud"`.

## Issue ticket number and link

https://github.com/dfds/cloudplatform/issues/2791

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
