### PR TITLE
Use only one sub module for setting alternate security contact details

### DIFF
--- a/_sub/security/hardened-account/main.tf
+++ b/_sub/security/hardened-account/main.tf
@@ -422,17 +422,6 @@ module "config_local_2" {
   }
 }
 
-resource "aws_account_alternate_contact" "security" {
-  count                  = var.harden ? 1 : 0
-  alternate_contact_type = "SECURITY"
-  name                   = var.security_contact_name
-  title                  = var.security_contact_title
-  email_address          = join("+${var.account_name}@", split("@", var.security_contact_email))
-  phone_number           = var.security_contact_phone_number
-
-  provider = aws.workload
-}
-
 # --------------------------------------------------
 # Default VPC flow logging
 # --------------------------------------------------

--- a/_sub/security/hardened-account/vars.tf
+++ b/_sub/security/hardened-account/vars.tf
@@ -36,22 +36,6 @@ variable "monitoring_slack_token" {
   default   = null
 }
 
-variable "security_contact_name" {
-  type = string
-}
-
-variable "security_contact_title" {
-  type = string
-}
-
-variable "security_contact_email" {
-  type = string
-}
-
-variable "security_contact_phone_number" {
-  type = string
-}
-
 variable "sso_support_permission_set_name" {
   type    = string
   default = null

--- a/security/legacy-account-context/main.tf
+++ b/security/legacy-account-context/main.tf
@@ -21,6 +21,23 @@ module "iam_account_alias" {
 }
 
 # --------------------------------------------------
+# AWS Account - Alternate contact
+# --------------------------------------------------
+
+module "alternate_contact_security" {
+  source = "../../_sub/security/alternate-contact"
+  count  = var.email_security != null ? 1 : 0
+
+  contact_type = "SECURITY"
+  email        = join("+${var.name}@", split("@", var.email_security))
+  phone_number = var.primary_phone_number
+
+  providers = {
+    aws = aws.workload
+  }
+}
+
+# --------------------------------------------------
 # Account hardening
 # --------------------------------------------------
 module "hardened-account" {
@@ -40,10 +57,6 @@ module "hardened-account" {
   monitoring_email                = var.hardened_monitoring_email
   monitoring_slack_channel        = var.hardened_monitoring_slack_channel
   monitoring_slack_token          = var.hardened_monitoring_slack_token
-  security_contact_name           = var.hardened_security_contact_name
-  security_contact_title          = var.hardened_security_contact_title
-  security_contact_email          = var.hardened_security_contact_email
-  security_contact_phone_number   = var.hardened_security_contact_phone_number
   sso_support_permission_set_name = var.sso_support_permission_set_name
   sso_support_group_name          = var.sso_support_group_name
 }

--- a/security/legacy-account-context/vars.tf
+++ b/security/legacy-account-context/vars.tf
@@ -56,6 +56,15 @@ variable "email" {
   type = string
 }
 
+variable "primary_phone_number" {
+  type = string
+}
+
+variable "email_security" {
+  type    = string
+  default = null
+}
+
 variable "parent_id" {
   type        = string
   description = "The ID of the parent AWS Organization OU."
@@ -105,22 +114,6 @@ variable "hardened_monitoring_slack_token" {
   type      = string
   sensitive = true
   default   = null
-}
-
-variable "hardened_security_contact_name" {
-  type = string
-}
-
-variable "hardened_security_contact_title" {
-  type = string
-}
-
-variable "hardened_security_contact_email" {
-  type = string
-}
-
-variable "hardened_security_contact_phone_number" {
-  type = string
 }
 
 variable "deploy_backup" {

--- a/security/org-account-assume/main.tf
+++ b/security/org-account-assume/main.tf
@@ -110,6 +110,23 @@ module "iam_role_certero" {
 }
 
 # --------------------------------------------------
+# AWS Account - Alternate contact
+# --------------------------------------------------
+
+module "alternate_contact_security" {
+  source = "../../_sub/security/alternate-contact"
+  count  = var.email_security != null ? 1 : 0
+
+  contact_type = "SECURITY"
+  email        = join("+${var.name}@", split("@", var.email_security))
+  phone_number = var.primary_phone_number
+
+  providers = {
+    aws = aws.workload
+  }
+}
+
+# --------------------------------------------------
 # Account hardening
 # --------------------------------------------------
 module "hardened-account" {
@@ -129,10 +146,6 @@ module "hardened-account" {
   monitoring_email                = var.hardened_monitoring_email
   monitoring_slack_channel        = var.hardened_monitoring_slack_channel
   monitoring_slack_token          = var.hardened_monitoring_slack_token
-  security_contact_name           = var.hardened_security_contact_name
-  security_contact_title          = var.hardened_security_contact_title
-  security_contact_email          = var.hardened_security_contact_email
-  security_contact_phone_number   = var.hardened_security_contact_phone_number
   enable_default_standards        = var.hardened_enable_default_standards
   sso_support_permission_set_name = var.sso_support_permission_set_name
   sso_support_group_name          = var.sso_support_group_name

--- a/security/org-account-assume/vars.tf
+++ b/security/org-account-assume/vars.tf
@@ -54,6 +54,15 @@ variable "email" {
   type = string
 }
 
+variable "primary_phone_number" {
+  type = string
+}
+
+variable "email_security" {
+  type    = string
+  default = null
+}
+
 variable "cloudtrail_local_s3_bucket" {
   type    = string
   default = ""
@@ -138,22 +147,6 @@ variable "hardened_monitoring_slack_token" {
   type      = string
   sensitive = true
   default   = null
-}
-
-variable "hardened_security_contact_name" {
-  type = string
-}
-
-variable "hardened_security_contact_title" {
-  type = string
-}
-
-variable "hardened_security_contact_email" {
-  type = string
-}
-
-variable "hardened_security_contact_phone_number" {
-  type = string
 }
 
 variable "hardened_enable_default_standards" {

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -348,10 +348,6 @@ module "hardened-account" {
   monitoring_email                = var.hardened_monitoring_email
   monitoring_slack_channel        = var.hardened_monitoring_slack_channel
   monitoring_slack_token          = var.hardened_monitoring_slack_token
-  security_contact_name           = var.hardened_security_contact_name
-  security_contact_title          = var.hardened_security_contact_title
-  security_contact_email          = var.hardened_security_contact_email
-  security_contact_phone_number   = var.hardened_security_contact_phone_number
   sso_support_permission_set_name = var.sso_support_permission_set_name
   sso_support_group_name          = var.sso_support_group_name
 }

--- a/security/org-account-context/vars.tf
+++ b/security/org-account-context/vars.tf
@@ -155,22 +155,6 @@ variable "hardened_monitoring_slack_token" {
   default   = null
 }
 
-variable "hardened_security_contact_name" {
-  type = string
-}
-
-variable "hardened_security_contact_title" {
-  type = string
-}
-
-variable "hardened_security_contact_email" {
-  type = string
-}
-
-variable "hardened_security_contact_phone_number" {
-  type = string
-}
-
 variable "primary_phone_number" {
   type = string
 }


### PR DESCRIPTION
## Describe your changes

BREAKING CHANGE:

These four variables are deprecated:
- hardened_security_contact_name
- hardened_security_contact_title
- hardened_security_contact_email
- hardened_security_contact_phone_number

Instead use:
- email_security
- primary_phone_number

These two are existing variables that are already used by the `alternate-contact` sub module.

This pull request refactors how AWS account alternate contact information is managed by removing redundant variables and resources from the `hardened-account` module and introducing a new reusable `alternate-contact` module. The changes aim to simplify the codebase and improve maintainability by centralizing the alternate contact logic.

### Refactoring of AWS account alternate contact management:

* Removed the `aws_account_alternate_contact` resource and associated variables (`security_contact_name`, `security_contact_title`, `security_contact_email`, and `security_contact_phone_number`) from the `hardened-account` module in `_sub/security/hardened-account/main.tf` and `_sub/security/hardened-account/vars.tf`. These variables are no longer needed as the alternate contact logic has been modularized. [[1]](diffhunk://#diff-b69fe7fdcb4985492eb3f79db2c2c0c869269ad6b0f9cbfedb343bd673b50ab7L425-L435) [[2]](diffhunk://#diff-6ca6c1f43bbe7a9826bf2dfcec00c67793abd315f46f05a5b233e02109d60ff8L39-L54)

* Added a new `alternate-contact` module to manage alternate contact details. This module is now used in the `legacy-account-context` and `org-account-assume` contexts to handle security contact information. [[1]](diffhunk://#diff-12809496af746334776e8375c9541251a01fed063a15dcc19490dc9633ebe209R23-R39) [[2]](diffhunk://#diff-e21a8d7fb5e4bcb409fc007cf445d3b7981b1cdc9a8ffad4c004e05cf3f6230bR112-R128)

### Updates to `legacy-account-context`:

* Removed alternate contact variables (`hardened_security_contact_*`) from `vars.tf` and updated the `hardened-account` module to no longer pass these variables. Instead, the new `alternate-contact` module is used. [[1]](diffhunk://#diff-12809496af746334776e8375c9541251a01fed063a15dcc19490dc9633ebe209L43-L46) [[2]](diffhunk://#diff-881d90d79074d856bd1a23c8db819412994eddcba0fbe1ed28d510cacabe7cbdL110-L125)

* Added new variables (`primary_phone_number` and `email_security`) to support the `alternate-contact` module.

### Updates to `org-account-assume`:

* Similarly, removed alternate contact variables (`hardened_security_contact_*`) from `vars.tf` and updated the `hardened-account` module. The `alternate-contact` module is now used for security contact management. [[1]](diffhunk://#diff-e21a8d7fb5e4bcb409fc007cf445d3b7981b1cdc9a8ffad4c004e05cf3f6230bL132-L135) [[2]](diffhunk://#diff-45faabede4b7ec664cd2f3a10cd103ede0b581d49792fc4d4b0be628ec5c60dbL143-L158)

* Added new variables (`primary_phone_number` and `email_security`) to support the `alternate-contact` module.

### Updates to `org-account-context`:

* Removed alternate contact variables (`hardened_security_contact_*`) from `vars.tf` and updated the `hardened-account` module to align with the new approach. [[1]](diffhunk://#diff-7b7c091a5ddacc1b6dbe68e60823ae348a8a271b036f0120b408e5ccd84b52dbL351-L354) [[2]](diffhunk://#diff-b58b1b3e6ff71b800ae44c9180a674ea4f9e43d461d834f99af7fa6c56588f1aL158-L173)

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
