### PR TITLE
Add a feature toggle to determine if VPC Peering connections should automatically be migrated to new route tables. Default false

### DIFF
--- a/_sub/network/route-table/main.tf
+++ b/_sub/network/route-table/main.tf
@@ -31,7 +31,7 @@ data "aws_vpc_peering_connection" "pc" {
 }
 
 resource "aws_route" "peering" {
-  count                     = length(data.aws_vpc_peering_connections.pcs.ids)
+  count                     = var.migrate_vpc_peering_routes ? length(data.aws_vpc_peering_connections.pcs.ids) : 0
   route_table_id            = aws_route_table.table.id
   destination_cidr_block    = data.aws_vpc_peering_connection.pc[count.index].cidr_block
   vpc_peering_connection_id = data.aws_vpc_peering_connection.pc[count.index].id

--- a/_sub/network/route-table/vars.tf
+++ b/_sub/network/route-table/vars.tf
@@ -21,3 +21,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "migrate_vpc_peering_routes" {
+  description = "If true, migrate the peering connection to the new route table"
+  type        = bool
+  default     = false
+}

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -88,32 +88,35 @@ module "eks_nat_gateway" {
 }
 
 module "eks_route_table" {
-  count      = var.use_worker_nat_gateway ? 0 : 1
-  source     = "../../_sub/network/route-table"
-  name       = "eks-${var.eks_cluster_name}-subnet"
-  vpc_id     = module.eks_cluster.vpc_id
-  gateway_id = module.eks_internet_gateway.id
-  tags       = local.eks_route_table_tags
+  count                      = var.use_worker_nat_gateway ? 0 : 1
+  source                     = "../../_sub/network/route-table"
+  name                       = "eks-${var.eks_cluster_name}-subnet"
+  vpc_id                     = module.eks_cluster.vpc_id
+  gateway_id                 = module.eks_internet_gateway.id
+  migrate_vpc_peering_routes = var.migrate_vpc_peering_routes
+  tags                       = local.eks_route_table_tags
 }
 
 # Control Plane Route Table with NAT Gateway
 module "eks_route_table_nat_gateway" {
-  count      = var.use_worker_nat_gateway ? length(module.eks_cluster.subnet_ids) : 0
-  source     = "../../_sub/network/route-table"
-  name       = "eks-${var.eks_cluster_name}-subnet-control-plane-${count.index}"
-  vpc_id     = module.eks_cluster.vpc_id
-  gateway_id = module.eks_internet_gateway.id
-  tags       = local.eks_route_table_tags
+  count                      = var.use_worker_nat_gateway ? length(module.eks_cluster.subnet_ids) : 0
+  source                     = "../../_sub/network/route-table"
+  name                       = "eks-${var.eks_cluster_name}-subnet-control-plane-${count.index}"
+  vpc_id                     = module.eks_cluster.vpc_id
+  gateway_id                 = module.eks_internet_gateway.id
+  migrate_vpc_peering_routes = var.migrate_vpc_peering_routes
+  tags                       = local.eks_route_table_tags
 }
 
 # Worker Node Route Table with NAT Gateway
 module "eks_route_table_workers_nat_gateway" {
-  count          = var.use_worker_nat_gateway ? length(module.eks_managed_workers_subnet.subnet_ids) : 0
-  source         = "../../_sub/network/route-table"
-  name           = "eks-${var.eks_cluster_name}-subnet-worker-node-${count.index}"
-  vpc_id         = module.eks_cluster.vpc_id
-  nat_gateway_id = count.index < length(module.eks_nat_gateway) ? module.eks_nat_gateway[count.index].gateway_id : module.eks_nat_gateway[count.index - 1].gateway_id
-  tags           = local.eks_route_table_tags
+  count                      = var.use_worker_nat_gateway ? length(module.eks_managed_workers_subnet.subnet_ids) : 0
+  source                     = "../../_sub/network/route-table"
+  name                       = "eks-${var.eks_cluster_name}-subnet-worker-node-${count.index}"
+  vpc_id                     = module.eks_cluster.vpc_id
+  nat_gateway_id             = count.index < length(module.eks_nat_gateway) ? module.eks_nat_gateway[count.index].gateway_id : module.eks_nat_gateway[count.index - 1].gateway_id
+  migrate_vpc_peering_routes = var.migrate_vpc_peering_routes
+  tags                       = local.eks_route_table_tags
 }
 
 # Control Plane Route Table Association

--- a/compute/eks-ec2/vars.tf
+++ b/compute/eks-ec2/vars.tf
@@ -278,3 +278,9 @@ variable "eks_cluster_subnets" {
   default     = 3
   description = "Number of subnets to use for the Cluster Control Plane"
 }
+
+variable "migrate_vpc_peering_routes" {
+  description = "If true, migrate the peering connection to the new route table"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Describe your changes

It turned out that having two pipelines managing the same route tables wasn't such a good idea after all....

This is a BREAKING change that requires some manual cleanup of Terraform state from the compute/eks-ec2 modules use of the _sub/network/route-table module.

This pull request introduces changes to support the conditional migration of VPC peering routes in the AWS infrastructure. The main enhancements include the addition of a new variable to control the migration and updates to the route table configurations to utilize this variable.

Key changes include:

### New Variable Addition:

* Added `migrate_vpc_peering_routes` variable to control the migration of VPC peering routes in `_sub/network/route-table/vars.tf` and `compute/eks-ec2/vars.tf`. This variable is a boolean with a default value of `false`. [[1]](diffhunk://#diff-efd596944d1707d83866e600f4331703feff6fbf4110cc4690be1ef771d0074dR24-R29) [[2]](diffhunk://#diff-b18f8354ea8f3932f1be0681155c6e70c457a10798e9be3a07994adfea3d16b3R281-R286)

### Route Table Configuration Updates:

* Updated the `aws_route` resource in `_sub/network/route-table/main.tf` to conditionally set the count based on the `migrate_vpc_peering_routes` variable.

### Module Updates:

* Passed the `migrate_vpc_peering_routes` variable to multiple route table modules in `compute/eks-ec2/main.tf` to ensure the new variable is utilized throughout the relevant configurations. [[1]](diffhunk://#diff-377519e7ca2d872af5e1381cb6c57e93942c12625344ff8fc8a970e19a400742R96) [[2]](diffhunk://#diff-377519e7ca2d872af5e1381cb6c57e93942c12625344ff8fc8a970e19a400742R107) [[3]](diffhunk://#diff-377519e7ca2d872af5e1381cb6c57e93942c12625344ff8fc8a970e19a400742R118)

## Issue ticket number and link

https://dfds.visualstudio.com/Cloud%20Engineering%20Team/_sprints/taskboard/Cloud%20Engineering%20Team/Cloud%20Engineering%20Team/CE%20Sprint%20-%202025.Mar-02?workitem=525120

## Checklist before requesting a review
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
