### PR TITLE
Add missing parentheses around PathPrefix rules for the Traefik Dashboard ingressroute

### DIFF
--- a/_sub/compute/k8s-traefik-flux/values/helm-patch.yaml
+++ b/_sub/compute/k8s-traefik-flux/values/helm-patch.yaml
@@ -23,5 +23,5 @@ spec:
     ingressRoute:
       dashboard:
         enabled: true
-        matchRule: Host(`${dashboard_ingress_host}`) && PathPrefix(`/dashboard`) || PathPrefix(`/api`)
+        matchRule: Host(`${dashboard_ingress_host}`) && (PathPrefix(`/api`) || PathPrefix(`/dashboard`))
         entryPoints: [traefik, web]


### PR DESCRIPTION
## Describe your changes

This pull request includes a change to the `helm-patch.yaml` file to improve the match rule for the dashboard ingress route.

Improvements to match rule:

* [`_sub/compute/k8s-traefik-flux/values/helm-patch.yaml`](diffhunk://#diff-9554dc2f79ee28eca6234f05f5fbea1633c956a90f4e5eeb839681bb7c45eec8L26-R26): Updated the `matchRule` for the dashboard ingress route to use parentheses for better logical grouping.


## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
