### PR TITLE
fix: correct provider source for archive in versions.tf and versions.tofu

### DIFF
--- a/_sub/compute/lambda/lambda-from-archive/versions.tf
+++ b/_sub/compute/lambda/lambda-from-archive/versions.tf
@@ -7,7 +7,7 @@ terraform {
       version = "~> 5.100.0"
     }
     archive = {
-      source  = "hashicorp/archive-file"
+      source  = "hashicorp/archive"
       version = "~> 2.7.1"
     }
   }

--- a/_sub/compute/lambda/lambda-from-archive/versions.tofu
+++ b/_sub/compute/lambda/lambda-from-archive/versions.tofu
@@ -7,7 +7,7 @@ terraform {
       version = "~> 5.100.0"
     }
     archive = {
-      source  = "hashicorp/archive-file"
+      source  = "hashicorp/archive"
       version = "~> 2.7.1"
     }
   }


### PR DESCRIPTION
## Describe your changes

This pull request updates the Terraform provider configuration for the Lambda from Archive module, specifically changing the archive provider source to use the correct name. This ensures compatibility and proper provider usage in both Terraform and OpenTofu configurations.

Provider configuration updates:

* Changed the archive provider source from `hashicorp/archive-file` to `hashicorp/archive` in `_sub/compute/lambda/lambda-from-archive/versions.tf` to use the correct provider name.
* Made the same provider source change in `_sub/compute/lambda/lambda-from-archive/versions.tofu` for consistency with OpenTofu.

## Checklist before requesting a review
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
