### PR TITLE
feat(external-secrets): add helm chart version input and update custom hook for ESO installation

### DIFF
--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -245,6 +245,7 @@ inputs = {
   # --------------------------------------------------
 
   external_secrets_deploy = true
+  external_secrets_helm_chart_version = "0.19.2"
 
   # --------------------------------------------------
   # External Secrets with SSM

--- a/test/integration/hooks/custom_hook_01.sh
+++ b/test/integration/hooks/custom_hook_01.sh
@@ -19,7 +19,7 @@ echo "KUBECONFIG=${KUBECONFIG}"
 
 cd "${PARENT_DIR}/eu-west-1/k8s-qa/services" || return
 
-# Check if namespace exists
+# Check if Grafana namespace exists
 NS=$(kubectl get namespace --no-headers | grep -w grafana | wc -l | tr -d ' ')
 if [[ ${NS} -eq 1 ]]; then
 	PVC=$(kubectl get pvc -n grafana --no-headers | wc -l | tr -d ' ')
@@ -33,7 +33,18 @@ if [[ ${NS} -eq 1 ]]; then
 	fi
 fi
 
+# Check if ESO is installed
+ESO=$(kubectl get helmrelease -n external-secrets -o custom-columns=VERSION:.spec.chart.spec.version --no-headers | wc -l | tr -d ' ')
+if [[ ${ESO} -eq 1 ]]; then
+	# Find desired helm chart version
+	HELMRELEASE=$(grep external_secrets_helm_chart_version terragrunt.hcl | cut -d '"' -f2)
+	if [[ "x${HELMRELEASE}x" != "xx" ]]; then
+		echo "Applying/Upgrading CRDs for ESO"
+		kubectl apply --server-side -f https://raw.githubusercontent.com/external-secrets/external-secrets/refs/tags/v${HELMRELEASE}/deploy/crds/bundle.yaml
+	fi
+fi
+
 TENANT_NS=$(kubectl get namespace --no-headers | grep -w flux-tenant-test | wc -l | tr -d ' ')
 if [[ ${TENANT_NS} -eq 0 ]]; then
-  kubectl create namespace flux-tenant-test
+	kubectl create namespace flux-tenant-test
 fi


### PR DESCRIPTION
## Describe your changes

This pull request introduces updates to the deployment process for External Secrets Operator (ESO) and improves the custom integration hook script. The main changes focus on specifying the ESO Helm chart version and ensuring the correct Custom Resource Definitions (CRDs) are applied or upgraded during integration tests.

**External Secrets Operator deployment improvements:**

* Added the `external_secrets_helm_chart_version` input to the `terragrunt.hcl` configuration to specify the ESO Helm chart version.
* Updated the custom hook script to check if ESO is installed and, if so, automatically apply or upgrade the ESO CRDs using the version defined in `terragrunt.hcl`.

**Script clarity and robustness:**

* Clarified the namespace check in `custom_hook_01.sh` to specifically reference the Grafana namespace.

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
