### PR TITLE
fix(deps): update Velero Helm chart and AWS plugin versions to 10.0.4 and v1.12.1

### DIFF
--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -242,8 +242,8 @@ inputs = {
 
   velero_deploy                               = true
   velero_bucket_arn                           = "arn:aws:s3:::dfds-velero-qa"
-  velero_helm_chart_version                   = "9.1.2"
-  velero_plugin_for_aws_version               = "v1.12.0"
+  velero_helm_chart_version                   = "10.0.4"
+  velero_plugin_for_aws_version               = "v1.12.1"
   velero_excluded_namespace_scoped_resources  = ["secrets"]
   velero_filesystem_backup_enabled            = false
 


### PR DESCRIPTION
## Describe your changes

This pull request updates the Velero configuration in the `terragrunt.hcl` file for the `k8s-qa` environment. The changes include upgrading the Velero Helm chart and AWS plugin versions to ensure compatibility and access to the latest features and fixes.

Version upgrades:

* [`test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl`](diffhunk://#diff-23bdbeb0d3e57bc3139b318801dda0b1c266354c34072dffc2a1932f1df0cc11L245-R246): Updated `velero_helm_chart_version` from `9.1.2` to `10.0.4` and `velero_plugin_for_aws_version` from `v1.12.0` to `v1.12.1`.

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
