### PR TITLE
Add variables for Docker Hub credentials

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -41,6 +41,8 @@ resources:
         TF_VAR_grafana_agent_tempo_username: $(TF_VAR_grafana_agent_tempo_username)
         TF_VAR_onepassword_credentials_json: $(TF_VAR_onepassword_credentials_json)
         TF_VAR_onepassword_token_for_atlantis: $(TF_VAR_onepassword_token_for_atlantis)
+        TF_VAR_docker_hub_username: $(TF_VAR_docker_hub_username)
+        TF_VAR_docker_hub_password: $(TF_VAR_docker_hub_password)
         TF_IN_AUTOMATION: "true"
         TERRAGRUNT_TFPATH: /usr/local/bin/tofu
     - container: aws-nuke


### PR DESCRIPTION
## Describe your changes
This pull request includes a small change to the `azure-pipelines.yaml` file. The change adds Docker Hub credentials to the environment variables section.

* [`azure-pipelines.yaml`](diffhunk://#diff-9eedc1d7d657ddb36b1105a0fffb4852f6d34e26454371f27b6e0ad1391f290eR44-R45): Added `TF_VAR_docker_hub_username` and `TF_VAR_docker_hub_password` to the environment variables.

## Issue ticket number and link
https://dfds.visualstudio.com/Cloud%20Engineering%20Team/_workitems/edit/520271

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
