### PR TITLE
DO NOT MERGE: Configure CredentialProviderConfig to allow for authenticating to Docker Hub

### DIFF
--- a/_sub/compute/eks-nodegroup-managed/main.tf
+++ b/_sub/compute/eks-nodegroup-managed/main.tf
@@ -17,7 +17,8 @@ resource "aws_launch_template" "eks" {
     cpu : var.cpu,
     memory : var.memory,
     docker_hub_username : var.docker_hub_username,
-    docker_hub_password : var.docker_hub_password
+    docker_hub_password : var.docker_hub_password,
+    essentials_url : var.essentials_url,
   }))
   key_name               = var.ec2_ssh_key
   update_default_version = true

--- a/_sub/compute/eks-nodegroup-managed/user-data.sh.tftpl
+++ b/_sub/compute/eks-nodegroup-managed/user-data.sh.tftpl
@@ -10,8 +10,46 @@ set -o xtrace
 echo fs.inotify.max_user_watches=${worker_inotify_max_user_watches} | sudo tee -a /etc/sysctl.conf
 sudo sysctl -p
 
-%{ if docker_hub_password != "" && docker_hub_username != "" ~}
-echo ${docker_hub_password} | nerdctl login --username ${docker_hub_username} --password-stdin
+%{ if docker_hub_password != "" && docker_hub_username != "" && essentials_url != "" ~}
+cd /tmp
+wget -O static-credential-provider.tar.gz ${essentials_url}/static-credential-provider_0.1.5_linux_amd64.tar.gz
+sudo tar xzf static-credential-provider.tar.gz -C /etc/eks/image-credential-provider/
+rm static-credential-provider.tar.gz
+sudo cat >/etc/eks/image-credential-provider/dfds-config.json <<EOL
+{
+  "apiVersion": "kubelet.config.k8s.io/v1",
+  "kind": "CredentialProviderConfig",
+  "providers": [
+    {
+      "name": "ecr-credential-provider",
+      "matchImages": [
+        "*.dkr.ecr.*.amazonaws.com",
+        "*.dkr-ecr.*.on.aws",
+        "*.dkr.ecr.*.amazonaws.com.cn",
+        "*.dkr-ecr.*.on.amazonwebservices.com.cn",
+        "*.dkr.ecr-fips.*.amazonaws.com",
+        "*.dkr-ecr-fips.*.on.aws",
+        "*.dkr.ecr.*.c2s.ic.gov",
+        "*.dkr.ecr.*.sc2s.sgov.gov",
+        "*.dkr.ecr.*.cloud.adc-e.uk",
+        "*.dkr.ecr.*.csp.hci.ic.gov"
+      ],
+      "defaultCacheDuration": "12h",
+      "apiVersion": "credentialprovider.kubelet.k8s.io/v1"
+    },
+    {
+      "name": "static-credential-provider",
+      "matchImages": ["docker.io", "*.docker.io"],
+      "defaultCacheDuration": "12h",
+      "apiVersion": "credentialprovider.kubelet.k8s.io/v1",
+      "env": [
+        {"name": "KSCP_REGISTRY_USERNAME", "value": "${docker_hub_username}"},
+        {"name": "KSCP_REGISTRY_PASSWORD", "value": "${docker_hub_password}"}
+      ]
+    }
+  ]
+}
+EOL
 %{ endif ~}
 
 --BOUNDARY
@@ -27,6 +65,9 @@ spec:
         certificateAuthority: ${eks_certificate_authority}
         cidr: ${cidr}
     kubelet:
+        flags:
+          - "--image-credential-provider-bin-dir=/etc/eks/image-credential-provider/"
+          - "--image-credential-provider-config=/etc/eks/image-credential-provider/dfds-config.json"
         config:
 %{ if vpc_cni_prefix_delegation_enabled }
             maxPods: ${max_pods}

--- a/_sub/compute/eks-nodegroup-managed/user-data.sh.tftpl
+++ b/_sub/compute/eks-nodegroup-managed/user-data.sh.tftpl
@@ -67,7 +67,9 @@ spec:
     kubelet:
         flags:
           - "--image-credential-provider-bin-dir=/etc/eks/image-credential-provider/"
+%{ if docker_hub_password != "" && docker_hub_username != "" && essentials_url != "" ~}
           - "--image-credential-provider-config=/etc/eks/image-credential-provider/dfds-config.json"
+%{ endif ~}
         config:
 %{ if vpc_cni_prefix_delegation_enabled }
             maxPods: ${max_pods}

--- a/_sub/compute/eks-nodegroup-managed/vars.tf
+++ b/_sub/compute/eks-nodegroup-managed/vars.tf
@@ -107,6 +107,12 @@ variable "docker_hub_password" {
   default     = ""
 }
 
+variable "essentials_url" {
+  type = string
+  description = "HTTP server that provides essentials"
+  default = ""
+}
+
 # ------------------------------------------------------
 # Inactivity based scale down for sandboxes
 # ------------------------------------------------------

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -200,6 +200,7 @@ module "eks_managed_workers_node_group" {
   # Docker Hub credentials
   docker_hub_username = var.docker_hub_username
   docker_hub_password = var.docker_hub_password
+  essentials_url = var.essentials_url
 
   depends_on = [module.eks_cluster]
 }

--- a/compute/eks-ec2/vars.tf
+++ b/compute/eks-ec2/vars.tf
@@ -253,6 +253,12 @@ variable "docker_hub_password" {
   default     = ""
 }
 
+variable "essentials_url" {
+  type = string
+  description = "HTTP server that provides essentials"
+  default = ""
+}
+
 # --------------------------------------------------
 # NAT Gateway
 # --------------------------------------------------


### PR DESCRIPTION
Override the default CredentialProviderConfig configuration to include Docker Hub access.

It makes use of https://github.com/hegerdes/kubelet-static-credential-provider. Since it's being put directly on the worker nodes I preferred to keep a copy of the release in our own S3 bucket for a few reasons:
- In case they go rogue and change the release content on us
- In case it disappears and it breaks deployment of new nodes


Tested in my sandbox but would be lovely if other people would also give it a try.

**This PR** is necessary before deploying it: https://github.com/dfds/eks-pipeline/pull/1645/files

# DO NOT MERGE UNLESS YOU ARE PREPARED TO DO A NODE ROLLOVER 