### PR TITLE
Add QA pipeline workflow for testing and provisioning

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,0 +1,192 @@
+name: QA Pipeline
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches: [master]
+    paths-ignore:
+      - ".github/workflows/*"
+      - ".trunk/*"
+      - .gitignore
+      - .pre-commit-config.yaml
+      - .tflint.hcl
+      - LICENSE
+      - README.md
+      - renovate.json
+
+  workflow_dispatch:
+
+env:
+  AWS_DEFAULT_REGION: eu-west-1
+  TF_IN_AUTOMATION: "true"
+  TG_TF_PATH: /usr/local/bin/tofu
+
+jobs:
+  build_test_master:
+    name: Build test binary from master branch
+    runs-on: ubuntu-latest
+    container:
+      image: golang:1.24.6-bullseye
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          repository: dfds/infrastructure-modules
+          ref: master
+      - name: Restore Go build cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.cache/go-build/
+          key: go-${{ runner.os }}-${{ hashFiles('test/integration/suite/go.sum', 'src/qa-test-eks.sh') }}
+      - name: Build test binary
+        run: ./src/qa-test-eks.sh test-build eu-west-1 qa ${{ github.workspace }}/test-master.bin
+        env:
+          GOCACHE: ${{ github.workspace }}/.cache/go-build/
+      - name: Upload test binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-master
+          path: ${{ github.workspace }}/test-master.bin
+
+  build_test_feature:
+    name: Build test binary from feature branch
+    runs-on: ubuntu-latest
+    container:
+      image: golang:1.24.6-bullseye
+    if: github.ref != 'refs/heads/master'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Restore Go build cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.cache/go-build/
+          key: go-${{ runner.os }}-${{ hashFiles('test/integration/suite/go.sum', 'src/qa-test-eks.sh') }}
+      - name: Build test binary
+        run: ./src/qa-test-eks.sh test-build eu-west-1 qa ${{ github.workspace }}/test-feature.bin
+        env:
+          GOCACHE: ${{ github.workspace }}/.cache/go-build/
+      - name: Upload test binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-feature
+          path: ${{ github.workspace }}/test-feature.bin
+
+  apply_test_master:
+    name: Provision from master branch
+    runs-on: ubuntu-latest
+    needs: build_test_master
+    container:
+      image: dfdsdk/prime-pipeline:2.2.1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          repository: dfds/infrastructure-modules
+          ref: master
+
+      - name: Load secrets
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_GITHUB_TOKEN }}
+          ARM_CLIENT_ID: op://CloudEng-General/Terraform Azure App Service Principal/username
+          ARM_CLIENT_SECRET: op://CloudEng-General/Terraform Azure App Service Principal/password
+          ARM_SUBSCRIPTION_ID: op://CloudEng-General/Terraform Azure App Service Principal/subscription_id
+          ARM_TENANT_ID: op://CloudEng-General/Terraform Azure App Service Principal/tenant_id
+          AWS_ACCESS_KEY_ID: op://CloudEng-General/AWS account dfds-qa IAM user terratest-qa-user/username
+          AWS_SECRET_ACCESS_KEY: op://CloudEng-General/AWS account dfds-qa IAM user terratest-qa-user/password
+          TF_VAR_atlantis_github_token: op://CloudEng-General/Github account devex-sa/Tokens/atlantis-qa
+          TF_VAR_docker_hub_password: op://CloudEng-General/Docker Cloud/username
+          TF_VAR_docker_hub_username: op://CloudEng-General/Docker Cloud/password
+          TF_VAR_eks_addon_awsebscsidriver_kms_arn: op://CloudEng-General/Hardened Account EBS Volume Shared KMS Key/arn
+          TF_VAR_fluxcd_bootstrap_repo_owner_token: op://CloudEng-General/Github account devex-sa/Tokens/flux-qa
+          TF_VAR_grafana_agent_api_token: op://CloudEng-General/Grafana.com - sandbox/grafana_token
+          TF_VAR_grafana_agent_loki_url: op://CloudEng-General/Grafana.com - sandbox/Loki_URL
+          TF_VAR_grafana_agent_loki_username: op://CloudEng-General/Grafana.com - sandbox/Loki_Username
+          TF_VAR_grafana_agent_prometheus_url: op://CloudEng-General/Grafana.com - sandbox/Prometheus_URL
+          TF_VAR_grafana_agent_prometheus_username: op://CloudEng-General/Grafana.com - sandbox/Prometheus_Username
+          TF_VAR_grafana_agent_tempo_url: op://CloudEng-General/Grafana.com - sandbox/Tempo_URL
+          TF_VAR_grafana_agent_tempo_username: op://CloudEng-General/Grafana.com - sandbox/Tempo_Username
+          TF_VAR_onepassword_credentials_json: op://CloudEng-General/1Password Connect/nonprod_json
+          TF_VAR_onepassword_token_for_atlantis: op://CloudEng-General/1Password Connect/nonprod_atlantis_token
+          TF_VAR_velero_ebs_csi_kms_arn: op://CloudEng-General/Hardened Account EBS Volume Shared KMS Key/arn
+
+      - name: Provision shared EKS S3 bucket
+        run: ./src/qa-test-eks.sh apply-shared _global/eks-public-s3-bucket
+      - name: Provision cluster & services
+        run: ./src/qa-test-eks.sh apply-cluster eu-west-1 qa
+      - name: Provision Velero S3 bucket
+        run: ./src/qa-test-eks.sh apply-shared _global/s3-bucket-velero
+      - name: Wait for managed node groups to become active
+        run: ./wait-for-ngs.sh qa
+      - name: Wait for auto scaling groups's instances to be in service
+        run: ./wait-for-asgs.sh qa
+      - name: Download test binary
+        uses: actions/download-artifact@v4
+        with:
+          name: test-master
+      - name: Run tests
+        run: ./src/qa-test-eks.sh test-run eu-west-1 qa ${{ github.workspace }}/test-master/test-master.bin
+
+  apply_test_feature:
+    name: Apply from feature branch
+    runs-on: ubuntu-latest
+    needs: [apply_test_master, build_test_feature]
+    if: github.ref != 'refs/heads/master'
+    container:
+      image: dfdsdk/prime-pipeline:2.2.1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Load secrets
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_GITHUB_TOKEN }}
+          ARM_CLIENT_ID: op://CloudEng-General/Terraform Azure App Service Principal/username
+          ARM_CLIENT_SECRET: op://CloudEng-General/Terraform Azure App Service Principal/password
+          ARM_SUBSCRIPTION_ID: op://CloudEng-General/Terraform Azure App Service Principal/subscription_id
+          ARM_TENANT_ID: op://CloudEng-General/Terraform Azure App Service Principal/tenant_id
+          AWS_ACCESS_KEY_ID: op://CloudEng-General/AWS account dfds-qa IAM user terratest-qa-user/username
+          AWS_SECRET_ACCESS_KEY: op://CloudEng-General/AWS account dfds-qa IAM user terratest-qa-user/password
+          TF_VAR_atlantis_github_token: op://CloudEng-General/Github account devex-sa/Tokens/atlantis-qa
+          TF_VAR_docker_hub_password: op://CloudEng-General/Docker Cloud/username
+          TF_VAR_docker_hub_username: op://CloudEng-General/Docker Cloud/password
+          TF_VAR_eks_addon_awsebscsidriver_kms_arn: op://CloudEng-General/Hardened Account EBS Volume Shared KMS Key/arn
+          TF_VAR_fluxcd_bootstrap_repo_owner_token: op://CloudEng-General/Github account devex-sa/Tokens/flux-qa
+          TF_VAR_grafana_agent_api_token: op://CloudEng-General/Grafana.com - sandbox/grafana_token
+          TF_VAR_grafana_agent_loki_url: op://CloudEng-General/Grafana.com - sandbox/Loki_URL
+          TF_VAR_grafana_agent_loki_username: op://CloudEng-General/Grafana.com - sandbox/Loki_Username
+          TF_VAR_grafana_agent_prometheus_url: op://CloudEng-General/Grafana.com - sandbox/Prometheus_URL
+          TF_VAR_grafana_agent_prometheus_username: op://CloudEng-General/Grafana.com - sandbox/Prometheus_Username
+          TF_VAR_grafana_agent_tempo_url: op://CloudEng-General/Grafana.com - sandbox/Tempo_URL
+          TF_VAR_grafana_agent_tempo_username: op://CloudEng-General/Grafana.com - sandbox/Tempo_Username
+          TF_VAR_onepassword_credentials_json: op://CloudEng-General/1Password Connect/nonprod_json
+          TF_VAR_onepassword_token_for_atlantis: op://CloudEng-General/1Password Connect/nonprod_atlantis_token
+          TF_VAR_velero_ebs_csi_kms_arn: op://CloudEng-General/Hardened Account EBS Volume Shared KMS Key/arn
+
+      - name: Provision shared EKS S3 bucket
+        run: ./src/qa-test-eks.sh apply-shared _global/eks-public-s3-bucket
+      - name: Provision cluster & services
+        run: ./src/qa-test-eks.sh apply-cluster eu-west-1 qa
+      - name: Provision Velero S3 bucket
+        run: ./src/qa-test-eks.sh apply-shared _global/s3-bucket-velero
+      - name: Wait for managed node groups to become active
+        run: ./wait-for-ngs.sh qa
+      - name: Wait for auto scaling groups's instances to be in service
+        run: ./wait-for-asgs.sh qa
+      - name: Download test binary
+        uses: actions/download-artifact@v4
+        with:
+          name: test-feature
+      - name: Run tests
+        run: ./src/qa-test-eks.sh test-run eu-west-1 qa ${{ github.workspace }}/test-feature/test-feature.bin


### PR DESCRIPTION
## Describe your changes

This pull request introduces a new GitHub Actions workflow for automated QA testing and provisioning in the repository. The workflow builds and tests binaries for both the master and feature branches, provisions infrastructure using secrets from 1Password, and runs integration tests on provisioned environments.

### CI/CD and QA Automation

* Added a new workflow file `.github/workflows/qa.yml` that automates building, provisioning, and testing for both master and feature branches using GitHub Actions.

### Build and Test Binaries

* Configured jobs to build test binaries for master and feature branches in isolated containers, leveraging Go build cache for faster builds.
* Uploaded built test binaries as artifacts for use in downstream jobs.

### Infrastructure Provisioning

* Added jobs to provision infrastructure (EKS clusters, S3 buckets, Velero) using custom scripts (`qa-test-eks.sh`) and a dedicated container image.
* Integrated 1Password secrets loading for secure access to cloud credentials and tokens required for provisioning.

### Test Execution

* Implemented steps to wait for infrastructure readiness (node groups, auto scaling groups) before running integration tests with the built binaries.

This workflow ensures that new changes are automatically tested in a realistic environment, improving reliability and reducing manual effort in the QA process.


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
