### PR TITLE
Add modules for handling customer managed keys in KMS that can be used by multiple principals

### DIFF
--- a/_sub/security/kms-key/main.tf
+++ b/_sub/security/kms-key/main.tf
@@ -1,0 +1,80 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  key_admin_arns = concat(["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"], var.key_admin_arns)
+}
+
+# trunk-ignore(checkov/CKV_AWS_109)
+# trunk-ignore(checkov/CKV_AWS_111)
+# trunk-ignore(checkov/CKV_AWS_356)
+data "aws_iam_policy_document" "this" {
+  statement {
+    sid       = "Enable IAM User Permissions"
+    effect    = "Allow"
+    actions   = ["kms:*"]
+    resources = ["*"]
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+  }
+  statement {
+    sid    = "Allow key administration"
+    effect = "Allow"
+    actions = [
+      "kms:ReplicateKey",
+      "kms:Create*",
+      "kms:Describe*",
+      "kms:Enable*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Update*",
+      "kms:Revoke*",
+      "kms:Disable*",
+      "kms:Get*",
+      "kms:Delete*",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion"
+    ]
+    resources = ["*"]
+    principals {
+      type        = "AWS"
+      identifiers = local.key_admin_arns
+    }
+  }
+  statement {
+    sid    = "Allow key usage"
+    effect = "Allow"
+    actions = [
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey",
+      "kms:GenerateDataKeyWithoutPlaintext"
+    ]
+    resources = ["*"]
+    dynamic "principals" {
+      for_each = var.key_user_arns
+      content {
+        type        = "AWS"
+        identifiers = [principals.value]
+      }
+    }
+  }
+}
+
+resource "aws_kms_key" "this" {
+  description             = var.description
+  key_usage               = var.key_usage
+  enable_key_rotation     = var.enable_key_rotation
+  rotation_period_in_days = var.rotation_period_in_days
+  deletion_window_in_days = var.deletion_window_in_days
+  policy                  = data.aws_iam_policy_document.this.json
+  tags                    = var.tags
+}
+
+resource "aws_kms_alias" "this" {
+  name          = var.key_alias
+  target_key_id = aws_kms_key.this.key_id
+}

--- a/_sub/security/kms-key/outputs.tf
+++ b/_sub/security/kms-key/outputs.tf
@@ -1,0 +1,11 @@
+output "arn" {
+  value = aws_kms_key.this.arn
+}
+
+output "key_id" {
+  value = aws_kms_key.this.key_id
+}
+
+output "alias" {
+  value = aws_kms_alias.this.name
+}

--- a/_sub/security/kms-key/vars.tf
+++ b/_sub/security/kms-key/vars.tf
@@ -1,0 +1,56 @@
+variable "description" {
+  description = "The description of the KMS key."
+  type        = string
+  default     = "Customer managed key"
+}
+
+variable "key_alias" {
+  description = "The alias for the KMS key."
+  type        = string
+  validation {
+    condition     = can(regex("^alias/[a-zA-Z0-9/_-]+$", var.key_alias))
+    error_message = "The key alias must start with 'alias/' and contain only alphanumeric characters, underscores, and hyphens."
+  }
+}
+
+variable "key_admin_arns" {
+  description = "The administrator of the KMS key."
+  type        = list(string)
+  default     = []
+}
+
+variable "key_user_arns" {
+  description = "The users of the KMS key."
+  type        = list(string)
+  default     = []
+}
+
+variable "key_usage" {
+  description = "The key usage for the KMS key."
+  type        = string
+  default     = "ENCRYPT_DECRYPT"
+}
+
+variable "enable_key_rotation" {
+  description = "Whether to enable key rotation for the KMS key."
+  type        = bool
+  default     = true
+}
+
+variable "rotation_period_in_days" {
+  description = "The rotation period in days for the KMS key."
+  type        = number
+  default     = 90
+}
+
+variable "deletion_window_in_days" {
+  description = "The number of days before the KMS key can be deleted."
+  type        = number
+  default     = 30
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the resources."
+  type        = map(string)
+  default     = {}
+}

--- a/_sub/security/kms-key/versions.tf
+++ b/_sub/security/kms-key/versions.tf
@@ -1,0 +1,10 @@
+
+terraform {
+  required_version = ">= 1.3.0, < 1.6.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.98.0"
+    }
+  }
+}

--- a/_sub/security/kms-key/versions.tofu
+++ b/_sub/security/kms-key/versions.tofu
@@ -1,0 +1,10 @@
+
+terraform {
+  required_version = ">= 1.8.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.98.0"
+    }
+  }
+}

--- a/security/shared-symmetric-key/main.tf
+++ b/security/shared-symmetric-key/main.tf
@@ -1,0 +1,7 @@
+module "shared_symmetric_key" {
+  source        = "../../_sub/security/kms-key"
+  key_alias     = var.key_alias
+  description   = "Shared symmetric key for encrypting data at rest"
+  key_user_arns = var.key_user_arns
+  tags          = var.tags
+}

--- a/security/shared-symmetric-key/outputs.tf
+++ b/security/shared-symmetric-key/outputs.tf
@@ -1,0 +1,11 @@
+output "arn" {
+  value = module.shared_symmetric_key.arn
+}
+
+output "id" {
+  value = module.shared_symmetric_key.key_id
+}
+
+output "alias" {
+  value = module.shared_symmetric_key.alias
+}

--- a/security/shared-symmetric-key/providers.tf
+++ b/security/shared-symmetric-key/providers.tf
@@ -1,0 +1,16 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = var.tags
+  }
+
+  assume_role {
+    role_arn = var.aws_assume_role_arn
+  }
+}

--- a/security/shared-symmetric-key/vars.tf
+++ b/security/shared-symmetric-key/vars.tf
@@ -1,0 +1,28 @@
+variable "aws_region" {
+  type = string
+}
+
+variable "aws_assume_role_arn" {
+  type = string
+}
+
+variable "key_alias" {
+  description = "The alias for the KMS key."
+  type        = string
+  validation {
+    condition     = can(regex("^alias/[a-zA-Z0-9/_-]+$", var.key_alias))
+    error_message = "The key alias must start with 'alias/' and contain only alphanumeric characters, underscores, and hyphens."
+  }
+}
+
+variable "key_user_arns" {
+  description = "The users of the KMS key."
+  type        = list(string)
+  default     = []
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "A map of tags to apply to all the resources deployed by the module"
+  default     = {}
+}

--- a/security/shared-symmetric-key/versions.tf
+++ b/security/shared-symmetric-key/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0, < 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.98.0"
+    }
+  }
+}

--- a/security/shared-symmetric-key/versions.tofu
+++ b/security/shared-symmetric-key/versions.tofu
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.8.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.98.0"
+    }
+  }
+}


### PR DESCRIPTION
## Describe your changes

This pull request introduces a reusable Terraform module for managing AWS KMS keys and integrates it into a `shared-symmetric-key` module for encrypting data at rest. Key changes include defining the KMS key module, configuring its variables, outputs, and dependencies, and setting up the `shared-symmetric-key` module to use it.

### KMS Key Module Implementation:
* [`_sub/security/kms-key/main.tf`](diffhunk://#diff-c89687942573f9349376ec5e4fe54b19d432577a8b85e584b8bfe87ca0c041f3R1-R80): Added a Terraform configuration to create a KMS key and alias, with a policy allowing administration and usage based on provided ARNs.
* [`_sub/security/kms-key/vars.tf`](diffhunk://#diff-a1943559a44971da74f95caaff3cfab2c6cc40d358cf826d3cb86ac0a9def5a7R1-R56): Defined variables for configuring the KMS key, including description, alias, usage, rotation settings, and tags.
* [`_sub/security/kms-key/outputs.tf`](diffhunk://#diff-92343c514de62d3e3729b2e05073ec2b7c7f22603ae8d4093b14da65a078d6d6R1-R11): Added outputs for the KMS key ARN, key ID, and alias.
* `_sub/security/kms-key/versions.tf` and `_sub/security/kms-key/versions.tofu`: Specified Terraform and AWS provider version constraints. [[1]](diffhunk://#diff-a6befe9396d286ac29d871715fcb8144e0c2b30a623c6d8ca2a017e3c8c830b0R1-R10) [[2]](diffhunk://#diff-31ca37221550c04d69b63d4ec69355bff72f6ea9057f3d6cb9f831b695bb2169R1-R10)

### Shared Symmetric Key Module Integration:
* [`security/shared-symmetric-key/main.tf`](diffhunk://#diff-4a5957e67ab61f19ef39e81b932ab900071512f27b0b33ebb358dc5d607ec8faR1-R7): Integrated the KMS key module to create a shared symmetric key for encrypting data at rest.
* [`security/shared-symmetric-key/vars.tf`](diffhunk://#diff-347aef00aab9df441fc7aae478560d3b503bc63837d2f0e30a65bc9f8d653a42R1-R28): Defined variables for AWS region, assume role ARN, key alias, user ARNs, and resource tags.
* [`security/shared-symmetric-key/outputs.tf`](diffhunk://#diff-a32207cc3da85a435236b07072b325325bb7ccec1cbd9c7379954a333caf21e3R1-R11): Added outputs for the shared symmetric key's ARN, key ID, and alias.
* [`security/shared-symmetric-key/providers.tf`](diffhunk://#diff-d156c631e10858547b0cafd0de01f58f9e18f08209f76a9f2029f5568e81c484R1-R16): Configured the AWS provider with region, tags, and assume role settings.
* `security/shared-symmetric-key/versions.tf` and `security/shared-symmetric-key/versions.tofu`: Specified Terraform and AWS provider version constraints. [[1]](diffhunk://#diff-18466af0faa1d45bf63f0fab9f818f185cee1ed7493682f8724210bbe9efe591R1-R10) [[2]](diffhunk://#diff-d6e5bbf58349eebed70ef6fb94fd9d1c090ac80b515778cd6db0049d637ad8e8R1-R10)

## Checklist before requesting a review
- [x] I have tested changes locally towards our staging accounts
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
