### PR TITLE
Allow for overriding the identifier urls set in the AZ app registration used for alb

### DIFF
--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -84,7 +84,7 @@ module "traefik_alb_auth_appreg" {
   source          = "../../_sub/security/azure-app-registration"
   count           = var.traefik_alb_auth_deploy ? 1 : 0
   name            = "Kubernetes EKS ${local.eks_fqdn} cluster"
-  identifier_uris = ["https://${local.eks_fqdn}"]
+  identifier_uris = var.alb_az_app_registration_identifier_urls != null ? var.alb_az_app_registration_identifier_urls : ["https://${local.eks_fqdn}"]
   homepage_url    = "https://${local.eks_fqdn}"
   redirect_uris   = local.traefik_alb_auth_appreg_reply_urls
 }

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -112,6 +112,12 @@ variable "traefik_nlb_deploy" {
   default = false
 }
 
+variable "alb_az_app_registration_identifier_urls" {
+  type = list(string)
+  default = null
+  nullable = true
+}
+
 # --------------------------------------------------
 # Blaster
 # --------------------------------------------------


### PR DESCRIPTION
Default behaviour: It will continue to work as it does now, unless you set a value for the variable "alb_az_app_registration_identifier_urls"

Why: Due to an API change in Azure, it'll no longer allow hostnames in identifier urls that isn't verified domains. That makes it more difficult when playing around with things in sandbox.