### PR TITLE
fix: update default values for velero_ebs_csi_kms_arn variables. Use empty string instead of null

### DIFF
--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -114,8 +114,8 @@ variable "traefik_nlb_deploy" {
 }
 
 variable "alb_az_app_registration_identifier_urls" {
-  type = list(string)
-  default = null
+  type     = list(string)
+  default  = null
   nullable = true
 }
 
@@ -921,7 +921,7 @@ EOF
 
 variable "velero_ebs_csi_kms_arn" {
   type        = string
-  default     = null
+  default     = ""
   description = "The KMS ARN to use for EBS CSI volumes."
 }
 


### PR DESCRIPTION
## Describe your changes

If you opt-out of using EBS encryption, it will currently fail with:

```
Error: Invalid template interpolation value
  │
  │   on ../../_sub/storage/velero/main.tf line 177, in resource "aws_iam_policy" "kms_policy":
  │  150:   policy      = <<EOF
  │  151: {
  │  152:     "Version": "2012-10-17",
  │  153:     "Statement": [
  │  154:         {
  │  155:             "Action": [
  │  156:                 "kms:RevokeGrant",
  │  157:                 "kms:ListGrants",
  │  158:                 "kms:CreateGrant"
  │  159:             ],
  │  160:             "Condition": {
  │  161:                 "Bool": {
  │  162:                     "kms:GrantIsForAWSResource": "true"
  │  163:                 }
  │  164:             },
  │  165:             "Effect": "Allow",
  │  166:             "Resource": "${var.ebs_csi_kms_arn}"
  │  167:         },
  │  168:         {
  │  169:             "Action": [
  │  170:                 "kms:ReEncrypt*",
  │  171:                 "kms:GenerateDataKey*",
  │  172:                 "kms:Encrypt",
  │  173:                 "kms:DescribeKey",
  │  174:                 "kms:Decrypt"
  │  175:             ],
  │  176:             "Effect": "Allow",
  │  177:             "Resource": "${var.ebs_csi_kms_arn}"
  │  178:         }
  │  179:     ]
  │  180: }
  │  181: EOF
  │     ├────────────────
  │     │ var.ebs_csi_kms_arn is null
  │
  │ The expression result is null. Cannot include a null value in a string
  │ template.
```

This PR contains the fix to avoid that.

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
