### PR TITLE
Add a new variable to control the port number that blackbox exporter should contact the Traefik endpoint on

### DIFF
--- a/compute/k8s-services/dependencies.tf
+++ b/compute/k8s-services/dependencies.tf
@@ -225,13 +225,13 @@ locals {
 
   blackbox_exporter_monitoring_traefik_blue_variant = var.traefik_blue_variant_deploy ? [{
     "name"   = "traefik-blue-variant"
-    "url"    = "http://traefik-blue-variant.traefik-blue-variant:9000/ping"
+    "url"    = "http://traefik-blue-variant.traefik-blue-variant:${var.blackbox_exporter_monitoring_traefik_blue_variant_port}/ping"
     "module" = "http_2xx"
   }] : []
 
   blackbox_exporter_monitoring_traefik_green_variant = var.traefik_green_variant_deploy ? [{
     "name"   = "traefik-green-variant"
-    "url"    = "http://traefik-green-variant.traefik-green-variant:9000/ping"
+    "url"    = "http://traefik-green-variant.traefik-green-variant:${var.blackbox_exporter_monitoring_traefik_green_variant_port}/ping"
     "module" = "http_2xx"
   }] : []
 

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -785,6 +785,18 @@ variable "blackbox_exporter_namespace" {
   default     = "monitoring"
 }
 
+variable "blackbox_exporter_monitoring_traefik_blue_variant_port" {
+  type        = number
+  description = "Port to monitor for the blue variant of Traefik"
+  default     = 8080
+}
+
+variable "blackbox_exporter_monitoring_traefik_green_variant_port" {
+  type        = number
+  description = "Port to monitor for the green variant of Traefik"
+  default     = 8080
+}
+
 # --------------------------------------------------
 # Helm Exporter
 # --------------------------------------------------


### PR DESCRIPTION
## Describe your changes

This pull request includes updates to the monitoring configuration for Traefik variants in the Kubernetes services. The main changes involve parameterizing the ports used for monitoring the blue and green variants of Traefik.

Updates to monitoring configuration:

* [`compute/k8s-services/dependencies.tf`](diffhunk://#diff-2e7c8e5dd2f4a76d76adb2da41988c1905571c7b2d401b1c58fc0f113241e49bL228-R234): Modified the URLs for `blackbox_exporter_monitoring_traefik_blue_variant` and `blackbox_exporter_monitoring_traefik_green_variant` to use the new port variables `${var.blackbox_exporter_monitoring_traefik_blue_variant_port}` and `${var.blackbox_exporter_monitoring_traefik_green_variant_port}` respectively.

New variable definitions:

* [`compute/k8s-services/vars.tf`](diffhunk://#diff-83380a112934c41699d826a5e1a07c6ee2d0729366db765c2d9c40fd2967c45bR788-R799): Added new variables `blackbox_exporter_monitoring_traefik_blue_variant_port` and `blackbox_exporter_monitoring_traefik_green_variant_port` with default values set to 8080.


## Checklist before requesting a review
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
