### PR TITLE
Add module for setting up IAM trust between Flux CD source controller and AWS account with ECR

### DIFF
--- a/security/iam-ecr-access/main.tf
+++ b/security/iam-ecr-access/main.tf
@@ -1,0 +1,23 @@
+# Load IAM policy documents from module
+module "qa_iam_policies" {
+  source                            = "../../_sub/security/iam-policies"
+  iam_role_trusted_account_root_arn = var.qa_iam_role_trusted_account_root_arn
+}
+
+# Create the role for the master account
+resource "aws_iam_role" "qa_role" {
+  name               = var.qa_iam_role_name
+  description        = var.qa_iam_role_description
+  assume_role_policy = module.qa_iam_policies.trusted_account
+
+  provider = aws.workload
+}
+
+# Create the a role, allowing to create organisation accounts
+resource "aws_iam_role_policy" "qa_role_policy" {
+  name   = var.qa_iam_policy_name
+  role   = aws_iam_role.qa_role.id
+  policy = module.qa_iam_policies.admin
+
+  provider = aws.workload
+}

--- a/security/iam-ecr-access/main.tf
+++ b/security/iam-ecr-access/main.tf
@@ -27,8 +27,6 @@ data "aws_iam_policy_document" "fluxcd_role_trust" {
       }
     }
   }
-
-  provider = aws.workload
 }
 
 resource "aws_iam_role" "fluxcd_role" {
@@ -67,4 +65,6 @@ resource "aws_iam_openid_connect_provider" "default" {
   thumbprint_list = [data.tls_certificate.cert[each.key].certificates[0].sha1_fingerprint]
 
   tags = merge(var.tags, { Cluster = each.key })
+
+  provider = aws.workload
 }

--- a/security/iam-ecr-access/main.tf
+++ b/security/iam-ecr-access/main.tf
@@ -1,23 +1,44 @@
-# Load IAM policy documents from module
-module "qa_iam_policies" {
-  source                            = "../../_sub/security/iam-policies"
-  iam_role_trusted_account_root_arn = var.qa_iam_role_trusted_account_root_arn
+locals {
+  fluxcd_role_trust = merge(
+    var.fluxcd_role_prod_trust,
+    var.fluxcd_role_nonprod_trust
+  )
 }
 
-# Create the role for the master account
-resource "aws_iam_role" "qa_role" {
-  name               = var.qa_iam_role_name
-  description        = var.qa_iam_role_description
-  assume_role_policy = module.qa_iam_policies.trusted_account
+data "aws_iam_policy_document" "fluxcd_role_trust" {
+  dynamic "statement" {
+    for_each = local.fluxcd_role_trust
+    content {
+      sid     = replace(statement.key, "-", "") # https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_sid.html
+      effect  = statement.value["effect"]
+      actions = [statement.value["action"]]
+      principals {
+        type        = "Federated"
+        identifiers = ["arn:aws:iam::${var.aws_workload_account_id}:oidc-provider/${statement.value["oidc_fqdn_url"]}"]
+      }
+      condition {
+        test     = statement.value["condition_operator"]
+        variable = "${statement.value["oidc_fqdn_url"]}:${statement.value["condition_variable"]}"
+        values   = [statement.value["condition_values"]]
+      }
+    }
+  }
 
   provider = aws.workload
 }
 
-# Create the a role, allowing to create organisation accounts
-resource "aws_iam_role_policy" "qa_role_policy" {
-  name   = var.qa_iam_policy_name
-  role   = aws_iam_role.qa_role.id
-  policy = module.qa_iam_policies.admin
+resource "aws_iam_role" "fluxcd_role" {
+  name               = var.fluxcd_role_name
+  description        = "IAM role for ECR access from FluxCD source controller"
+  assume_role_policy = data.aws_iam_policy_document.fluxcd_role_trust.json
+  tags               = var.tags
+
+  provider = aws.workload
+}
+
+resource "aws_iam_role_policy_attachment" "fluxcd_read_only" {
+  role       = aws_iam_role.fluxcd_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
 
   provider = aws.workload
 }

--- a/security/iam-ecr-access/providers.tf
+++ b/security/iam-ecr-access/providers.tf
@@ -1,0 +1,25 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = var.tags
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+  alias  = "workload"
+
+  default_tags {
+    tags = var.tags
+  }
+
+  assume_role {
+    role_arn = "arn:aws:iam::${var.aws_workload_account_id}:role/${var.prime_role_name}"
+  }
+}
+
+terraform {
+  backend "s3" {
+  }
+}

--- a/security/iam-ecr-access/vars.tf
+++ b/security/iam-ecr-access/vars.tf
@@ -12,28 +12,39 @@ variable "prime_role_name" {
   default = ""
 }
 
-variable "qa_iam_role_name" {
-  description = "Name of IAM role"
-  type        = string
-}
-
-variable "qa_iam_role_description" {
-  description = "Description for IAM role"
-  type        = string
-}
-
-variable "qa_iam_policy_name" {
-  description = "Policy granting access to create new AWS Organization accounts"
-  type        = string
-}
-
-variable "qa_iam_role_trusted_account_root_arn" {
-  description = "The ARN of the account trusted to assume the role"
-  type        = list(string)
-}
-
 variable "tags" {
   type        = map(string)
   description = "A map of tags to apply to all the resources deployed by the module"
   default     = {}
+}
+
+variable "fluxcd_role_name" {
+  description = "IAM role for ECR access from FluxCD source controller"
+  type        = string
+  default     = "fluxcd-source-controller-ecr-reader"
+}
+
+variable "fluxcd_role_prod_trust" {
+  description = "A map of the trust relationship for the IAM role. Mandatory."
+  type = map(object({
+    oidc_fqdn_url      = optional(string, "")
+    action             = optional(string, "sts:AssumeRoleWithWebIdentity")
+    effect             = optional(string, "Allow")
+    condition_operator = optional(string, "StringEquals")
+    condition_variable = optional(string, "sub")
+    condition_values   = optional(string, "system:serviceaccount:flux-system:source-controller")
+  }))
+}
+
+variable "fluxcd_role_nonprod_trust" {
+  description = "A map of the trust relationship for the IAM role. Optional."
+  type = map(object({
+    oidc_fqdn_url      = optional(string, "")
+    action             = optional(string, "sts:AssumeRoleWithWebIdentity")
+    effect             = optional(string, "Allow")
+    condition_operator = optional(string, "StringEquals")
+    condition_variable = optional(string, "sub")
+    condition_values   = optional(string, "system:serviceaccount:flux-system:source-controller")
+  }))
+  default = {}
 }

--- a/security/iam-ecr-access/vars.tf
+++ b/security/iam-ecr-access/vars.tf
@@ -1,0 +1,39 @@
+variable "aws_region" {
+  type = string
+}
+
+variable "aws_workload_account_id" {
+  description = "The ID of the account trusted to assume the role"
+  type        = string
+}
+
+variable "prime_role_name" {
+  type    = string
+  default = ""
+}
+
+variable "qa_iam_role_name" {
+  description = "Name of IAM role"
+  type        = string
+}
+
+variable "qa_iam_role_description" {
+  description = "Description for IAM role"
+  type        = string
+}
+
+variable "qa_iam_policy_name" {
+  description = "Policy granting access to create new AWS Organization accounts"
+  type        = string
+}
+
+variable "qa_iam_role_trusted_account_root_arn" {
+  description = "The ARN of the account trusted to assume the role"
+  type        = list(string)
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "A map of tags to apply to all the resources deployed by the module"
+  default     = {}
+}

--- a/security/iam-ecr-access/versions.tf
+++ b/security/iam-ecr-access/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.94.0"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0.4"
+    }
   }
 }

--- a/security/iam-ecr-access/versions.tf
+++ b/security/iam-ecr-access/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0, < 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.94.0"
+    }
+  }
+}

--- a/security/iam-ecr-access/versions.tofu
+++ b/security/iam-ecr-access/versions.tofu
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.94.0"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0.4"
+    }
   }
 }

--- a/security/iam-ecr-access/versions.tofu
+++ b/security/iam-ecr-access/versions.tofu
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.8.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.94.0"
+    }
+  }
+}


### PR DESCRIPTION
- **Add directory structure for IAM resources in the shared-prod account**
- **Add module for seeting up IAM trust between Flux CD controller and IAM in an ECR account**

## Describe your changes

This pull request includes several changes to the `security/iam-ecr-access` module to support Flux CD source controller ECR access through IRSA, along with updates to providers, variables, and required versions. The most important changes include the addition of new IAM roles and policies, provider configurations, and variable definitions.

### IAM Role and Policy Changes:
* Added IAM role and policy for Flux CD source controller ECR access, including trust relationships and policy attachments. (`security/iam-ecr-access/main.tf`)

### Provider Configurations:
* Added AWS provider configurations, including default tags and assume role settings for workload accounts. (`security/iam-ecr-access/providers.tf`)

### Variable Definitions:
* Defined new variables for AWS region, workload account ID, prime role name, tags, and Flux CD role trust relationships. (`security/iam-ecr-access/vars.tf`)

### Required Versions:
* Specified required Terraform and provider versions to ensure compatibility. (`security/iam-ecr-access/versions.tf`, `security/iam-ecr-access/versions.tofu`) [[1]](diffhunk://#diff-94db272e9807fdf3b001f1105cf04438e8c7eb95d8a21a2e8939b4ba1a7c4ecfR1-R14) [[2]](diffhunk://#diff-16a2caa4904389abeebdfd9d9b7e10622271753a5b82e8efaa743c7e5279d0c6R1-R14)
## Issue ticket number and link
https://dfds.visualstudio.com/Cloud%20Engineering%20Team/_sprints/taskboard/Cloud%20Engineering%20Team/Cloud%20Engineering%20Team/CE%20Sprint%20-%202025.Apr-01?workitem=521750

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
