### PR TITLE
refactor: remove validation for repository refs in OIDC variables

### DIFF
--- a/_sub/security/iam-github-oidc-provider/vars.tf
+++ b/_sub/security/iam-github-oidc-provider/vars.tf
@@ -4,10 +4,6 @@ variable "repositories" {
     refs            = list(string)
   }))
   description = "List of repositories to authenticate to AWS from. Each object contains repository name and list of git refs that should be allowed to deploy from"
-  validation {
-    condition     = alltrue([for v in flatten(values({ for repo in var.repositories : repo.repository_name => repo.refs })) : startswith(v, "refs/heads/") || startswith(v, "refs/tags/")])
-    error_message = "The ref needs to start with `refs/heads/` for branches and `refs/tags/` for tags."
-  }
 }
 
 variable "oidc_role_access" {

--- a/security/oidc-github-workflows/vars.tf
+++ b/security/oidc-github-workflows/vars.tf
@@ -5,10 +5,6 @@ variable "iam_github_oidc_repositories" {
   }))
   default     = []
   description = "List of repositories to authenticate to AWS from. Each object contains repository name and list of git refs that should be allowed to deploy from"
-  validation {
-    condition     = alltrue([for v in flatten(values({ for repo in var.iam_github_oidc_repositories : repo.repository_name => repo.refs })) : startswith(v, "refs/heads/") || startswith(v, "refs/tags/")])
-    error_message = "The ref needs to start with `refs/heads/` for branches and `refs/tags/` for tags."
-  }
 }
 
 variable "iam_github_oidc_policy_json" {

--- a/security/org-account/vars.tf
+++ b/security/org-account/vars.tf
@@ -71,10 +71,6 @@ variable "iam_github_oidc_repositories" {
   }))
   default     = []
   description = "List of repositories to authenticate to AWS from. Each object contains repository name and list of git refs that should be allowed to deploy from"
-  validation {
-    condition     = alltrue([for v in flatten(values({ for repo in var.iam_github_oidc_repositories : repo.repository_name => repo.refs })) : startswith(v, "refs/heads/") || startswith(v, "refs/tags/")])
-    error_message = "The ref needs to start with `refs/heads/` for branches and `refs/tags/` for tags."
-  }
 }
 
 variable "iam_github_oidc_policy_json" {


### PR DESCRIPTION
## Describe your changes

This pull request removes the validation blocks from several Terraform variable definitions that previously enforced git ref formatting for repositories used in GitHub OIDC authentication. The main impact is that Terraform will no longer check that refs start with `refs/heads/` or `refs/tags/` for these variables, potentially allowing more flexible (but less strictly validated) input.

Validation removal for repository ref inputs:

* [`_sub/security/iam-github-oidc-provider/vars.tf`](diffhunk://#diff-74a62e9af9cb0c765f31f5ca7b42297b4dfdcb781e213d87084857ab28f4e571L7-L10): Removed the validation block from the `repositories` variable, so refs are no longer checked to start with `refs/heads/` or `refs/tags/`.
* [`security/oidc-github-workflows/vars.tf`](diffhunk://#diff-af1f9eb267b38882717adce01b1cf373c7ef47bc17491dd4f07e7d6d96bdf381L8-L11): Removed the validation block from the `iam_github_oidc_repositories` variable, allowing refs without strict prefix validation.
* [`security/org-account/vars.tf`](diffhunk://#diff-c389c579709e488bcf5f92ad94bfde6cc71fa11e1a63dd7ad7170f7754e5fa50L74-L77): Removed the validation block from the `iam_github_oidc_repositories` variable, similarly relaxing ref format requirements.

## Checklist before requesting a review
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
