### PR TITLE
Upgrade helm charts for Traefik, Velero and Atlantis

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,7 +2,7 @@
 # To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
 version: 0.1
 cli:
-  version: 1.22.12
+  version: 1.22.15
 # Trunk provides extensibility via plugins. (https://docs.trunk.io/plugins)
 plugins:
   sources:

--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -53,7 +53,7 @@ inputs = {
   # Blue variant
   traefik_blue_variant_deploy             = true
   traefik_blue_variant_dashboard_deploy   = true
-  traefik_blue_variant_helm_chart_version = "34.4.0"
+  traefik_blue_variant_helm_chart_version = "35.2.0"
   traefik_blue_variant_additional_args = [
     "--metrics.prometheus",
     "--providers.kubernetescrd.allowCrossNamespace=true",
@@ -63,7 +63,7 @@ inputs = {
   # Green variant
   traefik_green_variant_deploy             = false
   traefik_green_variant_dashboard_deploy   = false
-  traefik_green_variant_helm_chart_version = "34.4.0"
+  traefik_green_variant_helm_chart_version = "35.2.0"
   traefik_green_variant_additional_args = [
     "--metrics.prometheus",
     "--providers.kubernetescrd.allowCrossNamespace=true",
@@ -171,7 +171,7 @@ inputs = {
   atlantis_github_repositories = ["dfds/qa-dummy-atlantis"]
   atlantis_github_owner        = "dfds"
   atlantis_webhook_events      = ["issue_comment", "pull_request", "pull_request_review", "push"]
-  atlantis_chart_version       = "5.7.0"
+  atlantis_chart_version       = "5.17.2"
   atlantis_environment         = "qa"
   atlantis_image_tag           = "2.1.0"
   atlantis_add_secret_volumes  = true
@@ -242,10 +242,10 @@ inputs = {
 
   velero_deploy                               = true
   velero_bucket_arn                           = "arn:aws:s3:::dfds-velero-qa"
-  velero_helm_chart_version                   = "8.1.0"
-  velero_plugin_for_aws_version               = "v1.11.1"
+  velero_helm_chart_version                   = "9.1.2"
+  velero_plugin_for_aws_version               = "v1.12.0"
   velero_excluded_namespace_scoped_resources  = ["secrets"]
-  velero_filesystem_backup_enabled            = true
+  velero_filesystem_backup_enabled            = false
 
   # --------------------------------------------------
   # Grafana Agent for Kubernetes monitoring


### PR DESCRIPTION
## Describe your changes

This pull request includes updates to version dependencies in configuration files, focusing on the Trunk CLI version and Helm chart versions for various services. These changes ensure the use of newer, more stable, or feature-rich versions.

### Version Updates:

* [`.trunk/trunk.yaml`](diffhunk://#diff-45a5a35dd7ad9a52d0fd3540f6c0d16a763575de51cc9a0a6c6f6a9f1da62ecdL5-R5): Updated the Trunk CLI version from `1.22.12` to `1.22.15` to incorporate the latest improvements or bug fixes.

* `test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl`:
  - Updated the Helm chart version for the Traefik blue variant from `34.4.0` to `35.2.0`.
  - Updated the Helm chart version for the Traefik green variant from `34.4.0` to `35.2.0`.
  - Updated the Atlantis chart version from `5.7.0` to `5.17.2`.
  - Updated the Velero Helm chart version from `8.1.0` to `9.1.2` and the Velero plugin for AWS version from `v1.11.1` to `v1.12.0`. Additionally, disabled the Velero filesystem backup by changing `velero_filesystem_backup_enabled` from `true` to `false`.

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
