### PR TITLE
Fixed bug where no autoscaling is scheduled for sandboxes after refactoring

### DIFF
--- a/_sub/compute/eks-nodegroup-managed/dependencies.tf
+++ b/_sub/compute/eks-nodegroup-managed/dependencies.tf
@@ -1,7 +1,7 @@
 locals {
   asg_desired_size = length(var.subnet_ids) * var.desired_size_per_subnet
   # A sandbox should be able to be put scaled down to 0 at the end of the workday.
-  asg_min_size = var.eks_is_sandbox ? 0 : local.asg_desired_size
+  asg_min_size = var.enable_inactivity_cleanup ? 0 : local.asg_desired_size
   asg_max_size = 2 * local.asg_desired_size
 }
 
@@ -38,14 +38,4 @@ locals {
 
 data "aws_eks_cluster" "this" {
   name = var.cluster_name
-}
-
-# --------------------------------------------------
-# Inactivity based clean up for sandboxes
-# --------------------------------------------------
-
-locals {
-  enable_inactivity_cleanup = (
-    var.enable_inactivity_cleanup && var.eks_is_sandbox ? true : false
-  )
 }

--- a/_sub/compute/eks-nodegroup-managed/main.tf
+++ b/_sub/compute/eks-nodegroup-managed/main.tf
@@ -89,7 +89,7 @@ resource "aws_eks_node_group" "group" {
 }
 
 resource "aws_autoscaling_schedule" "eks" {
-  count                  = local.enable_inactivity_cleanup ? signum(var.desired_size_per_subnet) : 0
+  count                  = var.enable_inactivity_cleanup ? signum(var.desired_size_per_subnet) : 0
   autoscaling_group_name = aws_eks_node_group.group[0].resources[0].autoscaling_groups[0].name
   scheduled_action_name  = "Scale to zero"
   recurrence             = var.scale_to_zero_cron

--- a/_sub/compute/eks-nodegroup-managed/vars.tf
+++ b/_sub/compute/eks-nodegroup-managed/vars.tf
@@ -93,12 +93,6 @@ variable "worker_inotify_max_user_watches" {
   type = number
 }
 
-variable "eks_is_sandbox" {
-  type        = bool
-  description = "Indicates a sandbox cluster, causing ASG to scale to zero every night"
-  default     = false
-}
-
 # --------------------------------------------------
 # Inactivity based clean up for sandboxes
 # --------------------------------------------------


### PR DESCRIPTION
## Describe your changes

This pull request includes several changes to the `_sub/compute/eks-nodegroup-managed` module to improve the handling of inactivity cleanup for sandbox environments. The most important changes are focused on simplifying the conditions and variables related to scaling the ASG (Auto Scaling Group) to zero.

Changes to inactivity cleanup handling:

* [`_sub/compute/eks-nodegroup-managed/dependencies.tf`](diffhunk://#diff-f453dda9d53534bdd9b8c21523bb24902f90d4b2d02250e56845d2d2b234d968L4-R4): Modified the `asg_min_size` condition to use `var.enable_inactivity_cleanup` instead of `var.eks_is_sandbox`.
* [`_sub/compute/eks-nodegroup-managed/dependencies.tf`](diffhunk://#diff-f453dda9d53534bdd9b8c21523bb24902f90d4b2d02250e56845d2d2b234d968L42-L51): Removed the local variable `enable_inactivity_cleanup` and its associated conditional logic.
* [`_sub/compute/eks-nodegroup-managed/main.tf`](diffhunk://#diff-433c151dbb675a65e04574da2d95430b1cf8c9806eb62ed2adef18b8b6ecd8c2L92-R92): Updated the `count` attribute in the `aws_autoscaling_schedule` resource to directly use `var.enable_inactivity_cleanup`.
* [`_sub/compute/eks-nodegroup-managed/vars.tf`](diffhunk://#diff-02c4dec2654cbdd6b9ee622b405117081a32a236919b3b6693162357784ce3daL96-L101): Removed the `eks_is_sandbox` variable, as it is no longer needed with the new cleanup logic.

## Issue ticket number and link
https://github.com/dfds/cloudplatform/issues/3187

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
