### PR TITLE
Add support for (optionally) specifying a KMS key as default encryption key for EBS volumns in hardened accounts.

### DIFF
--- a/_sub/security/hardened-account/main.tf
+++ b/_sub/security/hardened-account/main.tf
@@ -474,6 +474,18 @@ resource "aws_ebs_encryption_by_default" "default_2" {
   provider = aws.workload_2
 }
 
+resource "aws_ebs_default_kms_key" "default" {
+  count    = var.harden && var.kms_primary_key_arn != null ? 1 : 0
+  key_arn  = var.kms_primary_key_arn
+  provider = aws.workload
+}
+
+resource "aws_ebs_default_kms_key" "default_2" {
+  count    = var.harden && var.kms_replica_key_arn != null ? 1 : 0
+  key_arn  = var.kms_replica_key_arn
+  provider = aws.workload_2
+}
+
 # --------------------------------------------------
 # Password policy
 # --------------------------------------------------

--- a/_sub/security/hardened-account/vars.tf
+++ b/_sub/security/hardened-account/vars.tf
@@ -50,3 +50,13 @@ variable "enable_default_standards" {
   type    = bool
   default = false
 }
+
+variable "kms_primary_key_arn" {
+  type    = string
+  default = null
+}
+
+variable "kms_replica_key_arn" {
+  type    = string
+  default = null
+}

--- a/security/legacy-account-context/main.tf
+++ b/security/legacy-account-context/main.tf
@@ -59,6 +59,8 @@ module "hardened-account" {
   monitoring_slack_token          = var.hardened_monitoring_slack_token
   sso_support_permission_set_name = var.sso_support_permission_set_name
   sso_support_group_name          = var.sso_support_group_name
+  kms_primary_key_arn             = var.hardened_kms_primary_key_arn
+  kms_replica_key_arn             = var.hardened_kms_replica_key_arn
 }
 
 # --------------------------------------------------

--- a/security/legacy-account-context/vars.tf
+++ b/security/legacy-account-context/vars.tf
@@ -116,6 +116,16 @@ variable "hardened_monitoring_slack_token" {
   default   = null
 }
 
+variable "hardened_kms_primary_key_arn" {
+  type    = string
+  default = null
+}
+
+variable "hardened_kms_replica_key_arn" {
+  type    = string
+  default = null
+}
+
 variable "deploy_backup" {
   type        = bool
   description = "Whether to deploy AWS Backup"

--- a/security/org-account-assume/main.tf
+++ b/security/org-account-assume/main.tf
@@ -149,6 +149,8 @@ module "hardened-account" {
   enable_default_standards        = var.hardened_enable_default_standards
   sso_support_permission_set_name = var.sso_support_permission_set_name
   sso_support_group_name          = var.sso_support_group_name
+  kms_primary_key_arn             = var.hardened_kms_primary_key_arn
+  kms_replica_key_arn             = var.hardened_kms_replica_key_arn
 
   depends_on = [
     module.iam_identity_center_assignment,

--- a/security/org-account-assume/vars.tf
+++ b/security/org-account-assume/vars.tf
@@ -154,6 +154,16 @@ variable "hardened_enable_default_standards" {
   default = false
 }
 
+variable "hardened_kms_primary_key_arn" {
+  type    = string
+  default = null
+}
+
+variable "hardened_kms_replica_key_arn" {
+  type    = string
+  default = null
+}
+
 variable "tags" {
   type        = map(string)
   description = "A map of tags to apply to all the resources deployed by the module"

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -350,6 +350,8 @@ module "hardened-account" {
   monitoring_slack_token          = var.hardened_monitoring_slack_token
   sso_support_permission_set_name = var.sso_support_permission_set_name
   sso_support_group_name          = var.sso_support_group_name
+  kms_primary_key_arn             = var.hardened_kms_primary_key_arn
+  kms_replica_key_arn             = var.hardened_kms_replica_key_arn
 }
 
 # --------------------------------------------------

--- a/security/org-account-context/vars.tf
+++ b/security/org-account-context/vars.tf
@@ -155,6 +155,16 @@ variable "hardened_monitoring_slack_token" {
   default   = null
 }
 
+variable "hardened_kms_primary_key_arn" {
+  type    = string
+  default = null
+}
+
+variable "hardened_kms_replica_key_arn" {
+  type    = string
+  default = null
+}
+
 variable "primary_phone_number" {
   type = string
 }


### PR DESCRIPTION
This pull request introduces support for specifying default KMS keys for EBS encryption in multiple AWS account contexts. It adds new variables for primary and replica KMS key ARNs and updates the relevant modules to utilize these variables. Below is a breakdown of the most important changes:

### Support for Default KMS Keys in EBS Encryption

* **New resources for default KMS keys**: Added `aws_ebs_default_kms_key` resources to enable default KMS key usage for EBS encryption in the hardened account module (`_sub/security/hardened-account/main.tf`). These resources are conditionally created based on the `harden` variable and the presence of KMS key ARNs.

### Variable Additions for KMS Key ARNs

* **Hardened account variables**: Introduced `kms_primary_key_arn` and `kms_replica_key_arn` variables in the hardened account module to allow specifying default KMS keys (`_sub/security/hardened-account/vars.tf`).

* **Legacy account variables**: Added `hardened_kms_primary_key_arn` and `hardened_kms_replica_key_arn` variables to the legacy account context module (`security/legacy-account-context/vars.tf`). These variables are passed down to the hardened account module.

* **Org account variables**: Added `hardened_kms_primary_key_arn` and `hardened_kms_replica_key_arn` variables to the org account context module (`security/org-account-context/vars.tf`) and org account assume module (`security/org-account-assume/vars.tf`). These variables are also passed to the hardened account module. [[1]](diffhunk://#diff-b58b1b3e6ff71b800ae44c9180a674ea4f9e43d461d834f99af7fa6c56588f1aR158-R167) [[2]](diffhunk://#diff-45faabede4b7ec664cd2f3a10cd103ede0b581d49792fc4d4b0be628ec5c60dbR157-R166)

### Module Updates to Pass KMS Key ARNs

* **Legacy account context**: Updated the `hardened-account` module block to pass the new KMS key ARN variables (`security/legacy-account-context/main.tf`).

* **Org account context and assume modules**: Updated the `hardened-account` module blocks in both the org account context and assume modules to pass the KMS key ARN variables (`security/org-account-context/main.tf`, `security/org-account-assume/main.tf`). [[1]](diffhunk://#diff-7b7c091a5ddacc1b6dbe68e60823ae348a8a271b036f0120b408e5ccd84b52dbR353-R354) [[2]](diffhunk://#diff-e21a8d7fb5e4bcb409fc007cf445d3b7981b1cdc9a8ffad4c004e05cf3f6230bR152-R153)