### PR TITLE
Add missing policy to KMS replica keys

### DIFF
--- a/_sub/security/kms-key/main.tf
+++ b/_sub/security/kms-key/main.tf
@@ -86,6 +86,7 @@ resource "aws_kms_replica_key" "this" {
   count                   = var.multi_region ? 1 : 0
   description             = var.description
   deletion_window_in_days = var.deletion_window_in_days
+  policy                  = data.aws_iam_policy_document.this.json
   primary_key_arn         = aws_kms_key.this.arn
   provider                = aws.workload_2
 }


### PR DESCRIPTION
## Describe your changes

This pull request introduces a small but important update to the `aws_kms_replica_key` resource in the `_sub/security/kms-key/main.tf` file. The change ensures that the KMS replica key now uses a specific IAM policy document for its `policy` attribute.

* [`_sub/security/kms-key/main.tf`](diffhunk://#diff-c89687942573f9349376ec5e4fe54b19d432577a8b85e584b8bfe87ca0c041f3R89): Added the `policy` attribute to the `aws_kms_replica_key` resource, assigning it the JSON output of the `data.aws_iam_policy_document.this` data source.

## Checklist before requesting a review
- [x] I have tested changes locally.
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
