### PR TITLE
Disable default standards for security hub, and make it into a optional variable instead

### DIFF
--- a/_sub/security/hardened-account/main.tf
+++ b/_sub/security/hardened-account/main.tf
@@ -8,7 +8,7 @@ data "aws_region" "workload" {
 
 resource "aws_securityhub_account" "workload" {
   count                    = var.harden ? 1 : 0
-  enable_default_standards = true
+  enable_default_standards = var.enable_default_standards
   provider                 = aws.workload
 }
 

--- a/_sub/security/hardened-account/vars.tf
+++ b/_sub/security/hardened-account/vars.tf
@@ -61,3 +61,8 @@ variable "sso_support_group_name" {
   type    = string
   default = null
 }
+
+variable "enable_default_standards" {
+  type    = bool
+  default = false
+}

--- a/security/org-account-assume/main.tf
+++ b/security/org-account-assume/main.tf
@@ -120,6 +120,7 @@ module "hardened-account" {
   security_contact_title          = var.hardened_security_contact_title
   security_contact_email          = var.hardened_security_contact_email
   security_contact_phone_number   = var.hardened_security_contact_phone_number
+  enable_default_standards        = var.hardened_enable_default_standards
   sso_support_permission_set_name = var.sso_support_permission_set_name
   sso_support_group_name          = var.sso_support_group_name
 

--- a/security/org-account-assume/vars.tf
+++ b/security/org-account-assume/vars.tf
@@ -144,6 +144,11 @@ variable "hardened_security_contact_phone_number" {
   type = string
 }
 
+variable "hardened_enable_default_standards" {
+  type    = bool
+  default = false
+}
+
 variable "tags" {
   type        = map(string)
   description = "A map of tags to apply to all the resources deployed by the module"


### PR DESCRIPTION
## Describe your changes

This pull request introduces changes to the Terraform configuration to allow for more flexibility in enabling default security standards. The most important changes include adding a new variable to control this behavior and updating the relevant modules to use this new variable.

### Changes to enable default security standards:

* [`_sub/security/hardened-account/main.tf`](diffhunk://#diff-b69fe7fdcb4985492eb3f79db2c2c0c869269ad6b0f9cbfedb343bd673b50ab7L11-R11): Modified the `aws_securityhub_account` resource to use the new `enable_default_standards` variable instead of a hardcoded value.
* [`_sub/security/hardened-account/vars.tf`](diffhunk://#diff-6ca6c1f43bbe7a9826bf2dfcec00c67793abd315f46f05a5b233e02109d60ff8R64-R68): Added a new variable `enable_default_standards` with a default value of `false`.
* [`security/org-account-assume/main.tf`](diffhunk://#diff-e21a8d7fb5e4bcb409fc007cf445d3b7981b1cdc9a8ffad4c004e05cf3f6230bR123): Updated the `hardened-account` module to pass the new `enable_default_standards` variable.
* [`security/org-account-assume/vars.tf`](diffhunk://#diff-45faabede4b7ec664cd2f3a10cd103ede0b581d49792fc4d4b0be628ec5c60dbR147-R151): Added a new variable `hardened_enable_default_standards` with a default value of `false`.

## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
