### PR TITLE
allow additional permissions on EBS related kms for Terraform can handle resource lifecycle

### DIFF
--- a/_sub/security/kms-key/main.tf
+++ b/_sub/security/kms-key/main.tf
@@ -52,7 +52,9 @@ data "aws_iam_policy_document" "this" {
       "kms:ReEncrypt*",
       "kms:GenerateDataKey",
       "kms:GenerateDataKeyWithoutPlaintext",
-      "kms:CreateGrant"
+      "kms:CreateGrant",
+      "kms:ListGrants",
+      "kms:RevokeGrant"
     ]
     resources = ["*"]
     dynamic "principals" {


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
This pull request updates the permissions in the IAM policy document for the KMS key to include additional grant-related actions. The changes ensure more comprehensive management capabilities for KMS grants.

IAM Policy Updates:

* [`_sub/security/kms-key/main.tf`](diffhunk://#diff-c89687942573f9349376ec5e4fe54b19d432577a8b85e584b8bfe87ca0c041f3L55-R57): Added `kms:ListGrants` and `kms:RevokeGrant` actions to the IAM policy document, alongside the existing `kms:CreateGrant` action, to enhance grant management capabilities.
## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
