### PR TITLE
Allow IPAM pool sharing with OUs instead of per account basis

### DIFF
--- a/_sub/security/org-account-query/main.tf
+++ b/_sub/security/org-account-query/main.tf
@@ -1,3 +1,9 @@
 data "aws_organizations_organizational_unit_child_accounts" "this" {
   parent_id = var.ou_id
 }
+
+data "aws_organizations_organization" "org" {}
+
+data "aws_organizations_organizational_unit_descendant_organizational_units" "ous" {
+  parent_id = data.aws_organizations_organization.org.roots[0].id
+}

--- a/_sub/security/org-account-query/outputs.tf
+++ b/_sub/security/org-account-query/outputs.tf
@@ -1,3 +1,7 @@
 output "account_ids" {
   value = [for account in data.aws_organizations_organizational_unit_child_accounts.this.accounts : account.id]
 }
+
+output "organizational_units" {
+  value = [for ou in data.aws_organizations_organizational_unit_descendant_organizational_units.ous.children : ou]
+}

--- a/network/ipam/main.tf
+++ b/network/ipam/main.tf
@@ -97,8 +97,17 @@ module "ram_share_with_platform" {
   resource_arns = [
     for pool in values(module.regional_platform_pools) : pool.arn
   ]
-  principals = [for ous in module.org-account-query.organizational_units : ous.arn if contains(var.platform_sharing_ou_names, ous.name)]
+  principals = [for ous in module.org-account-query.organizational_units : ous.arn if contains(var.platform_pool_sharing_ou_names, ous.name)]
   tags       = var.tags
+}
+
+locals {
+  # If var.capabilities_pool_sharing_ou_names is empty, we use the ipam_role_patterns to generate a list of principals based on the account IDs from the org-account-query module.
+  # If it is not empty, we filter the organizational units to find those that match the specified names.
+  # This allows for flexibility in sharing the capabilities pools either with specific OUs or with all accounts under the specified OU using the role patterns.
+  capabilities_pool_sharing_principals = length(var.capabilities_pool_sharing_ou_names) == 0 ? flatten([
+    for pattern in var.ipam_role_patterns : formatlist(pattern, module.org-account-query.account_ids)
+  ]) : [for ous in module.org-account-query.organizational_units : ous.arn if contains(var.capabilities_pool_sharing_ou_names, ous.name)]
 }
 
 module "ram_share_with_capabilities" {
@@ -107,8 +116,6 @@ module "ram_share_with_capabilities" {
   resource_arns = [
     for pool in values(module.regional_capabilities_pools) : pool.arn
   ]
-  principals = flatten([
-    for pattern in var.ipam_role_patterns : formatlist(pattern, module.org-account-query.account_ids)
-  ])
-  tags = var.tags
+  principals = local.capabilities_pool_sharing_principals
+  tags       = var.tags
 }

--- a/network/ipam/main.tf
+++ b/network/ipam/main.tf
@@ -97,7 +97,7 @@ module "ram_share_with_platform" {
   resource_arns = [
     for pool in values(module.regional_platform_pools) : pool.arn
   ]
-  principals = var.ipam_platform_principals
+  principals = [for ous in module.org-account-query.organizational_units : ous.arn if contains(var.platform_sharing_ou_names, ous.name)]
   tags       = var.tags
 }
 

--- a/network/ipam/vars.tf
+++ b/network/ipam/vars.tf
@@ -91,9 +91,15 @@ EOF
   default     = ["arn:aws:iam::%s:role/aws-service-role/ipam.amazonaws.com/AWSServiceRoleForIPAM"]
 }
 
-variable "platform_sharing_ou_names" {
+variable "platform_pool_sharing_ou_names" {
   type        = list(string)
   description = "A list of OU names that should be granted access to the platform IPAM pools."
+  default     = []
+}
+
+variable "capabilities_pool_sharing_ou_names" {
+  type        = list(string)
+  description = "A list of OU names that should be granted access to the capabilities IPAM pools."
   default     = []
 }
 

--- a/network/ipam/vars.tf
+++ b/network/ipam/vars.tf
@@ -76,12 +76,6 @@ variable "ipam_prefix" {
   default     = ""
 }
 
-variable "ipam_platform_principals" {
-  type        = list(string)
-  description = "The ARNs of the principals to associate with a Resource Manager share for the regional platform pools"
-  default     = []
-}
-
 variable "ipam_ou_id" {
   type        = string
   description = "The ID of the AWS Organization OU that you want to query for accounts. This is used for sharing access to the IPAM pools."
@@ -95,6 +89,12 @@ variable "ipam_role_patterns" {
     the OU specified by var.ipam_ou_id.
 EOF
   default     = ["arn:aws:iam::%s:role/aws-service-role/ipam.amazonaws.com/AWSServiceRoleForIPAM"]
+}
+
+variable "platform_sharing_ou_names" {
+  type        = list(string)
+  description = "A list of OU names that should be granted access to the platform IPAM pools."
+  default     = []
 }
 
 variable "tags" {


### PR DESCRIPTION
## Describe your changes

This pull request introduces changes to enhance flexibility and functionality in querying AWS Organizational Units (OUs) and sharing IPAM pools. The most significant updates include adding new data sources for querying OUs, updating logic for determining principals in resource sharing, and introducing new variables to support more granular control over IPAM pool sharing.

### Enhancements to AWS OU Querying:
* Added new data sources in `_sub/security/org-account-query/main.tf` to retrieve the AWS organization and its descendant OUs for more comprehensive querying.
* Updated `outputs.tf` to include an output for the list of descendant organizational units, enabling downstream modules to access this data.

### Improvements to IPAM Pool Sharing Logic:
* Modified `network/ipam/main.tf` to dynamically compute principals for sharing IPAM pools based on either specific OU names or account IDs, improving flexibility in access control.
* Replaced the hardcoded `ipam_platform_principals` variable with logic that derives principals from organizational units or account IDs, simplifying configuration.

### New Variables for Granular Control:
* Introduced `platform_pool_sharing_ou_names` and `capabilities_pool_sharing_ou_names` variables in `network/ipam/vars.tf` to allow specifying OUs for sharing platform and capabilities IPAM pools, respectively.

## Checklist before requesting a review
- [x] I have tested changes locally with pre-prime
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
