### PR TITLE
Add IAM action to watch recreation of SSO account assigments

### DIFF
--- a/_sub/security/iam-policies/main.tf
+++ b/_sub/security/iam-policies/main.tf
@@ -70,6 +70,7 @@ data "aws_iam_policy_document" "create_org_account" {
       "sso:ListPermissionSetsProvisionedToAccount",
       "sso:ListAccountAssignments",
       "sso:DescribeAccountAssignmentCreationStatus",
+      "sso:DescribeAccountAssignmentDeletionStatus",
     ]
 
     resources = ["*"]


### PR DESCRIPTION
## Describe your changes

This pull request includes a small change to the IAM policy document in `main.tf`. The change adds a new permission, `sso:DescribeAccountAssignmentDeletionStatus`, to the `actions` list for the `aws_iam_policy_document` resource named `create_org_account`.

## Checklist before requesting a review
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
