### PR TITLE
Add multi-region support for shared KMS key

### DIFF
--- a/_sub/security/kms-key/main.tf
+++ b/_sub/security/kms-key/main.tf
@@ -68,13 +68,31 @@ resource "aws_kms_key" "this" {
   description             = var.description
   key_usage               = var.key_usage
   enable_key_rotation     = var.enable_key_rotation
+  multi_region            = var.multi_region
   rotation_period_in_days = var.rotation_period_in_days
   deletion_window_in_days = var.deletion_window_in_days
   policy                  = data.aws_iam_policy_document.this.json
   tags                    = var.tags
+  provider                = aws.workload
 }
 
 resource "aws_kms_alias" "this" {
   name          = var.key_alias
   target_key_id = aws_kms_key.this.key_id
+  provider      = aws.workload
+}
+
+resource "aws_kms_replica_key" "this" {
+  count                   = var.multi_region ? 1 : 0
+  description             = var.description
+  deletion_window_in_days = var.deletion_window_in_days
+  primary_key_arn         = aws_kms_key.this.arn
+  provider                = aws.workload_2
+}
+
+resource "aws_kms_alias" "replica" {
+  count         = var.multi_region ? 1 : 0
+  name          = var.key_alias
+  target_key_id = aws_kms_replica_key.this[count.index].key_id
+  provider      = aws.workload_2
 }

--- a/_sub/security/kms-key/outputs.tf
+++ b/_sub/security/kms-key/outputs.tf
@@ -9,3 +9,7 @@ output "key_id" {
 output "alias" {
   value = aws_kms_alias.this.name
 }
+
+output "replica_arn" {
+  value = try(aws_kms_replica_key.this[0].arn, "No replica key created")
+}

--- a/_sub/security/kms-key/vars.tf
+++ b/_sub/security/kms-key/vars.tf
@@ -31,6 +31,12 @@ variable "key_usage" {
   default     = "ENCRYPT_DECRYPT"
 }
 
+variable "multi_region" {
+  description = "Whether the KMS key is multi-region."
+  type        = bool
+  default     = false
+}
+
 variable "enable_key_rotation" {
   description = "Whether to enable key rotation for the KMS key."
   type        = bool

--- a/security/shared-symmetric-key/main.tf
+++ b/security/shared-symmetric-key/main.tf
@@ -3,5 +3,10 @@ module "shared_symmetric_key" {
   key_alias     = var.key_alias
   description   = "Shared symmetric key for encrypting data at rest"
   key_user_arns = var.key_user_arns
+  multi_region  = true
   tags          = var.tags
+  providers = {
+    aws.workload   = aws.workload
+    aws.workload_2 = aws.workload_2
+  }
 }

--- a/security/shared-symmetric-key/outputs.tf
+++ b/security/shared-symmetric-key/outputs.tf
@@ -9,3 +9,7 @@ output "id" {
 output "alias" {
   value = module.shared_symmetric_key.alias
 }
+
+output "replica_arn" {
+  value = module.shared_symmetric_key.replica_arn
+}

--- a/security/shared-symmetric-key/providers.tf
+++ b/security/shared-symmetric-key/providers.tf
@@ -14,3 +14,31 @@ provider "aws" {
     role_arn = var.aws_assume_role_arn
   }
 }
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = var.tags
+  }
+
+  assume_role {
+    role_arn = var.aws_assume_role_arn
+  }
+
+  alias = "workload"
+}
+
+provider "aws" {
+  region = var.aws_region_2
+
+  default_tags {
+    tags = var.tags
+  }
+
+  assume_role {
+    role_arn = var.aws_assume_role_arn
+  }
+
+  alias = "workload_2"
+}

--- a/security/shared-symmetric-key/vars.tf
+++ b/security/shared-symmetric-key/vars.tf
@@ -2,6 +2,10 @@ variable "aws_region" {
   type = string
 }
 
+variable "aws_region_2" {
+  type = string
+}
+
 variable "aws_assume_role_arn" {
   type = string
 }


### PR DESCRIPTION
## Describe your changes

This pull request introduces support for multi-region AWS KMS keys, enabling the creation of replica keys in a secondary region. It also updates the module configurations and outputs to accommodate this feature. The most important changes are grouped below by theme.

### Multi-region KMS Key Support

* Added a new `multi_region` variable to control whether a KMS key should be multi-region. When enabled, a replica key is created in the secondary region (`_sub/security/kms-key/main.tf`, `_sub/security/kms-key/vars.tf`, [[1]](diffhunk://#diff-c89687942573f9349376ec5e4fe54b19d432577a8b85e584b8bfe87ca0c041f3R71-R97) [[2]](diffhunk://#diff-a1943559a44971da74f95caaff3cfab2c6cc40d358cf826d3cb86ac0a9def5a7R34-R39).
* Introduced a new `aws_kms_replica_key` resource to create the replica key, along with an alias for the replica (`_sub/security/kms-key/main.tf`, [_sub/security/kms-key/main.tfR71-R97](diffhunk://#diff-c89687942573f9349376ec5e4fe54b19d432577a8b85e584b8bfe87ca0c041f3R71-R97)).

### Module Enhancements

* Updated the `shared_symmetric_key` module to support multi-region keys by passing the `multi_region` variable and configuring providers for both primary and secondary regions (`security/shared-symmetric-key/main.tf`, `security/shared-symmetric-key/providers.tf`, [[1]](diffhunk://#diff-4a5957e67ab61f19ef39e81b932ab900071512f27b0b33ebb358dc5d607ec8faR6-R11) [[2]](diffhunk://#diff-d156c631e10858547b0cafd0de01f58f9e18f08209f76a9f2029f5568e81c484R17-R44).
* Added a new `aws_region_2` variable to specify the secondary region for the replica key (`security/shared-symmetric-key/vars.tf`, [security/shared-symmetric-key/vars.tfR5-R8](diffhunk://#diff-347aef00aab9df441fc7aae478560d3b503bc63837d2f0e30a65bc9f8d653a42R5-R8)).

### Output Updates

* Added a new `replica_arn` output in both the KMS key and shared symmetric key modules to expose the ARN of the replica key, if created (`_sub/security/kms-key/outputs.tf`, `security/shared-symmetric-key/outputs.tf`, [[1]](diffhunk://#diff-92343c514de62d3e3729b2e05073ec2b7c7f22603ae8d4093b14da65a078d6d6R12-R15) [[2]](diffhunk://#diff-a32207cc3da85a435236b07072b325325bb7ccec1cbd9c7379954a333caf21e3R12-R15).

## Checklist before requesting a review
- [x] I have tested changeslocally towards staging-security account
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
