### PR TITLE
fix: correct format in OIDC role assumption condition

### DIFF
--- a/_sub/security/iam-github-oidc-provider/main.tf
+++ b/_sub/security/iam-github-oidc-provider/main.tf
@@ -27,7 +27,7 @@ data "aws_iam_policy_document" "trust" {
     }
     condition {
       test     = "StringLike"
-      values   = flatten([for k, v in { for repo in var.repositories : repo.repository_name => repo.refs } : formatlist("repo:%s:ref:%s", k, v)])
+      values   = flatten([for k, v in { for repo in var.repositories : repo.repository_name => repo.refs } : formatlist("repo:%s:%s", k, v)])
       variable = "token.actions.githubusercontent.com:sub"
     }
   }


### PR DESCRIPTION
## Describe your changes

BREAKING CHANGE:
Users of GitHub OIDC integration needs to update their branch filers since 'ref:' is no longer added to the string. This is to ensure better compability with wildcard branch patterns.

This pull request makes a small adjustment to the trust policy document for the GitHub OIDC provider in the IAM configuration. The change updates the format of the values used in the `StringLike` condition to ensure correct matching of repository references.

* Changed the format string in the `values` field from `"repo:%s:ref:%s"` to `"repo:%s:%s"` in the `aws_iam_policy_document` data block, simplifying how repository references are specified for OIDC authentication.

## Checklist before requesting a review
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
