### PR TITLE
fix(terragrunt): disable kube-prometheus-stack deployment in configuration

### DIFF
--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -126,7 +126,7 @@ inputs = {
   # Kube-prometheus-stack
   # --------------------------------------------------
 
-  monitoring_kube_prometheus_stack_deploy                            = true
+  monitoring_kube_prometheus_stack_deploy                            = false
   monitoring_kube_prometheus_stack_chart_version                     = "55.4.1"
   monitoring_kube_prometheus_stack_target_namespaces                 = "kube-system|monitoring"
   monitoring_kube_prometheus_stack_prometheus_storage_size           = "5Gi"


### PR DESCRIPTION
## Describe your changes

This pull request includes a small change to the `terragrunt.hcl` file in the `k8s-qa` service configuration. The change disables the deployment of the `kube-prometheus-stack` by setting `monitoring_kube_prometheus_stack_deploy` to `false`.

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
