### PR TITLE
fix: use ami al2023 filter

### DIFF
--- a/_sub/compute/eks-nodegroup-managed/dependencies.tf
+++ b/_sub/compute/eks-nodegroup-managed/dependencies.tf
@@ -8,7 +8,7 @@ locals {
 data "aws_ami" "eks-node" {
   filter {
     name   = "name"
-    values = ["amazon-eks-node-${var.cluster_version}-*"]
+    values = ["amazon-eks-node-al2023-x86_64-standard-${var.cluster_version}-*"]
   }
 
   most_recent = true
@@ -19,7 +19,7 @@ data "aws_ami" "eks-node" {
 data "aws_ami" "eks-gpu-node" {
   filter {
     name   = "name"
-    values = ["amazon-eks-gpu-node-${var.cluster_version}-*"]
+    values = ["amazon-eks-node-al2023-x86_64-nvidia-${var.cluster_version}-*"]
   }
 
   most_recent = true


### PR DESCRIPTION
## Describe your changes
This PR fixes the default AMI filter for nodes to use AL2023 as expected

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
