### PR TITLE
Data lookups as primary way to find route tables for peering

### DIFF
--- a/_sub/compute/eks-cluster/network.tf
+++ b/_sub/compute/eks-cluster/network.tf
@@ -4,7 +4,7 @@ data "aws_availability_zones" "available" {
 }
 
 resource "aws_vpc" "eks" {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = var.cidr_block
 
   tags = {
     "Name"                                      = "eks-${var.cluster_name}-cluster"

--- a/_sub/compute/eks-cluster/vars.tf
+++ b/_sub/compute/eks-cluster/vars.tf
@@ -31,3 +31,8 @@ variable "sleep_after" {
   default     = 120
   description = "The AWS API will return OK before the Kubernetes cluster is actually available. Wait an arbitrary amount of time for cluster to become ready. Workaround for https://github.com/aws/containers-roadmap/issues/654"
 }
+
+variable "cidr_block" {
+  type        = string
+  description = "The CIDR block for the VPC. This is used to create the VPC and subnets for the EKS cluster."
+}

--- a/_sub/network/vpc-peering-requester/main.tf
+++ b/_sub/network/vpc-peering-requester/main.tf
@@ -289,7 +289,7 @@ resource "aws_iam_instance_profile" "ssm_tunnel" {
 
 resource "aws_vpc_security_group_ingress_rule" "postgres" {
   security_group_id = aws_default_security_group.default.id
-  cidr_ipv4         = var.cidr_block_peer
+  cidr_ipv4         = var.peer_cidr_block
   ip_protocol       = "tcp"
   from_port         = 5432
   to_port           = 5432
@@ -300,7 +300,7 @@ resource "aws_vpc_security_group_ingress_rule" "postgres" {
 
 resource "aws_vpc_security_group_ingress_rule" "redis" {
   security_group_id = aws_default_security_group.default.id
-  cidr_ipv4         = var.cidr_block_peer
+  cidr_ipv4         = var.peer_cidr_block
   ip_protocol       = "tcp"
   from_port         = 6379
   to_port           = 6379
@@ -338,7 +338,7 @@ resource "aws_vpc_peering_connection" "capability" {
 
 resource "aws_route" "capability_to_shared" {
   route_table_id            = aws_vpc.peering.main_route_table_id
-  destination_cidr_block    = var.cidr_block_peer
+  destination_cidr_block    = var.peer_cidr_block
   vpc_peering_connection_id = aws_vpc_peering_connection.capability.id
 }
 

--- a/_sub/network/vpc-peering-requester/vars.tf
+++ b/_sub/network/vpc-peering-requester/vars.tf
@@ -25,7 +25,7 @@ variable "cidr_block_subnet_c" {
   default     = ""
 }
 
-variable "cidr_block_peer" {
+variable "peer_cidr_block" {
   description = "The CIDR block of the peer VPC"
   type        = string
 }

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -6,6 +6,7 @@ module "eks_cluster" {
   source             = "../../_sub/compute/eks-cluster"
   cluster_name       = var.eks_cluster_name
   cluster_version    = var.eks_cluster_version
+  cidr_block         = var.eks_cluster_cidr_block
   cluster_zones      = var.eks_cluster_zones
   cluster_subnets    = var.enable_worker_nat_gateway || var.use_worker_nat_gateway ? var.eks_cluster_subnets : var.eks_cluster_zones
   log_types          = var.eks_cluster_log_types

--- a/compute/eks-ec2/vars.tf
+++ b/compute/eks-ec2/vars.tf
@@ -38,6 +38,12 @@ variable "eks_cluster_version" {
   type = string
 }
 
+variable "eks_cluster_cidr_block" {
+  type        = string
+  description = "The CIDR block for the VPC. This is used to create the VPC and subnets for the EKS cluster."
+  default     = "10.0.0.0/16"
+}
+
 variable "eks_worker_ssh_public_key" {
   type = string
 }

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -473,7 +473,7 @@ module "vpc_peering_capability_eu_west_1" {
   cidr_block_subnet_a          = each.value.assigned_cidr_block_subnet_a
   cidr_block_subnet_b          = each.value.assigned_cidr_block_subnet_b
   cidr_block_subnet_c          = each.value.assigned_cidr_block_subnet_c
-  cidr_block_peer              = each.value.cidr_block_peer
+  peer_cidr_block              = each.value.peer_cidr_block
   peer_owner_id                = var.shared_account_id
   peer_vpc_id                  = each.value.peer_vpc_id
   peer_region                  = each.value.peer_region
@@ -514,7 +514,7 @@ module "vpc_peering_capability_eu_central_1" {
   cidr_block_subnet_a          = each.value.assigned_cidr_block_subnet_a
   cidr_block_subnet_b          = each.value.assigned_cidr_block_subnet_b
   cidr_block_subnet_c          = each.value.assigned_cidr_block_subnet_c
-  cidr_block_peer              = each.value.cidr_block_peer
+  peer_cidr_block              = each.value.peer_cidr_block
   peer_owner_id                = var.shared_account_id
   peer_vpc_id                  = each.value.peer_vpc_id
   peer_region                  = each.value.peer_region

--- a/security/org-account-context/vars.tf
+++ b/security/org-account-context/vars.tf
@@ -339,7 +339,7 @@ variable "vpc_peering_settings_eu_west_1" {
   type = map(object({
     peer_vpc_id                  = string
     peer_region                  = string
-    peer_route_table_id          = string
+    peer_route_table_id          = optional(string, "")
     cidr_block_peer              = string
     assigned_cidr_block_vpc      = optional(string, "")
     assigned_cidr_block_subnet_a = optional(string, "")
@@ -383,7 +383,7 @@ variable "vpc_peering_settings_eu_central_1" {
   type = map(object({
     peer_vpc_id                  = string
     peer_region                  = string
-    peer_route_table_id          = string
+    peer_route_table_id          = optional(string, "")
     cidr_block_peer              = string
     assigned_cidr_block_vpc      = optional(string, "")
     assigned_cidr_block_subnet_a = optional(string, "")

--- a/security/org-account-context/vars.tf
+++ b/security/org-account-context/vars.tf
@@ -340,7 +340,7 @@ variable "vpc_peering_settings_eu_west_1" {
     peer_vpc_id                  = string
     peer_region                  = string
     peer_route_table_id          = optional(string, "")
-    cidr_block_peer              = string
+    peer_cidr_block              = string
     assigned_cidr_block_vpc      = optional(string, "")
     assigned_cidr_block_subnet_a = optional(string, "")
     assigned_cidr_block_subnet_b = optional(string, "")
@@ -367,7 +367,7 @@ EOF
       peer_vpc_id                  = ""
       peer_region                  = ""
       peer_route_table_id          = ""
-      cidr_block_peer              = ""
+      peer_cidr_block              = ""
       assigned_cidr_block_vpc      = ""
       assigned_cidr_block_subnet_a = ""
       assigned_cidr_block_subnet_b = ""
@@ -384,7 +384,7 @@ variable "vpc_peering_settings_eu_central_1" {
     peer_vpc_id                  = string
     peer_region                  = string
     peer_route_table_id          = optional(string, "")
-    cidr_block_peer              = string
+    peer_cidr_block              = string
     assigned_cidr_block_vpc      = optional(string, "")
     assigned_cidr_block_subnet_a = optional(string, "")
     assigned_cidr_block_subnet_b = optional(string, "")
@@ -411,7 +411,7 @@ EOF
       peer_vpc_id                  = ""
       peer_region                  = ""
       peer_route_table_id          = ""
-      cidr_block_peer              = ""
+      peer_cidr_block              = ""
       assigned_cidr_block_vpc      = ""
       assigned_cidr_block_subnet_a = ""
       assigned_cidr_block_subnet_b = ""

--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -53,7 +53,7 @@ inputs = {
   # Blue variant
   traefik_blue_variant_deploy             = true
   traefik_blue_variant_dashboard_deploy   = true
-  traefik_blue_variant_helm_chart_version = "35.2.0"
+  traefik_blue_variant_helm_chart_version = "35.4.0"
   traefik_blue_variant_additional_args = [
     "--metrics.prometheus",
     "--providers.kubernetescrd.allowCrossNamespace=true",
@@ -63,7 +63,7 @@ inputs = {
   # Green variant
   traefik_green_variant_deploy             = false
   traefik_green_variant_dashboard_deploy   = false
-  traefik_green_variant_helm_chart_version = "35.2.0"
+  traefik_green_variant_helm_chart_version = "35.4.0"
   traefik_green_variant_additional_args = [
     "--metrics.prometheus",
     "--providers.kubernetescrd.allowCrossNamespace=true",


### PR DESCRIPTION
## BREAKING CHANGE:

- The complex variables `vpc_peering_settings_eu_west_1` and `vpc_peering_settings_eu_central_1` previously had a mandatory field called `cidr_block_peer`. This has been renamed to `peer_cidr_block` to following the naming standard with other fields in this variable.
- This is only a breaking changes for pipelines that use the `org-account-context` module AND has VPC peering enabled. The migration path is to run Search/Replace in all the terragrunt.hcl files that has `vpc_peering_settings_eu_west_1` and `vpc_peering_settings_eu_central_1`  and replace `cidr_block_peer` with  `peer_cidr_block`.

## Describe your changes

This pull request introduces several changes across multiple Terraform modules and files. The main focus is on enhancing configurability by introducing new variables and renaming existing ones for clarity. Additionally, a minor update to Helm chart versions is included.

### Enhancements to configurability:

* [`_sub/compute/eks-cluster/network.tf`](diffhunk://#diff-7830e50c19dcc312136381a6f4b29c30ca1e33168dffd352a8d36e9fd8d493f5L7-R7): Updated the `aws_vpc` resource to use the `cidr_block` variable instead of a hardcoded value, allowing dynamic configuration of the VPC CIDR block.
* [`_sub/compute/eks-cluster/vars.tf`](diffhunk://#diff-a784efe4d929432b6601393a48f7c2872c0bb3fbf9ecee233a50aa7d16d59b91R34-R38): Added a new variable `cidr_block` to define the CIDR block for the VPC used in the EKS cluster.
* [`compute/eks-ec2/main.tf`](diffhunk://#diff-377519e7ca2d872af5e1381cb6c57e93942c12625344ff8fc8a970e19a400742R9): Passed the `eks_cluster_cidr_block` variable to the `eks_cluster` module for VPC configuration.
* [`compute/eks-ec2/vars.tf`](diffhunk://#diff-b18f8354ea8f3932f1be0681155c6e70c457a10798e9be3a07994adfea3d16b3R41-R46): Introduced the `eks_cluster_cidr_block` variable with a default value of `10.0.0.0/16` for better configurability.

### Renaming for clarity:

* [`_sub/network/vpc-peering-requester/main.tf`](diffhunk://#diff-102b9e9826581da57cda6e2b87f7c21b029eaac75b11e5e8414190104e07d554L292-R292): Renamed `cidr_block_peer` to `peer_cidr_block` in multiple resources for improved naming consistency. [[1]](diffhunk://#diff-102b9e9826581da57cda6e2b87f7c21b029eaac75b11e5e8414190104e07d554L292-R292) [[2]](diffhunk://#diff-102b9e9826581da57cda6e2b87f7c21b029eaac75b11e5e8414190104e07d554L303-R303) [[3]](diffhunk://#diff-102b9e9826581da57cda6e2b87f7c21b029eaac75b11e5e8414190104e07d554L341-R341)
* [`_sub/network/vpc-peering-requester/vars.tf`](diffhunk://#diff-762052db6807d99bdb939549c03c8ab8ed634d82dcb4c76f56a635d6cd63eb30L28-R28): Renamed the variable `cidr_block_peer` to `peer_cidr_block` to align with naming conventions.
* [`security/org-account-context/main.tf`](diffhunk://#diff-7b7c091a5ddacc1b6dbe68e60823ae348a8a271b036f0120b408e5ccd84b52dbL476-R476): Updated module inputs to use `peer_cidr_block` instead of `cidr_block_peer`. [[1]](diffhunk://#diff-7b7c091a5ddacc1b6dbe68e60823ae348a8a271b036f0120b408e5ccd84b52dbL476-R476) [[2]](diffhunk://#diff-7b7c091a5ddacc1b6dbe68e60823ae348a8a271b036f0120b408e5ccd84b52dbL517-R517)
* [`security/org-account-context/vars.tf`](diffhunk://#diff-b58b1b3e6ff71b800ae44c9180a674ea4f9e43d461d834f99af7fa6c56588f1aL342-R343): Renamed `cidr_block_peer` to `peer_cidr_block` in multiple variable definitions for consistency. [[1]](diffhunk://#diff-b58b1b3e6ff71b800ae44c9180a674ea4f9e43d461d834f99af7fa6c56588f1aL342-R343) [[2]](diffhunk://#diff-b58b1b3e6ff71b800ae44c9180a674ea4f9e43d461d834f99af7fa6c56588f1aL370-R370) [[3]](diffhunk://#diff-b58b1b3e6ff71b800ae44c9180a674ea4f9e43d461d834f99af7fa6c56588f1aL386-R387) [[4]](diffhunk://#diff-b58b1b3e6ff71b800ae44c9180a674ea4f9e43d461d834f99af7fa6c56588f1aL414-R414)

### Helm chart version updates:

* [`test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl`](diffhunk://#diff-23bdbeb0d3e57bc3139b318801dda0b1c266354c34072dffc2a1932f1df0cc11L56-R56): Updated the Helm chart version for both the blue and green variants of Traefik from `35.2.0` to `35.4.0`. [[1]](diffhunk://#diff-23bdbeb0d3e57bc3139b318801dda0b1c266354c34072dffc2a1932f1df0cc11L56-R56) [[2]](diffhunk://#diff-23bdbeb0d3e57bc3139b318801dda0b1c266354c34072dffc2a1932f1df0cc11L66-R66)

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
