### PR TITLE
fix: remove ec2 vpc endpoints

### DIFF
--- a/_sub/network/vpc-ssm/main.tf
+++ b/_sub/network/vpc-ssm/main.tf
@@ -60,31 +60,3 @@ resource "aws_vpc_endpoint" "ssmmessages" {
     Name = "peering-com.amazonaws.${data.aws_region.current.name}.ssmmessages"
   })
 }
-
-resource "aws_vpc_endpoint" "ec2" {
-  vpc_id            = var.vpc_id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.ec2"
-  vpc_endpoint_type = "Interface"
-
-  private_dns_enabled = true
-
-  subnet_ids = var.subnets
-
-  tags = merge(var.tags, {
-    Name = "peering-com.amazonaws.${data.aws_region.current.name}.ec2"
-  })
-}
-
-resource "aws_vpc_endpoint" "ec2messages" {
-  vpc_id            = var.vpc_id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.ec2messages"
-  vpc_endpoint_type = "Interface"
-
-  private_dns_enabled = true
-
-  subnet_ids = var.subnets
-
-  tags = merge(var.tags, {
-    Name = "peering-com.amazonaws.${data.aws_region.current.name}.ec2messages"
-  })
-}


### PR DESCRIPTION
## Describe your changes
Removes ec2 and ec2messaged vpc endpoints in attempt to fix the issue with ASG's since ssm introduction

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
