### PR TITLE
Migrate deprecated managed_policy_arns to using aws_iam_role_policy_attachment

### DIFF
--- a/_sub/network/vpc-peering-requester/main.tf
+++ b/_sub/network/vpc-peering-requester/main.tf
@@ -272,10 +272,14 @@ data "aws_iam_policy_document" "ssm_trust" {
 }
 
 resource "aws_iam_role" "ssm_tunnel" {
-  name                = "ssm-tunnel${local.regional_postfix}"
-  assume_role_policy  = data.aws_iam_policy_document.ssm_trust.json
-  managed_policy_arns = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
-  tags                = var.tags
+  name               = "ssm-tunnel${local.regional_postfix}"
+  assume_role_policy = data.aws_iam_policy_document.ssm_trust.json
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "ssm" {
+  role       = aws_iam_role.ssm_tunnel.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
 resource "aws_iam_instance_profile" "ssm_tunnel" {

--- a/security/legacy-account-context/main.tf
+++ b/security/legacy-account-context/main.tf
@@ -138,15 +138,24 @@ locals {
 }
 
 resource "aws_iam_role" "backup" {
-  provider = aws.workload
-  count    = var.deploy_backup ? 1 : 0
-
+  provider           = aws.workload
+  count              = var.deploy_backup ? 1 : 0
   name               = "backup-role"
   assume_role_policy = data.aws_iam_policy_document.backup_trust.json
-  managed_policy_arns = [
-    "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup",
-    "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores"
-  ]
+}
+
+resource "aws_iam_role_policy_attachment" "backup" {
+  provider   = aws.workload
+  count      = var.deploy_backup ? 1 : 0
+  role       = aws_iam_role.backup[count.index].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
+}
+
+resource "aws_iam_role_policy_attachment" "restore" {
+  provider   = aws.workload
+  count      = var.deploy_backup ? 1 : 0
+  role       = aws_iam_role.backup[count.index].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores"
 }
 
 data "aws_iam_policy_document" "backup_trust" {

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -381,15 +381,24 @@ locals {
 }
 
 resource "aws_iam_role" "backup" {
-  provider = aws.workload
-  count    = var.deploy_backup ? 1 : 0
-
+  provider           = aws.workload
+  count              = var.deploy_backup ? 1 : 0
   name               = "backup-role"
   assume_role_policy = data.aws_iam_policy_document.backup_trust.json
-  managed_policy_arns = [
-    "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup",
-    "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores"
-  ]
+}
+
+resource "aws_iam_role_policy_attachment" "backup" {
+  provider   = aws.workload
+  count      = var.deploy_backup ? 1 : 0
+  role       = aws_iam_role.backup[count.index].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
+}
+
+resource "aws_iam_role_policy_attachment" "restore" {
+  provider   = aws.workload
+  count      = var.deploy_backup ? 1 : 0
+  role       = aws_iam_role.backup[count.index].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores"
 }
 
 data "aws_iam_policy_document" "backup_trust" {


### PR DESCRIPTION
## Describe your changes

This pull request refactors the way IAM policies are attached to IAM roles by replacing the `managed_policy_arns` property with explicit `aws_iam_role_policy_attachment` resources. This change improves modularity and clarity in the Terraform configuration.

### IAM Role Policy Attachment Refactor:

* [`_sub/network/vpc-peering-requester/main.tf`](diffhunk://#diff-102b9e9826581da57cda6e2b87f7c21b029eaac75b11e5e8414190104e07d554L277-R284): Replaced the `managed_policy_arns` property in the `aws_iam_role.ssm_tunnel` resource with a new `aws_iam_role_policy_attachment.ssm` resource to attach the `AmazonSSMManagedInstanceCore` policy.

* [`security/legacy-account-context/main.tf`](diffhunk://#diff-12809496af746334776e8375c9541251a01fed063a15dcc19490dc9633ebe209L143-R158): Removed the `managed_policy_arns` property from the `aws_iam_role.backup` resource and added two new `aws_iam_role_policy_attachment` resources (`backup` and `restore`) to attach the `AWSBackupServiceRolePolicyForBackup` and `AWSBackupServiceRolePolicyForRestores` policies, respectively.

* [`security/org-account-context/main.tf`](diffhunk://#diff-7b7c091a5ddacc1b6dbe68e60823ae348a8a271b036f0120b408e5ccd84b52dbL386-R401): Similar to the changes in the legacy account context, replaced the `managed_policy_arns` property in the `aws_iam_role.backup` resource with two new `aws_iam_role_policy_attachment` resources (`backup` and `restore`) for attaching the same backup and restore policies.

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
