### PR TITLE
Add support for custom CIDR ranges for Kubernetes clusters

### DIFF
--- a/_sub/compute/efs-fs/main.tf
+++ b/_sub/compute/efs-fs/main.tf
@@ -1,4 +1,6 @@
 resource "aws_efs_file_system" "this" {
+  #checkov:skip=CKV_AWS_184: Ensure resource is encrypted by KMS using a customer managed Key (CMK)
+
   encrypted        = var.encrypted
   performance_mode = var.performance_mode
   throughput_mode  = var.throughput_mode
@@ -8,6 +10,7 @@ resource "aws_efs_file_system" "this" {
 }
 
 resource "aws_security_group" "this" {
+  #checkov:skip=CKV_AWS_23: Ensure every security group and rule has a description
   vpc_id = var.vpc_id
   tags = {
     Name = var.name
@@ -15,6 +18,7 @@ resource "aws_security_group" "this" {
 }
 
 resource "aws_security_group_rule" "this" {
+  #checkov:skip=CKV_AWS_23: Ensure every security group and rule has a description
   type              = "ingress"
   from_port         = 2049
   to_port           = 2049
@@ -24,7 +28,7 @@ resource "aws_security_group_rule" "this" {
 }
 
 resource "aws_efs_mount_target" "this" {
-  for_each = { for idx, subnet_id in flatten([for k, v in var.vpc_subnet_ids : v]) : idx => subnet_id }
+  for_each        = { for idx, subnet_id in flatten([for k, v in var.vpc_subnet_ids : v]) : idx => subnet_id }
   file_system_id  = aws_efs_file_system.this.id
   subnet_id       = each.value
   security_groups = [aws_security_group.this.id]

--- a/_sub/compute/eks-cluster/eks.tf
+++ b/_sub/compute/eks-cluster/eks.tf
@@ -1,11 +1,19 @@
-#tfsec:ignore:aws-cloudwatch-log-group-customer-key
 resource "aws_cloudwatch_log_group" "eks" {
+  #checkov:skip=CKV_AWS_158: Ensure that CloudWatch Log Group is encrypted by KMS
+  #checkov:skip=CKV_AWS_338: Ensure CloudWatch log groups retains logs for at least 1 year
   name              = "/aws/eks/${var.cluster_name}/cluster"
   retention_in_days = var.log_retention_days
 }
 
-#tfsec:ignore:aws-eks-no-public-cluster-access-to-cidr tfsec:ignore:aws-eks-no-public-cluster-access tfsec:ignore:aws-eks-encrypt-secrets tfsec:ignore:aws-eks-enable-control-plane-logging
+#trivy:ignore:AVD-AWS-0038 EKS Clusters should have cluster control plane logging turned on
+#trivy:ignore:AVD-AWS-0039 EKS should have the encryption of secrets enabled
+#trivy:ignore:AVD-AWS-0040 EKS Clusters should have the public access disabled
+#trivy:ignore:AVD-AWS-0041 EKS cluster should not have open CIDR range for public access
 resource "aws_eks_cluster" "eks" {
+  #checkov:skip=CKV_AWS_37: Ensure Amazon EKS control plane logging is enabled for all log types
+  #checkov:skip=CKV_AWS_38: Ensure Amazon EKS public endpoint not accessible to 0.0.0.0/0
+  #checkov:skip=CKV_AWS_39: Ensure Amazon EKS public endpoint disabled
+  #checkov:skip=CKV_AWS_58: Ensure EKS Cluster has Secrets Encryption Enabled
   name     = var.cluster_name
   role_arn = aws_iam_role.eks.arn
   version  = var.cluster_version

--- a/_sub/compute/eks-cluster/securitygroup.tf
+++ b/_sub/compute/eks-cluster/securitygroup.tf
@@ -1,4 +1,6 @@
+#trivy:ignore:AVD-AWS-0104 Security group rule allows unrestricted egress to any IP address
 resource "aws_security_group" "eks-cluster" {
+  #checkov:skip=CKV_AWS_382: Ensure no security groups allow egress from 0.0.0.0:0 to port -1
   name_prefix = "eks-${var.cluster_name}-cluster-"
   description = "Cluster communication with worker nodes"
   vpc_id      = aws_vpc.eks.id
@@ -8,7 +10,7 @@ resource "aws_security_group" "eks-cluster" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"] #tfsec:ignore:aws-vpc-no-public-egress-sg tfsec:ignore:aws-ec2-no-public-egress-sgr
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   tags = {
@@ -16,7 +18,6 @@ resource "aws_security_group" "eks-cluster" {
   }
 }
 
-#tfsec:ignore:aws-vpc-disallow-mixed-sgr tfsec:ignore:no-public-ingress-sgr tfsec:ignore:aws-vpc-no-public-ingress-sg tfsec:ignore:aws-vpc-no-public-ingress-sgr
 resource "aws_security_group_rule" "eks-ingress-workstation-https" {
   cidr_blocks       = ["0.0.0.0/0"]
   description       = "Allow workstation to communicate with the cluster API Server"

--- a/_sub/compute/eks-cluster/vars.tf
+++ b/_sub/compute/eks-cluster/vars.tf
@@ -14,6 +14,11 @@ variable "cluster_subnets" {
   type = number
 }
 
+variable "cluster_reserved_cidr" {
+  type        = string
+  description = "The CIDR block reserved for the control plane subnets. This is used to create the subnets for the EKS cluster control plane."
+}
+
 variable "log_types" {
   type        = list(string)
   description = "A list of the desired control plane logging to enable: api, audit, authenticator, controllerManager, scheduler. See also https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html."

--- a/_sub/compute/eks-cluster/vars.tf
+++ b/_sub/compute/eks-cluster/vars.tf
@@ -10,9 +10,6 @@ variable "cluster_zones" {
   type = number
 }
 
-variable "cluster_subnets" {
-  type = number
-}
 
 variable "cluster_reserved_cidr" {
   type        = string

--- a/_sub/compute/eks-nodegroup-managed/main.tf
+++ b/_sub/compute/eks-nodegroup-managed/main.tf
@@ -1,4 +1,5 @@
 resource "aws_launch_template" "eks" {
+  #checkov:skip=CKV_AWS_88: EC2 instance should not have public IP.
   count = signum(var.desired_size_per_subnet)
 
   image_id      = local.node_ami

--- a/_sub/compute/eks-nodegroup-managed/vars.tf
+++ b/_sub/compute/eks-nodegroup-managed/vars.tf
@@ -108,9 +108,9 @@ variable "docker_hub_password" {
 }
 
 variable "essentials_url" {
-  type = string
+  type        = string
   description = "HTTP server that provides essentials"
-  default = ""
+  default     = ""
 }
 
 # ------------------------------------------------------

--- a/_sub/compute/eks-workers/iam.tf
+++ b/_sub/compute/eks-workers/iam.tf
@@ -43,7 +43,7 @@ resource "aws_iam_instance_profile" "eks" {
   role = aws_iam_role.eks.name
 }
 
-# tfsec:ignore:aws-iam-no-policy-wildcards
+#trivy:ignore:AVD-AWS-0345 IAM role uses a policy that allows 's3:*' action
 resource "aws_iam_role_policy" "cloudwatch-agent-config-bucket" {
   name = "eks-${var.cluster_name}-cl-agent-config-bucket"
   role = aws_iam_role.eks.id
@@ -78,8 +78,8 @@ EOF
 
 }
 
-# tfsec:ignore:aws-iam-no-policy-wildcards
 resource "aws_iam_role_policy" "cloudwatch_agent_metrics" {
+  #checkov:skip=CKV_AWS_355: Ensure no IAM policies documents allow "*" as a statement's resource for restrictable actions
   name = "cloudwatch_agent_metrics"
   role = aws_iam_role.eks.id
 

--- a/_sub/compute/k8s-clusterrole/main.tf
+++ b/_sub/compute/k8s-clusterrole/main.tf
@@ -1,4 +1,5 @@
 resource "kubernetes_cluster_role" "role" {
+  #checkov:skip=CKV_K8S_49: Minimize wildcard use in Roles and ClusterRoles
   metadata {
     name = var.name
   }

--- a/_sub/network/security-group-eks-node/main.tf
+++ b/_sub/network/security-group-eks-node/main.tf
@@ -1,4 +1,6 @@
+#trivy:ignore:AVD-AWS-0104 Security group rule allows unrestricted egress to any IP address
 resource "aws_security_group" "eks-node" {
+  #checkov:skip=CKV_AWS_382: Ensure no security groups allow egress from 0.0.0.0:0 to port -1
   name        = "eks-${var.cluster_name}-node"
   description = "Security group for all nodes in the cluster"
   vpc_id      = var.vpc_id
@@ -8,7 +10,7 @@ resource "aws_security_group" "eks-node" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"] #tfsec:ignore:aws-vpc-no-public-egress-sg tfsec:ignore:aws-ec2-no-public-egress-sgr
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   tags = {
@@ -17,7 +19,6 @@ resource "aws_security_group" "eks-node" {
   }
 }
 
-#tfsec:ignore:aws-vpc-disallow-mixed-sgr
 resource "aws_security_group_rule" "eks-node-ingress-self" {
   description              = "Allow node to communicate with each other"
   from_port                = 0
@@ -28,7 +29,6 @@ resource "aws_security_group_rule" "eks-node-ingress-self" {
   type                     = "ingress"
 }
 
-#tfsec:ignore:aws-vpc-disallow-mixed-sgr
 resource "aws_security_group_rule" "eks-node-ingress-cluster" {
   description              = "Allow worker Kubelets and pods to receive communication from the cluster control plane"
   from_port                = 1024
@@ -50,8 +50,8 @@ resource "aws_security_group_rule" "eks-cluster-ingress-node-https" {
 }
 
 #Enable SSH access to nodes by tfvars set to 1
-#tfsec:ignore:aws-vpc-disallow-mixed-sgr
 resource "aws_security_group_rule" "ssh-access-to-worker-nodes" {
+  #checkov:skip=CKV_AWS_24: Ensure no security groups allow ingress from 0.0.0.0:0 to port 22
   description       = "Allow SSH access to worker nodes"
   cidr_blocks       = var.ssh_ip_whitelist
   from_port         = 22

--- a/_sub/network/vpc-flow-log/main.tf
+++ b/_sub/network/vpc-flow-log/main.tf
@@ -1,4 +1,6 @@
 resource "aws_cloudwatch_log_group" "vpc_eks" {
+  #checkov:skip=CKV_AWS_338: Ensure CloudWatch log groups retains logs for at least 1 year
+  #checkov:skip=CKV_AWS_158: Ensure that CloudWatch Log Group is encrypted by KMS
   name              = "/aws/vpc/${var.log_name}"
   retention_in_days = var.retention_in_days
 }
@@ -41,8 +43,8 @@ data "aws_iam_policy_document" "flow_log" {
     ]
 
     resources = [
-      "${aws_cloudwatch_log_group.vpc_eks.arn}",
-      "${aws_cloudwatch_log_group.vpc_eks.arn}:*",
+      aws_cloudwatch_log_group.vpc_eks.arn,
+      format("%s:*", aws_cloudwatch_log_group.vpc_eks.arn),
     ]
   }
 }

--- a/_sub/security/ssm-parameter-store/main.tf
+++ b/_sub/security/ssm-parameter-store/main.tf
@@ -1,4 +1,5 @@
 resource "aws_ssm_parameter" "putSecureString" {
+  #checkov:skip=CKV_AWS_337: Ensure SSM parameters are using KMS CMK
   count       = var.deploy ? 1 : 0
   name        = var.key_name
   description = var.key_description

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -64,7 +64,6 @@ module "eks_cluster" {
   cidr_block            = var.eks_cluster_cidr_block
   cluster_zones         = var.eks_cluster_zones
   cluster_reserved_cidr = local.cluster_reserved_cidr
-  cluster_subnets       = var.enable_worker_nat_gateway || var.use_worker_nat_gateway ? var.eks_cluster_subnets : var.eks_cluster_zones
   log_types             = var.eks_cluster_log_types
   log_retention_days    = var.eks_cluster_log_retention_days
 }

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -13,13 +13,17 @@ locals {
   # into smaller chunks based on the prefix length.
   # The calculations for VPC CIDR prefix with value 16 are ensuring backward compatibility with existing deployments.
   # This includes removing the first element of the list of prefixes.
-  eks_managed_worker_subnets = [
+  worker_subnets_calculated = [
     {
       availability_zone = format("%sa", var.aws_region)
       subnet_cidr       = local.managed_subnet_az_a
       prefix_reservations_cidrs = local.vpc_cidr_prefix == 20 ? cidrsubnets(local.managed_subnet_az_a, 1, 2, 2) : (
-        local.vpc_cidr_prefix == 18 ? cidrsubnets(local.managed_subnet_az_a, 2, 3, 3, 2, 3, 3) : (
-          local.vpc_cidr_prefix == 16 ? slice(cidrsubnets(local.managed_subnet_az_a, 4, 4, 3, 2, 2, 3, 4), 1, 7) : []
+        local.vpc_cidr_prefix == 19 ? cidrsubnets(local.managed_subnet_az_a, 2, 2, 2, 2) : (
+          local.vpc_cidr_prefix == 18 ? cidrsubnets(local.managed_subnet_az_a, 2, 3, 3, 2, 3, 3) : (
+            local.vpc_cidr_prefix == 17 ? cidrsubnets(local.managed_subnet_az_a, 3, 3, 3, 3, 3, 3, 3, 3) : (
+              local.vpc_cidr_prefix == 16 ? slice(cidrsubnets(local.managed_subnet_az_a, 4, 4, 3, 2, 2, 3, 4), 1, 7) : []
+            )
+          )
         )
       )
     },
@@ -27,8 +31,12 @@ locals {
       availability_zone = format("%sb", var.aws_region)
       subnet_cidr       = local.managed_subnet_az_b
       prefix_reservations_cidrs = local.vpc_cidr_prefix == 20 ? cidrsubnets(local.managed_subnet_az_b, 1, 2, 2) : (
-        local.vpc_cidr_prefix == 18 ? cidrsubnets(local.managed_subnet_az_b, 2, 3, 3, 2, 3, 3) : (
-          local.vpc_cidr_prefix == 16 ? slice(cidrsubnets(local.managed_subnet_az_b, 4, 4, 3, 2, 2, 3, 4), 1, 7) : []
+        local.vpc_cidr_prefix == 19 ? cidrsubnets(local.managed_subnet_az_b, 2, 2, 2, 2) : (
+          local.vpc_cidr_prefix == 18 ? cidrsubnets(local.managed_subnet_az_b, 2, 3, 3, 2, 3, 3) : (
+            local.vpc_cidr_prefix == 17 ? cidrsubnets(local.managed_subnet_az_b, 3, 3, 3, 3, 3, 3, 3, 3) : (
+              local.vpc_cidr_prefix == 16 ? slice(cidrsubnets(local.managed_subnet_az_b, 4, 4, 3, 2, 2, 3, 4), 1, 7) : []
+            )
+          )
         )
       )
     },
@@ -36,12 +44,17 @@ locals {
       availability_zone = format("%sc", var.aws_region)
       subnet_cidr       = local.managed_subnet_az_c
       prefix_reservations_cidrs = local.vpc_cidr_prefix == 20 ? cidrsubnets(local.managed_subnet_az_c, 1, 2, 2) : (
-        local.vpc_cidr_prefix == 18 ? cidrsubnets(local.managed_subnet_az_c, 2, 3, 3, 2, 3, 3) : (
-          local.vpc_cidr_prefix == 16 ? slice(cidrsubnets(local.managed_subnet_az_c, 4, 4, 3, 2, 2, 3, 4), 1, 7) : []
+        local.vpc_cidr_prefix == 19 ? cidrsubnets(local.managed_subnet_az_c, 2, 2, 2, 2) : (
+          local.vpc_cidr_prefix == 18 ? cidrsubnets(local.managed_subnet_az_c, 2, 3, 3, 2, 3, 3) : (
+            local.vpc_cidr_prefix == 17 ? cidrsubnets(local.managed_subnet_az_c, 3, 3, 3, 3, 3, 3, 3, 3) : (
+              local.vpc_cidr_prefix == 16 ? slice(cidrsubnets(local.managed_subnet_az_c, 4, 4, 3, 2, 2, 3, 4), 1, 7) : []
+            )
+          )
         )
       )
     },
   ]
+  eks_managed_worker_subnets = length(var.eks_managed_worker_subnets) > 0 ? var.eks_managed_worker_subnets : local.worker_subnets_calculated
 }
 
 module "eks_cluster" {

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -13,14 +13,15 @@ locals {
   # into smaller chunks based on the prefix length.
   # The calculations for VPC CIDR prefix with value 16 are ensuring backward compatibility with existing deployments.
   # This includes removing the first element of the list of prefixes.
+  # In each subnet calculation, we ensure that at least 256 IP addresses are available for other use than prefix reservations.
   worker_subnets_calculated = [
     {
       availability_zone = format("%sa", var.aws_region)
       subnet_cidr       = local.managed_subnet_az_a
-      prefix_reservations_cidrs = local.vpc_cidr_prefix == 20 ? cidrsubnets(local.managed_subnet_az_a, 1, 2, 2) : (
-        local.vpc_cidr_prefix == 19 ? cidrsubnets(local.managed_subnet_az_a, 2, 2, 2, 2) : (
-          local.vpc_cidr_prefix == 18 ? cidrsubnets(local.managed_subnet_az_a, 2, 3, 3, 2, 3, 3) : (
-            local.vpc_cidr_prefix == 17 ? cidrsubnets(local.managed_subnet_az_a, 3, 3, 3, 3, 3, 3, 3, 3) : (
+      prefix_reservations_cidrs = local.vpc_cidr_prefix == 20 ? cidrsubnets(local.managed_subnet_az_a, 2, 2, 2) : (
+        local.vpc_cidr_prefix == 19 ? cidrsubnets(local.managed_subnet_az_a, 2, 2, 2, 3) : (
+          local.vpc_cidr_prefix == 18 ? cidrsubnets(local.managed_subnet_az_a, 2, 3, 3, 2, 3, 4) : (
+            local.vpc_cidr_prefix == 17 ? cidrsubnets(local.managed_subnet_az_a, 3, 3, 3, 3, 3, 3, 3, 4, 5) : (
               local.vpc_cidr_prefix == 16 ? slice(cidrsubnets(local.managed_subnet_az_a, 4, 4, 3, 2, 2, 3, 4), 1, 7) : []
             )
           )
@@ -30,10 +31,10 @@ locals {
     {
       availability_zone = format("%sb", var.aws_region)
       subnet_cidr       = local.managed_subnet_az_b
-      prefix_reservations_cidrs = local.vpc_cidr_prefix == 20 ? cidrsubnets(local.managed_subnet_az_b, 1, 2, 2) : (
-        local.vpc_cidr_prefix == 19 ? cidrsubnets(local.managed_subnet_az_b, 2, 2, 2, 2) : (
-          local.vpc_cidr_prefix == 18 ? cidrsubnets(local.managed_subnet_az_b, 2, 3, 3, 2, 3, 3) : (
-            local.vpc_cidr_prefix == 17 ? cidrsubnets(local.managed_subnet_az_b, 3, 3, 3, 3, 3, 3, 3, 3) : (
+      prefix_reservations_cidrs = local.vpc_cidr_prefix == 20 ? cidrsubnets(local.managed_subnet_az_b, 2, 2, 2) : (
+        local.vpc_cidr_prefix == 19 ? cidrsubnets(local.managed_subnet_az_b, 2, 2, 2, 3) : (
+          local.vpc_cidr_prefix == 18 ? cidrsubnets(local.managed_subnet_az_b, 2, 3, 3, 2, 3, 4) : (
+            local.vpc_cidr_prefix == 17 ? cidrsubnets(local.managed_subnet_az_b, 3, 3, 3, 3, 3, 3, 3, 4, 5) : (
               local.vpc_cidr_prefix == 16 ? slice(cidrsubnets(local.managed_subnet_az_b, 4, 4, 3, 2, 2, 3, 4), 1, 7) : []
             )
           )
@@ -43,10 +44,10 @@ locals {
     {
       availability_zone = format("%sc", var.aws_region)
       subnet_cidr       = local.managed_subnet_az_c
-      prefix_reservations_cidrs = local.vpc_cidr_prefix == 20 ? cidrsubnets(local.managed_subnet_az_c, 1, 2, 2) : (
-        local.vpc_cidr_prefix == 19 ? cidrsubnets(local.managed_subnet_az_c, 2, 2, 2, 2) : (
-          local.vpc_cidr_prefix == 18 ? cidrsubnets(local.managed_subnet_az_c, 2, 3, 3, 2, 3, 3) : (
-            local.vpc_cidr_prefix == 17 ? cidrsubnets(local.managed_subnet_az_c, 3, 3, 3, 3, 3, 3, 3, 3) : (
+      prefix_reservations_cidrs = local.vpc_cidr_prefix == 20 ? cidrsubnets(local.managed_subnet_az_c, 2, 2, 2) : (
+        local.vpc_cidr_prefix == 19 ? cidrsubnets(local.managed_subnet_az_c, 2, 2, 2, 3) : (
+          local.vpc_cidr_prefix == 18 ? cidrsubnets(local.managed_subnet_az_c, 2, 3, 3, 2, 3, 4) : (
+            local.vpc_cidr_prefix == 17 ? cidrsubnets(local.managed_subnet_az_c, 3, 3, 3, 3, 3, 3, 3, 4, 5) : (
               local.vpc_cidr_prefix == 16 ? slice(cidrsubnets(local.managed_subnet_az_c, 4, 4, 3, 2, 2, 3, 4), 1, 7) : []
             )
           )

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -5,9 +5,43 @@
 locals {
   managed_subnets_calculated = cidrsubnets(var.eks_cluster_cidr_block, 2, 2, 2, 2)
   cluster_reserved_cidr      = local.managed_subnets_calculated[0] # Reserved for the control plane subnets
-  managed_subnet_1           = local.managed_subnets_calculated[1]
-  managed_subnet_2           = local.managed_subnets_calculated[2]
-  managed_subnet_3           = local.managed_subnets_calculated[3]
+  managed_subnet_az_a        = local.managed_subnets_calculated[1] # Worker nodes subnet for availability zone a
+  managed_subnet_az_b        = local.managed_subnets_calculated[2] # Worker nodes subnet for availability zone b
+  managed_subnet_az_c        = local.managed_subnets_calculated[3] # Worker nodes subnet for availability zone c
+  vpc_cidr_prefix            = tonumber(substr(var.eks_cluster_cidr_block, -2, -1))
+  # This is used to determine the prefix length for the subnets, by splitting the CIDR block for the subnets
+  # into smaller chunks based on the prefix length.
+  # The calculations for VPC CIDR prefix with value 16 are ensuring backward compatibility with existing deployments.
+  # This includes removing the first element of the list of prefixes.
+  eks_managed_worker_subnets = [
+    {
+      availability_zone = format("%sa", var.aws_region)
+      subnet_cidr       = local.managed_subnet_az_a
+      prefix_reservations_cidrs = local.vpc_cidr_prefix == 20 ? cidrsubnets(local.managed_subnet_az_a, 1, 2, 2) : (
+        local.vpc_cidr_prefix == 18 ? cidrsubnets(local.managed_subnet_az_a, 2, 3, 3, 2, 3, 3) : (
+          local.vpc_cidr_prefix == 16 ? slice(cidrsubnets(local.managed_subnet_az_a, 4, 4, 3, 2, 2, 3, 4), 1, 7) : []
+        )
+      )
+    },
+    {
+      availability_zone = format("%sb", var.aws_region)
+      subnet_cidr       = local.managed_subnet_az_b
+      prefix_reservations_cidrs = local.vpc_cidr_prefix == 20 ? cidrsubnets(local.managed_subnet_az_b, 1, 2, 2) : (
+        local.vpc_cidr_prefix == 18 ? cidrsubnets(local.managed_subnet_az_b, 2, 3, 3, 2, 3, 3) : (
+          local.vpc_cidr_prefix == 16 ? slice(cidrsubnets(local.managed_subnet_az_b, 4, 4, 3, 2, 2, 3, 4), 1, 7) : []
+        )
+      )
+    },
+    {
+      availability_zone = format("%sc", var.aws_region)
+      subnet_cidr       = local.managed_subnet_az_c
+      prefix_reservations_cidrs = local.vpc_cidr_prefix == 20 ? cidrsubnets(local.managed_subnet_az_c, 1, 2, 2) : (
+        local.vpc_cidr_prefix == 18 ? cidrsubnets(local.managed_subnet_az_c, 2, 3, 3, 2, 3, 3) : (
+          local.vpc_cidr_prefix == 16 ? slice(cidrsubnets(local.managed_subnet_az_c, 4, 4, 3, 2, 2, 3, 4), 1, 7) : []
+        )
+      )
+    },
+  ]
 }
 
 module "eks_cluster" {
@@ -37,7 +71,7 @@ data "aws_availability_zones" "available" {
 
     precondition {
       condition = alltrue([
-        for sn in var.eks_managed_worker_subnets : startswith(sn.availability_zone, var.aws_region)
+        for sn in local.eks_managed_worker_subnets : startswith(sn.availability_zone, var.aws_region)
       ])
       error_message = "All managed worker subnet availability zones must be within the region specified by var.aws_region."
     }
@@ -56,11 +90,11 @@ data "aws_availability_zones" "available" {
 
 module "eks_managed_workers_subnet" {
   source       = "../../_sub/network/vpc-subnet-eks"
-  deploy       = length(var.eks_managed_worker_subnets) >= 1 ? true : false
+  deploy       = length(local.eks_managed_worker_subnets) >= 1 ? true : false
   name         = "eks-${var.eks_cluster_name}-managed-nodes"
   cluster_name = var.eks_cluster_name
   vpc_id       = module.eks_cluster.vpc_id
-  subnets      = var.eks_managed_worker_subnets
+  subnets      = local.eks_managed_worker_subnets
 }
 
 module "eks_workers_keypair" {

--- a/compute/eks-ec2/vars.tf
+++ b/compute/eks-ec2/vars.tf
@@ -43,7 +43,7 @@ variable "eks_cluster_cidr_block" {
   description = "The CIDR block for the VPC. This is used to create the VPC and subnets for the EKS cluster."
   default     = "10.0.0.0/16"
   validation {
-    condition     = can(cidrhost(var.eks_cluster_cidr_block, 1)) && substr(var.eks_cluster_cidr_block, -2, -1) <= 20
+    condition     = can(cidrhost(var.eks_cluster_cidr_block, 1)) && tonumber(substr(var.eks_cluster_cidr_block, -2, -1)) <= 20
     error_message = "The CIDR block must be a valid CIDR block, and at least /20 in size."
   }
 }

--- a/compute/eks-ec2/vars.tf
+++ b/compute/eks-ec2/vars.tf
@@ -42,6 +42,10 @@ variable "eks_cluster_cidr_block" {
   type        = string
   description = "The CIDR block for the VPC. This is used to create the VPC and subnets for the EKS cluster."
   default     = "10.0.0.0/16"
+  validation {
+    condition     = can(cidrhost(var.eks_cluster_cidr_block, 1)) && substr(var.eks_cluster_cidr_block, -2, -1) <= 20
+    error_message = "The CIDR block must be a valid CIDR block, and at least /20 in size."
+  }
 }
 
 variable "eks_worker_ssh_public_key" {

--- a/compute/eks-ec2/vars.tf
+++ b/compute/eks-ec2/vars.tf
@@ -291,12 +291,6 @@ variable "use_worker_nat_gateway" {
   description = "Whether to use NAT Gateway for worker nodes"
 }
 
-variable "eks_cluster_subnets" {
-  type        = number
-  default     = 3
-  description = "Number of subnets to use for the Cluster Control Plane"
-}
-
 variable "migrate_vpc_peering_routes" {
   description = "If true, migrate the peering connection to the new route table"
   type        = bool


### PR DESCRIPTION
- **feat: enhance security and configuration for EKS and related resources**
- **fix: correct type conversion in CIDR block validation for EKS**
- **refactor: improve subnet management for EKS with enhanced CIDR calculations and local variable usage**
- **refactor: enhance subnet calculations for EKS with additional prefix handling and improved variable naming**
- **refactor: remove unused cluster_subnets variable from EKS configuration**
- **refactor: improve subnet calculations for EKS with enhanced prefix reservation logic and ensure sufficient IP availability**

## Describe your changes
<!--Describe the change here-->

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
