### PR TITLE
Harden coreDNS setup before HPA and NA rollout by implementing HPA (2-5 replicas) on coreDNS

### DIFF
--- a/_sub/compute/eks-addons/main.tf
+++ b/_sub/compute/eks-addons/main.tf
@@ -15,6 +15,13 @@ resource "aws_eks_addon" "coredns" {
   cluster_name                = var.cluster_name
   addon_name                  = "coredns"
   addon_version               = local.coredns_version
+  configuration_values = jsonencode({
+    autoScaling = {
+      enabled = true
+      minReplicas = 2
+      maxReplicas = 5
+    }
+  })
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "OVERWRITE"
 }


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
Enable HPA for coreDNS accordign to AWS EKS recomendations. This will allow coreDNS to scale from the current 2 up to maximum 5. Since we do not have node autoscaling I'm leaving maximum at 5, but we had it at 10 in Veo. Lameduck and readinessProbe is already set in the corednsfile see `kubectl get cm -n kube-system coredns -oyaml | yq .data.Corefile`:

```
.:53 {
    errors
    health {
        lameduck 5s
      }
    ready
    kubernetes cluster.local in-addr.arpa ip6.arpa {
      pods insecure
      fallthrough in-addr.arpa ip6.arpa
    }
    prometheus :9153
    forward . /etc/resolv.conf
    cache 30
    loop
    reload
    loadbalance
}
```

## Issue ticket number and link
<!--#issue number here -->
https://dev.azure.com/dfds/Cloud%20Engineering%20Team/_workitems/edit/555904

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
