### PR TITLE
Support bucket encryption for bucket replication

### DIFF
--- a/_sub/storage/s3-bucket-lifecycle/vars.tf
+++ b/_sub/storage/s3-bucket-lifecycle/vars.tf
@@ -38,9 +38,10 @@ variable "object_ownership" {
 
 variable "replication" {
   type = map(object({
-    destination_account_id = string
-    destination_bucket_arn = string
-    kms_encryption_key_arn = optional(string, "")
+    destination_account_id  = string
+    destination_bucket_arn  = string
+    destination_kms_key_arn = optional(string, "")
+    source_kms_key_arn      = optional(string, "")
   }))
   default = {}
 }

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -63,9 +63,10 @@ variable "traefik_alb_s3_access_logs_retiontion_days" {
 
 variable "alb_access_logs_replication" {
   type = map(object({
-    destination_account_id = string
-    destination_bucket_arn = string
-    kms_encryption_key_arn = optional(string, "")
+    destination_account_id  = string
+    destination_bucket_arn  = string
+    destination_kms_key_arn = optional(string, "")
+    source_kms_key_arn      = optional(string, "")
   }))
   default = {}
 }

--- a/storage/s3-velero-backup/vars.tf
+++ b/storage/s3-velero-backup/vars.tf
@@ -15,7 +15,6 @@ variable "replication" {
   type = map(object({
     destination_account_id = string
     destination_bucket_arn = string
-    kms_encryption_key_arn = optional(string, "")
   }))
   default = {}
 }


### PR DESCRIPTION
## Describe your changes

This pull request refactors the handling of KMS encryption keys in S3 bucket replication configurations. The changes introduce separate variables and logic for source and destination KMS keys, improving clarity and flexibility in replication policies.

### Refactoring KMS Key Handling:

* `_sub/storage/s3-bucket-lifecycle/main.tf`: 
  - Replaced `kms_encryption_key_arns` with `source_kms_key_arns` and `destination_kms_key_arns` for better distinction between source and destination KMS keys. Updated IAM policy documents and replication configurations to use these new variables. [[1]](diffhunk://#diff-b58282d7fd3f2d9fe8b950b6f94a8d638746989c7581a4951d4d583a4e6b0574L89-R95) [[2]](diffhunk://#diff-b58282d7fd3f2d9fe8b950b6f94a8d638746989c7581a4951d4d583a4e6b0574L134-R163) [[3]](diffhunk://#diff-b58282d7fd3f2d9fe8b950b6f94a8d638746989c7581a4951d4d583a4e6b0574L186-R212)

### Updates to Variable Definitions:

* `_sub/storage/s3-bucket-lifecycle/vars.tf`: 
  - Updated the `replication` variable to replace `kms_encryption_key_arn` with `source_kms_key_arn` and `destination_kms_key_arn`.
* `compute/k8s-services/vars.tf`: 
  - Made similar updates to the `alb_access_logs_replication` variable.
* `storage/s3-velero-backup/vars.tf`: 
  - Removed the `kms_encryption_key_arn` variable as it is no longer used.

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
