### PR TITLE
feat: add worker nodes ssm access

### DIFF
--- a/_sub/compute/eks-workers/iam.tf
+++ b/_sub/compute/eks-workers/iam.tf
@@ -18,6 +18,11 @@ POLICY
 
 }
 
+resource "aws_iam_role_policy_attachment" "ssm" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  role       = aws_iam_role.eks.name
+}
+
 resource "aws_iam_role_policy_attachment" "node" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
   role       = aws_iam_role.eks.name

--- a/_sub/network/vpc-ssm/main.tf
+++ b/_sub/network/vpc-ssm/main.tf
@@ -1,0 +1,90 @@
+data "aws_region" "current" {}
+
+data "aws_vpc" "vpc" {
+  id = var.vpc_id
+}
+
+resource "aws_security_group" "ssm" {
+  name        = "ssm-eks"
+  description = "SSM EKS security group"
+  vpc_id      = var.vpc_id
+
+  tags = merge(var.tags, {
+    Name = "ssm-eks"
+  })
+}
+
+resource "aws_vpc_security_group_ingress_rule" "ssm_https" {
+  security_group_id = aws_security_group.ssm.id
+  cidr_ipv4         = data.aws_vpc.vpc.cidr_block
+  ip_protocol       = "tcp"
+  from_port         = 443
+  to_port           = 443
+  description       = "Allow SSM to VPC endpoints"
+
+  tags = var.tags
+}
+
+resource "aws_vpc_endpoint" "ssm" {
+  vpc_id            = var.vpc_id
+  service_name      = "com.amazonaws.${data.aws_region.current.name}.ssm"
+  vpc_endpoint_type = "Interface"
+
+  private_dns_enabled = true
+
+  subnet_ids = var.subnets
+
+  security_group_ids = [
+    aws_security_group.ssm.id,
+  ]
+
+  tags = merge(var.tags, {
+    Name = "peering-com.amazonaws.${data.aws_region.current.name}.ssm"
+  })
+}
+
+resource "aws_vpc_endpoint" "ssmmessages" {
+  vpc_id            = var.vpc_id
+  service_name      = "com.amazonaws.${data.aws_region.current.name}.ssmmessages"
+  vpc_endpoint_type = "Interface"
+
+  private_dns_enabled = true
+
+  subnet_ids = var.subnets
+
+  security_group_ids = [
+    aws_security_group.ssm.id,
+  ]
+
+  tags = merge(var.tags, {
+    Name = "peering-com.amazonaws.${data.aws_region.current.name}.ssmmessages"
+  })
+}
+
+resource "aws_vpc_endpoint" "ec2" {
+  vpc_id            = var.vpc_id
+  service_name      = "com.amazonaws.${data.aws_region.current.name}.ec2"
+  vpc_endpoint_type = "Interface"
+
+  private_dns_enabled = true
+
+  subnet_ids = var.subnets
+
+  tags = merge(var.tags, {
+    Name = "peering-com.amazonaws.${data.aws_region.current.name}.ec2"
+  })
+}
+
+resource "aws_vpc_endpoint" "ec2messages" {
+  vpc_id            = var.vpc_id
+  service_name      = "com.amazonaws.${data.aws_region.current.name}.ec2messages"
+  vpc_endpoint_type = "Interface"
+
+  private_dns_enabled = true
+
+  subnet_ids = var.subnets
+
+  tags = merge(var.tags, {
+    Name = "peering-com.amazonaws.${data.aws_region.current.name}.ec2messages"
+  })
+}

--- a/_sub/network/vpc-ssm/vars.tf
+++ b/_sub/network/vpc-ssm/vars.tf
@@ -1,0 +1,13 @@
+variable "vpc_id" {
+  type = string
+}
+
+variable "subnets" {
+    type = list(string)
+    default = []
+}
+
+variable "tags" {
+    type = map(string)
+    default = {}
+}

--- a/_sub/network/vpc-ssm/versions.tf
+++ b/_sub/network/vpc-ssm/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.3.0, < 1.6.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.93.0"
+    }
+  }
+}

--- a/_sub/network/vpc-ssm/versions.tofu
+++ b/_sub/network/vpc-ssm/versions.tofu
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.8.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.93.0"
+    }
+  }
+}

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -74,6 +74,12 @@ module "eks_workers" {
   cur_bucket_arn                 = var.eks_worker_cur_bucket_arn
 }
 
+module "ssm" {
+  source  = "../../_sub/network/vpc-ssm"
+  vpc_id  = module.eks_cluster.vpc_id
+  subnets = [for sn in module.eks_managed_workers_subnet.subnets : sn.id]
+}
+
 # --------------------------------------------------
 # NAT Gateway - with or without
 # --------------------------------------------------


### PR DESCRIPTION
## Describe your changes
Adds SSM support for accessing worker nodes

Can be achieved by using the AWS console or via CLI with `aws ssm start-session --region eu-west-1 --target <ec2-instance-id>`

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
