### PR TITLE
fix: pin ebs csi driver in qa and manage with renovate

### DIFF
--- a/test/integration/eu-west-1/k8s-qa/cluster/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/cluster/terragrunt.hcl
@@ -36,6 +36,8 @@ inputs = {
   eks_addon_kubeproxy_version_override = "v1.33.0-eksbuild.2"
   # renovate: eksAddonsFilter={"kubernetesVersion":"1.33","addonName":"aws-efs-csi-driver"}
   eks_addon_awsefscsidriver_version_override = "v2.1.9-eksbuild.1"
+  # renovate: eksAddonsFilter={"kubernetesVersion":"1.33","addonName":"aws-ebs-csi-driver"}
+  eks_addon_awsebscsidriver_version_override = "v1.45.0-eksbuild.2"
 
   enable_worker_nat_gateway                  = true
   use_worker_nat_gateway                     = true


### PR DESCRIPTION
## Describe your changes
Pins EBS CSI Driver version in QA and adds renovate filter for it

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
