### PR TITLE
Increase the amount of allowed concurrent ops for flux helm-controller

### DIFF
--- a/_sub/compute/k8s-fluxcd/values/flux-system-patch.yaml
+++ b/_sub/compute/k8s-fluxcd/values/flux-system-patch.yaml
@@ -22,6 +22,14 @@ patches:
       name: "(kustomize-controller|helm-controller)"
   - patch: |
       - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --concurrent=40
+    target:
+      kind: Deployment
+      # trunk-ignore(yamllint/quoted-strings)
+      name: "helm-controller"
+  - patch: |
+      - op: add
         path: /spec/serviceAccountName
         value: kustomize-controller
     target:


### PR DESCRIPTION
## Describe your changes
With the soon pretty big increase in helm releases due to ssu-k8s, to make sure helm controller is runner a bit smoother I want to bump the max concurrent ops.

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
