### PR TITLE
Change subnets for traefik_alb_anon only when enabling NAT gateway

### DIFF
--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -182,7 +182,7 @@ module "traefik_alb_anon" {
   name                  = "${var.eks_cluster_name}-traefik-alb"
   cluster_name          = var.eks_cluster_name
   vpc_id                = data.aws_eks_cluster.eks.vpc_config[0].vpc_id
-  subnet_ids            = data.terraform_remote_state.cluster.outputs.eks_control_subnet_ids
+  subnet_ids            = var.use_worker_nat_gateway ? data.terraform_remote_state.cluster.outputs.eks_control_subnet_ids : data.terraform_remote_state.cluster.outputs.eks_worker_subnet_ids
   autoscaling_group_ids = data.terraform_remote_state.cluster.outputs.eks_worker_autoscaling_group_ids
   alb_certificate_arn   = module.traefik_alb_cert.certificate_arn
   nodes_sg_id           = data.terraform_remote_state.cluster.outputs.eks_cluster_nodes_sg_id


### PR DESCRIPTION
## Describe your changes
This pull request includes a modification to the `compute/k8s-services/main.tf` file to enhance the configuration of the `traefik_alb_anon` module. The most important change involves updating the `subnet_ids` parameter to conditionally use different subnet IDs based on the `use_worker_nat_gateway` variable.

Changes in `compute/k8s-services/main.tf`:

* Updated the `subnet_ids` parameter to use `eks_control_subnet_ids` if `use_worker_nat_gateway` is true, otherwise use `eks_worker_subnet_ids`.

## Issue ticket number and link

None. Reported by @samidbb on Slack.

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
