### PR TITLE
Add support for accessMode: ReadOnly in Velero in order to support restore from replicated bucket

### DIFF
--- a/_sub/storage/velero/main.tf
+++ b/_sub/storage/velero/main.tf
@@ -53,6 +53,7 @@ resource "github_repository_file" "velero_flux_helm_patch_yaml" {
     schedules_template_ttl              = var.schedules_template_ttl
     excluded_cluster_scoped_resources   = var.excluded_cluster_scoped_resources
     excluded_namespace_scoped_resources = var.excluded_namespace_scoped_resources
+    read_only                           = var.read_only
   })
   overwrite_on_create = var.overwrite_on_create
 }

--- a/_sub/storage/velero/values/patch.yaml
+++ b/_sub/storage/velero/values/patch.yaml
@@ -32,12 +32,16 @@ spec:
           bucket: ${bucket_name}
           config:
             region: ${bucket_region}
+%{ if read_only ~}
+          accessMode: ReadOnly
+%{ endif ~}
     serviceAccount:
       server:
         create: true
         annotations:
           eks.amazonaws.com/role-arn: "${velero_role_arn}"
           eks.amazonaws.com/sts-regional-endpoints: "true"
+%{ if !read_only ~}
     schedules:
       ${cluster_name}-cluster-backup:
         schedule: "${cron_schedule}"
@@ -55,4 +59,5 @@ spec:
 %{ for ex_cl in excluded_cluster_scoped_resources ~}
             - ${ex_cl}
 %{ endfor ~}
+%{ endif ~}
 %{ endif ~}

--- a/_sub/storage/velero/vars.tf
+++ b/_sub/storage/velero/vars.tf
@@ -158,3 +158,12 @@ variable "excluded_namespace_scoped_resources" {
   default     = []
   description = "List of namespace-scoped resources to exclude from backup"
 }
+
+variable "read_only" {
+  type        = bool
+  default     = false
+  description = <<EOF
+    Set to true to access the backup storage location in read-only mode.
+    This is useful for restoring from a backup without modifying the backup storage location.
+EOF
+}

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -653,6 +653,7 @@ module "velero" {
   workload_account_id                 = var.aws_workload_account_id
   excluded_cluster_scoped_resources   = var.velero_excluded_cluster_scoped_resources
   excluded_namespace_scoped_resources = var.velero_excluded_namespace_scoped_resources
+  read_only                           = var.velero_read_only
 
   providers = {
     github = github.fluxcd

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -903,6 +903,14 @@ variable "velero_excluded_namespace_scoped_resources" {
   description = "List of namespace-scoped resources to exclude from backup"
 }
 
+variable "velero_read_only" {
+  type        = bool
+  default     = false
+  description = <<EOF
+    Set to true to access the backup storage location in read-only mode.
+    This is useful for restoring from a backup without modifying the backup storage location.
+EOF
+}
 
 # --------------------------------------------------
 # Kyverno


### PR DESCRIPTION
## Describe your changes

This pull request introduces a new `read_only` variable to enable read-only access to Velero backup storage locations. This feature is designed to facilitate restoring backups without modifying the backup storage. The changes include updates to Terraform and Helm templates to support this functionality.

### Addition of `read_only` variable:

* [`_sub/storage/velero/vars.tf`](diffhunk://#diff-36860fab725b133094d511f993ea9f4ec62acf6f5eefd607f08d4cd1152a763dR161-R169): Added a new `read_only` variable with a default value of `false` and a description explaining its purpose.
* [`compute/k8s-services/vars.tf`](diffhunk://#diff-83380a112934c41699d826a5e1a07c6ee2d0729366db765c2d9c40fd2967c45bR906-R913): Added a corresponding `velero_read_only` variable for the Velero module.

### Integration with Terraform resources:

* [`_sub/storage/velero/main.tf`](diffhunk://#diff-18fcf31da50bd6c39fcf96a7c13f404b3457ce8a0fe3bbe9e9da785df9ffba4dR56): Passed the `read_only` variable to the `github_repository_file` resource.
* [`compute/k8s-services/main.tf`](diffhunk://#diff-9dcb2b34c331c83c7b15b8785fc38080f22e765d3119f854acc7848e7f669485R656): Integrated the `velero_read_only` variable into the Velero module configuration.

### Updates to Helm templates:

* [`_sub/storage/velero/values/patch.yaml`](diffhunk://#diff-9bcea7b85ef86a4cd2047a80b14dede9dbbe7721053b6efd7ef3a1745aeaebd9R35-R44): Added conditional logic to set `accessMode` to `ReadOnly` when `read_only` is true and to disable schedules when `read_only` is true. [[1]](diffhunk://#diff-9bcea7b85ef86a4cd2047a80b14dede9dbbe7721053b6efd7ef3a1745aeaebd9R35-R44) [[2]](diffhunk://#diff-9bcea7b85ef86a4cd2047a80b14dede9dbbe7721053b6efd7ef3a1745aeaebd9R63)

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
