### PR TITLE
fix: update resource association for_each to use index mapping

### DIFF
--- a/network/ipam/vars.tf
+++ b/network/ipam/vars.tf
@@ -39,9 +39,8 @@ variable "ipam_pools_cascade" {
 
 variable "ipam_pools" {
   type = map(object({
-    cidr           = string
-    address_family = optional(string, "ipv4")
-    locale         = optional(string, null)
+    cidr             = string
+    sharing_ou_names = optional(list(string), [])
     sub_pools = optional(map(object({
       cidr = string
     })), {})
@@ -57,6 +56,7 @@ variable "ipam_pools" {
       }
       "platform" = {
         cidr = "192.168.0.0/15"
+        sharing_ou_names = ["Platform OU", "Infrastructure OU"]
         sub_pools = {
           "us-east-1" = {
             cidr = "192.168.0.0/17"
@@ -79,34 +79,6 @@ variable "ipam_prefix" {
 variable "ipam_ou_id" {
   type        = string
   description = "The ID of the AWS Organization OU that you want to query for accounts. This is used for sharing access to the IPAM pools."
-}
-
-variable "ipam_role_patterns" {
-  type        = list(string)
-  description = <<EOF
-    The pattern of a role ARNs that are1 allowed to request IP addresses from the IPAM pools.
-    The %s placeholders will be replaced with the AWS account ID from accounts under
-    the OU specified by var.ipam_ou_id.
-EOF
-  default     = ["arn:aws:iam::%s:role/aws-service-role/ipam.amazonaws.com/AWSServiceRoleForIPAM"]
-}
-
-variable "platform_pool_sharing_ou_names" {
-  type        = list(string)
-  description = "A list of OU names that should be granted access to the platform IPAM pools."
-  default     = []
-}
-
-variable "capabilities_pool_sharing_ou_names" {
-  type        = list(string)
-  description = "A list of OU names that should be granted access to the capabilities IPAM pools."
-  default     = []
-}
-
-variable "reserve_pool_sharing_ou_names" {
-  type        = list(string)
-  description = "A list of OU names that should be granted access to the reserve IPAM pools."
-  default     = []
 }
 
 variable "tags" {


### PR DESCRIPTION
## Describe your changes

### BREAKING CHANGE

- The `network/ipam` module has breaking changes, which means that `terraform/terragrunt/tofu import` should be run prior to `apply` in order to migrate the ipam configuration to the new standard.

This pull request refactors the IPAM pool Terraform configuration to make it more generic, scalable, and easier to manage. The changes consolidate repeated module definitions into dynamic, data-driven constructs, and move sharing configuration into the main `ipam_pools` variable for improved flexibility. The most important changes are grouped below:

### Refactoring and Generalization of Pool Modules

* Replaced multiple hardcoded pool modules (`platform_pool`, `capabilities_pool`, `reserve_pool`) with a single dynamic `sub_pools` module using `for_each` over `ipam_pools`, allowing any number of pools except "main" to be defined in the input variable.
* Consolidated regional pool modules into a single `regional_pools` module, dynamically generating regional pools for any pool type with sub-pools, instead of separate modules for each pool type.

### Simplification and Unification of Resource Sharing

* Unified RAM sharing modules into a single dynamic `ram_share` module, which creates a resource share for each pool type based on the new `sharing_ou_names` property in `ipam_pools`. This replaces the previous separate modules and local variables for sharing principals.

### Variable and Data Structure Changes

* Added a `sharing_ou_names` property to each pool object in the `ipam_pools` variable, allowing sharing configuration to be specified alongside pool definitions. [[1]](diffhunk://#diff-b6b5032784caba9f359f6af2a89bebbfbe181771a56f10067e1628a1412542afL43-R43) [[2]](diffhunk://#diff-b6b5032784caba9f359f6af2a89bebbfbe181771a56f10067e1628a1412542afR59)
* Removed now-unnecessary variables related to sharing (such as `platform_pool_sharing_ou_names`, `capabilities_pool_sharing_ou_names`, `reserve_pool_sharing_ou_names`, and `ipam_role_patterns`), since sharing configuration is now handled directly within `ipam_pools`.

## Checklist before requesting a review
- [x] I have tested changes towards our pre-prime pipeline's AWS IPAM instance.
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
