### PR TITLE
Add support for IRSA for the Flux CD source controller

### DIFF
--- a/_sub/compute/k8s-fluxcd/main.tf
+++ b/_sub/compute/k8s-fluxcd/main.tf
@@ -24,10 +24,12 @@ resource "github_repository_deploy_key" "main" {
 }
 
 resource "flux_bootstrap_git" "this" {
-  depends_on             = [github_repository_deploy_key.main]
-  path                   = local.cluster_target_path
-  version                = var.release_tag
-  kustomization_override = file("${path.module}/values/flux-system-patch.yaml")
+  depends_on = [github_repository_deploy_key.main]
+  path       = local.cluster_target_path
+  version    = var.release_tag
+  kustomization_override = templatefile("${path.module}/values/flux-system-patch.yaml", {
+    src_ctrl_arn = var.source_controller_role_arn
+  })
 }
 
 

--- a/_sub/compute/k8s-fluxcd/values/flux-system-patch.yaml
+++ b/_sub/compute/k8s-fluxcd/values/flux-system-patch.yaml
@@ -28,3 +28,16 @@ patches:
       kind: Kustomization
       # trunk-ignore(yamllint/quoted-strings)
       name: "flux-system"
+%{ if src_ctrl_arn != "" }
+  - patch: |
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: source-controller
+        annotations:
+          eks.amazonaws.com/role-arn: "${src_ctrl_arn}"
+          eks.amazonaws.com/sts-regional-endpoints: "true"
+    target:
+      kind: ServiceAccount
+      name: source-controller
+%{ endif ~}

--- a/_sub/compute/k8s-fluxcd/vars.tf
+++ b/_sub/compute/k8s-fluxcd/vars.tf
@@ -81,3 +81,9 @@ variable "tenants" {
   description = "List of tenants' namespaces and repository URLs"
   default     = []
 }
+
+variable "source_controller_role_arn" {
+  type        = string
+  default     = ""
+  description = "The ARN of the IAM role for the source controller. Used for IAM roles for service accounts (IRSA). Optional."
+}

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -462,21 +462,22 @@ module "aws_node_service" {
 # --------------------------------------------------
 
 module "platform_fluxcd" {
-  source                  = "../../_sub/compute/k8s-fluxcd"
-  release_tag             = var.fluxcd_version
-  repository_name         = var.fluxcd_bootstrap_repo_name
-  branch                  = var.fluxcd_bootstrap_repo_branch
-  github_owner            = var.fluxcd_bootstrap_repo_owner
-  overwrite_on_create     = var.fluxcd_bootstrap_overwrite_on_create
-  gitops_apps_repo_url    = local.fluxcd_apps_repo_url
-  gitops_apps_repo_branch = var.fluxcd_apps_repo_branch
-  cluster_name            = var.eks_cluster_name
-  prune                   = var.fluxcd_prune
-  endpoint                = data.aws_eks_cluster.eks.endpoint
-  token                   = data.aws_eks_cluster_auth.eks.token
-  cluster_ca_certificate  = base64decode(data.aws_eks_cluster.eks.certificate_authority[0].data)
-  enable_monitoring       = var.monitoring_kube_prometheus_stack_deploy || var.grafana_deploy ? true : false
-  tenants                 = var.fluxcd_tenants
+  source                     = "../../_sub/compute/k8s-fluxcd"
+  release_tag                = var.fluxcd_version
+  repository_name            = var.fluxcd_bootstrap_repo_name
+  branch                     = var.fluxcd_bootstrap_repo_branch
+  github_owner               = var.fluxcd_bootstrap_repo_owner
+  overwrite_on_create        = var.fluxcd_bootstrap_overwrite_on_create
+  gitops_apps_repo_url       = local.fluxcd_apps_repo_url
+  gitops_apps_repo_branch    = var.fluxcd_apps_repo_branch
+  cluster_name               = var.eks_cluster_name
+  prune                      = var.fluxcd_prune
+  endpoint                   = data.aws_eks_cluster.eks.endpoint
+  token                      = data.aws_eks_cluster_auth.eks.token
+  cluster_ca_certificate     = base64decode(data.aws_eks_cluster.eks.certificate_authority[0].data)
+  enable_monitoring          = var.monitoring_kube_prometheus_stack_deploy || var.grafana_deploy ? true : false
+  tenants                    = var.fluxcd_tenants
+  source_controller_role_arn = var.fluxcd_source_controller_role_arn
 
   providers = {
     github = github.fluxcd

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -501,6 +501,12 @@ variable "fluxcd_tenants" {
   default     = []
 }
 
+variable "fluxcd_source_controller_role_arn" {
+  type        = string
+  default     = ""
+  description = "The ARN of the IAM role for the source controller. Used for IAM roles for service accounts (IRSA). Optional."
+}
+
 # --------------------------------------------------
 # GitOps apps used by Flux CD
 # --------------------------------------------------


### PR DESCRIPTION
## Describe your changes

This pull request includes changes to add support for specifying an IAM role ARN for the source controller in the Flux CD configuration. The most important changes involve updating the Terraform configuration and adding a new variable to handle the IAM role ARN.

### Support for IAM Role ARN for Source Controller:

* [`_sub/compute/k8s-fluxcd/main.tf`](diffhunk://#diff-2e3be66af9677da6611ef57a5c721e764d0cda8b70ee86caa4ca9f9bb3c08b53L30-R32): Updated the `kustomization_override` to use `templatefile` and pass the `src_ctrl_arn` variable.
* [`_sub/compute/k8s-fluxcd/values/flux-system-patch.yaml`](diffhunk://#diff-3af6a8f87eefe902ab5a6ec8b1b5d23a3b12aa81af11090e712296eaa96d3ac6R31-R43): Added conditional logic to include a patch for the `ServiceAccount` if `src_ctrl_arn` is provided.
* [`_sub/compute/k8s-fluxcd/vars.tf`](diffhunk://#diff-f5c407fdb38f18002fce04693813606eab07206878d876746271eb448035e57dR84-R89): Added a new variable `source_controller_role_arn` to store the IAM role ARN for the source controller.

### Integration with Existing Configuration:

* [`compute/k8s-services/main.tf`](diffhunk://#diff-9dcb2b34c331c83c7b15b8785fc38080f22e765d3119f854acc7848e7f669485R480): Passed the new `source_controller_role_arn` variable to the `platform_fluxcd` module.
* [`compute/k8s-services/vars.tf`](diffhunk://#diff-83380a112934c41699d826a5e1a07c6ee2d0729366db765c2d9c40fd2967c45bR504-R509): Added a new variable `fluxcd_source_controller_role_arn` to store the IAM role ARN for the source controller.

## Issue ticket number and link
[<!--#issue number here -->](https://dfds.visualstudio.com/Cloud%20Engineering%20Team/_sprints/taskboard/Cloud%20Engineering%20Team/Cloud%20Engineering%20Team/CE%20Sprint%20-%202025.Apr-01?workitem=521750)

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
