### PR TITLE
fix(helm): add description for kube_prometheus_stack helm release. This is now mandatory even though the provider documentation says otherwise

### DIFF
--- a/_sub/compute/helm-kube-prometheus-stack/main.tf
+++ b/_sub/compute/helm-kube-prometheus-stack/main.tf
@@ -29,6 +29,10 @@ resource "aws_ssm_parameter" "param_grafana_username" {
   }
 }
 
+locals {
+  description = coalesce(var.chart_version, "unknown")
+}
+
 resource "helm_release" "kube_prometheus_stack" {
   name          = "monitoring"
   chart         = "kube-prometheus-stack"
@@ -37,7 +41,7 @@ resource "helm_release" "kube_prometheus_stack" {
   namespace     = var.namespace
   recreate_pods = true
   force_update  = false
-  description   = "Helm chart version: ${var.chart_version}"
+  description   = "Helm chart version is ${local.description}"
 
   values = [
     templatefile("${path.module}/values/components.yaml", {


### PR DESCRIPTION
- **fix(helm): add description for kube_prometheus_stack helm release. This is now mandatory even though the provider documentation says otherwise.**
- **fix(helm): update description for kube_prometheus_stack to use local variable for chart version**

## Describe your changes

This pull request introduces a new local variable to improve the handling of Helm chart descriptions and updates the `helm_release` resource to use this variable. These changes enhance clarity and maintainability in the Terraform configuration.

### Enhancements to Helm chart description:

* [`_sub/compute/helm-kube-prometheus-stack/main.tf`](diffhunk://#diff-a1b1f48f0f21865ec2dcbc54a84c60f3c7d3c7d32f6b8d1c9d45066189b4e25fR32-R35): Added a `locals` block defining a `description` variable, which uses the `coalesce` function to set the chart version or default to "unknown" if the version is not provided.
* [`_sub/compute/helm-kube-prometheus-stack/main.tf`](diffhunk://#diff-a1b1f48f0f21865ec2dcbc54a84c60f3c7d3c7d32f6b8d1c9d45066189b4e25fR44): Updated the `helm_release` resource to include a `description` attribute that dynamically references the `local.description` variable for improved contextual information.

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
