### PR TITLE
chore: update Traefik helm chart version for blue and green variants to v37.0.0

### DIFF
--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -53,7 +53,7 @@ inputs = {
   # Blue variant
   traefik_blue_variant_deploy             = true
   traefik_blue_variant_dashboard_deploy   = true
-  traefik_blue_variant_helm_chart_version = "35.4.0"
+  traefik_blue_variant_helm_chart_version = "37.0.0"
   traefik_blue_variant_additional_args = [
     "--metrics.prometheus",
     "--providers.kubernetescrd.allowCrossNamespace=true",
@@ -63,7 +63,7 @@ inputs = {
   # Green variant
   traefik_green_variant_deploy             = false
   traefik_green_variant_dashboard_deploy   = false
-  traefik_green_variant_helm_chart_version = "35.4.0"
+  traefik_green_variant_helm_chart_version = "37.0.0"
   traefik_green_variant_additional_args = [
     "--metrics.prometheus",
     "--providers.kubernetescrd.allowCrossNamespace=true",


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
