### PR TITLE
do not merge - feat: split system and kube reserved settings

### DIFF
--- a/_sub/compute/eks-nodegroup-managed/main.tf
+++ b/_sub/compute/eks-nodegroup-managed/main.tf
@@ -14,8 +14,10 @@ resource "aws_launch_template" "eks" {
     vpc_cni_prefix_delegation_enabled : var.vpc_cni_prefix_delegation_enabled,
     cidr : data.aws_eks_cluster.this.kubernetes_network_config[0].service_ipv4_cidr
     max_pods : var.max_pods,
-    cpu : var.cpu,
-    memory : var.memory,
+    kube_cpu : var.kube_reserved_cpu,
+    kube_memory : var.kube_reserved_memory,
+    sys_cpu : var.system_reserved_cpu,
+    sys_memory : var.system_reserved_memory,
     docker_hub_username : var.docker_hub_username,
     docker_hub_password : var.docker_hub_password
   }))

--- a/_sub/compute/eks-nodegroup-managed/user-data.sh.tftpl
+++ b/_sub/compute/eks-nodegroup-managed/user-data.sh.tftpl
@@ -32,23 +32,23 @@ spec:
             maxPods: ${max_pods}
 %{ endif ~}
             registryPullQPS: 0
-%{ if cpu != null || memory != null }
+%{ if kube_cpu != null || kube_memory != null }
             kubeReserved:
 %{ endif ~}
-%{ if cpu != null }
-                cpu: ${cpu}
+%{ if kube_cpu != null }
+                cpu: ${kube_cpu}
 %{ endif ~}
-%{ if memory != null }
-                memory: ${memory}
+%{ if kube_memory != null }
+                memory: ${kube_memory}
 %{ endif ~}
-%{ if cpu != null || memory != null }
+%{ if sys_cpu != null || sys_memory != null }
             systemReserved:
 %{ endif ~}
-%{ if cpu != null }
-                cpu: ${cpu}
+%{ if sys_cpu != null }
+                cpu: ${sys_cpu}
 %{ endif ~}
-%{ if memory != null }
-                memory: ${memory}
+%{ if sys_memory != null }
+                memory: ${sys_memory}
 %{ endif ~}
 
 --BOUNDARY--

--- a/_sub/compute/eks-nodegroup-managed/vars.tf
+++ b/_sub/compute/eks-nodegroup-managed/vars.tf
@@ -146,14 +146,26 @@ variable "max_pods" {
   default     = 110
 }
 
-variable "cpu" {
+variable "kube_reserved_cpu" {
   type        = string
   description = "CPU reserved for kubernetes system components"
   default     = null
 }
 
-variable "memory" {
+variable "kube_reserved_memory" {
   type        = string
   description = "Memory reserved for kubernetes system components"
+  default     = null
+}
+
+variable "system_reserved_cpu" {
+  type        = string
+  description = "CPU reserved for system components"
+  default     = null
+}
+
+variable "system_reserved_memory" {
+  type        = string
+  description = "Memory reserved for system components"
   default     = null
 }

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -194,8 +194,10 @@ module "eks_managed_workers_node_group" {
     for sn in module.eks_managed_workers_subnet.subnets : sn.id if contains(each.value.availability_zones, sn.availability_zone)
   ]
   max_pods = each.value.max_pods
-  cpu      = each.value.cpu
-  memory   = each.value.memory
+  kube_reserved_cpu      = each.value.kube_cpu
+  kube_reserved_memory   = each.value.kube_memory
+  system_reserved_cpu      = each.value.sys_cpu
+  system_reserved_memory   = each.value.sys_memory
 
   # Docker Hub credentials
   docker_hub_username = var.docker_hub_username

--- a/compute/eks-ec2/vars.tf
+++ b/compute/eks-ec2/vars.tf
@@ -163,8 +163,10 @@ variable "eks_managed_nodegroups" {
     })), [])
     labels   = optional(map(string), {})
     max_pods = optional(number, 110)
-    cpu      = optional(string, null)
-    memory   = optional(string, null)
+    sys_cpu      = optional(string, null)
+    sys_memory   = optional(string, null)
+    kube_cpu      = optional(string, null)
+    kube_memory   = optional(string, null)
   }))
   default = {}
 }

--- a/test/integration/eu-west-1/k8s-qa/cluster/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/cluster/terragrunt.hcl
@@ -100,6 +100,10 @@ inputs = {
       ami_id             = "ami-042316b3ed8996e41"
       availability_zones         = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
       max_unavailable_percentage = 50
+      kube_memory                     = "1024Mi"
+      kube_cpu                        = "500m"
+      sys_memory                     = "768Mi"
+      sys_cpu                        = "300m"
     }
     "observability" = {
       instance_types          = ["t3.large"]
@@ -121,8 +125,10 @@ inputs = {
         dedicated = "observability"
       }
       max_pods = 30
-      memory = "585Mi"
-      cpu = "90m"
+      kube_memory                     = "585Mi"
+      kube_cpu                        = "90m"
+      sys_memory                     = "585i"
+      sys_cpu                        = "90m"
     }
   }
 

--- a/test/integration/eu-west-1/k8s-qa/cluster/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/cluster/terragrunt.hcl
@@ -127,7 +127,7 @@ inputs = {
       max_pods = 30
       kube_memory                     = "585Mi"
       kube_cpu                        = "90m"
-      sys_memory                     = "585i"
+      sys_memory                     = "585Mi"
       sys_cpu                        = "90m"
     }
   }


### PR DESCRIPTION
## Describe your changes
Allows setting different values for kube and system reserved

Do not merge until the next scheduled node rollover as it is a breaking change and updating the required variable values will trigger new nodes

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
