### PR TITLE
Exposed 1password-connect helm chart version as variable to enable locking

### DIFF
--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -746,6 +746,7 @@ module "onepassword_connect" {
   aws_region              = local.aws_region
   credentials_json        = var.onepassword_credentials_json
   token_for_atlantis      = var.onepassword_token_for_atlantis
+  chart_version           = var.onepassword_connect_chart_version
 
   providers = {
     github = github.fluxcd

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -946,6 +946,12 @@ variable "onepassword_token_for_atlantis" {
   description = "The 1Password Connect tokens to be stored in SSM if Atlantis is enabled"
 }
 
+variable "onepassword_connect_chart_version" {
+  type        = string
+  default     = ""
+  description = "The 1Password Connect helm chart version"
+}
+
 # --------------------------------------------------
 # Nvidia device plugin
 # --------------------------------------------------


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
Helm chart version variable introduced but never exposed blocking version locking.

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
