### PR TITLE
fix: encode IAM role assume policy and policy for subnet-exporter

### DIFF
--- a/_sub/compute/k8s-subnet-exporter/main.tf
+++ b/_sub/compute/k8s-subnet-exporter/main.tf
@@ -2,14 +2,14 @@ resource "aws_iam_role" "this" {
   name                 = local.iam_role_name
   path                 = "/"
   description          = "Role for subnet-exporter to describe ec2 subnets"
-  assume_role_policy   = data.aws_iam_policy_document.subnet_exporter_trust.json
+  assume_role_policy   = jsonencode(jsondecode(data.aws_iam_policy_document.subnet_exporter_trust.json))
   max_session_duration = 3600
 }
 
 resource "aws_iam_role_policy" "this" {
   name   = local.iam_role_name
   role   = aws_iam_role.this.id
-  policy = data.aws_iam_policy_document.subnet_exporter.json
+  policy = jsonencode(jsondecode(data.aws_iam_policy_document.subnet_exporter.json))
 }
 
 resource "kubernetes_service_account" "this" {


### PR DESCRIPTION
## Describe your changes

This pull request updates the handling of IAM role policies in the `k8s-subnet-exporter` Terraform module to ensure compatibility with Terraform's JSON encoding/decoding requirements. The changes primarily involve wrapping policy documents with `jsonencode` and `jsondecode` for better parsing and validation.

### IAM Role Policy Handling:

* Updated `assume_role_policy` in `aws_iam_role` resource to use `jsonencode(jsondecode(...))` for the `subnet_exporter_trust` policy document.
* Updated `policy` in `aws_iam_role_policy` resource to use `jsonencode(jsondecode(...))` for the `subnet_exporter` policy document.

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
