### PR TITLE
Update apiVersion for External Secrets Operator

### DIFF
--- a/_sub/compute/atlantis/values/kubeconfigs.yaml
+++ b/_sub/compute/atlantis/values/kubeconfigs.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: kubeconfigs

--- a/_sub/security/helm-1password-connect/dependencies.tf
+++ b/_sub/security/helm-1password-connect/dependencies.tf
@@ -73,7 +73,7 @@ metadata:
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::${var.workload_account_id}:role/${var.deploy_name}-irsa
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: 1password-connect-ssm


### PR DESCRIPTION
## Describe your changes

BREAKING CHANGE: 
Requires External Secrets Operator to use external-secrets.io/v1 instead of external-secrets.io/v1beta1 in your Flux manifest repository too.

This pull request updates the `apiVersion` for resources using the `external-secrets.io` API to align with the latest version. The changes ensure compatibility with the updated API version.

### Updates to `apiVersion` for `external-secrets.io`:

* [`_sub/compute/atlantis/values/kubeconfigs.yaml`](diffhunk://#diff-fd803327123245972f08521bcacddc77607940902eedc0936c973ce22793852fL1-R1): Updated the `apiVersion` for the `ExternalSecret` resource from `v1beta1` to `v1`.
* [`_sub/security/helm-1password-connect/dependencies.tf`](diffhunk://#diff-09ae9456db86c758d054f434dbbe9976fc109be9626a3f52dac006dc9e984beeL76-R76): Updated the `apiVersion` for the `SecretStore` resource from `v1beta1` to `v1`.

## Checklist before requesting a review
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
