### PR TITLE
fix(velero): correct casing for volumeSnapshotLocation and add name field

### DIFF
--- a/_sub/storage/velero/values/patch.yaml
+++ b/_sub/storage/velero/values/patch.yaml
@@ -35,8 +35,9 @@ spec:
 %{ if read_only ~}
           accessMode: ReadOnly
 %{ endif ~}
-      VolumeSnapshotLocation:
-        - provider: aws
+      volumeSnapshotLocation:
+        - name: velero-snapshot
+          provider: aws
           config:
             region: ${bucket_region}
     serviceAccount:


### PR DESCRIPTION
## Describe your changes

This pull request includes a change to the `volumeSnapshotLocation` configuration in the `patch.yaml` file for Velero storage settings. The change renames the key and adds a `name` field to improve clarity and configuration specificity.

Velero storage configuration changes:

* [`_sub/storage/velero/values/patch.yaml`](diffhunk://#diff-9bcea7b85ef86a4cd2047a80b14dede9dbbe7721053b6efd7ef3a1745aeaebd9L38-R40): Renamed `VolumeSnapshotLocation` to `volumeSnapshotLocation` and added a `name` field (`velero-snapshot`) to the configuration.

## Checklist before requesting a review

- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
