### PR TITLE
Implement livenessprobe for nginx-test pod and use Status.NumberReady instead of Available

### DIFF
--- a/test/integration/suite/traefik_test.go
+++ b/test/integration/suite/traefik_test.go
@@ -66,6 +66,16 @@ func TestTraefikIngressRouteAndMiddleware(t *testing.T) {
 						{
 							Name:  "nginx",
 							Image: "nginx",
+							LivenessProbe: &apiv1.Probe{
+								ProbeHandler: apiv1.ProbeHandler{
+									HTTPGet: &apiv1.HTTPGetAction{
+										Port: intstr.IntOrString{IntVal: 80},
+										Path: "/",
+									},
+								},
+								InitialDelaySeconds: 3,
+								PeriodSeconds:       3,
+							},
 						},
 					},
 				},
@@ -89,7 +99,7 @@ func TestTraefikIngressRouteAndMiddleware(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: apiv1.ServiceSpec{
-			Ports: []apiv1.ServicePort{apiv1.ServicePort{
+			Ports: []apiv1.ServicePort{{
 				Name:       "web",
 				Port:       int32(80),
 				TargetPort: intstr.IntOrString{IntVal: int32(80)},

--- a/test/integration/suite/util_k8s_test.go
+++ b/test/integration/suite/util_k8s_test.go
@@ -83,7 +83,7 @@ func SetK8sAnnotation(gvr schema.GroupVersionResource, namespace, name, key, val
 	return nil
 }
 
-func AssertK8sDaemonSet(t *testing.T, clientset *kubernetes.Clientset, namespace, name string, numberAvailable int) {
+func AssertK8sDaemonSet(t *testing.T, clientset *kubernetes.Clientset, namespace, name string, numberReady int) {
 	check := func() bool {
 		resp, err := clientset.AppsV1().DaemonSets(namespace).Get(
 			context.Background(), name, metav1.GetOptions{})
@@ -93,9 +93,9 @@ func AssertK8sDaemonSet(t *testing.T, clientset *kubernetes.Clientset, namespace
 		}
 
 		// Assertions
-		if int(resp.Status.NumberAvailable) != numberAvailable {
-			t.Logf("expecting number available pods to be %d, found %d",
-				numberAvailable, resp.Status.NumberAvailable)
+		if int(resp.Status.NumberReady) != numberReady {
+			t.Logf("expecting number ready pods to be %d, found %d",
+				numberReady, resp.Status.NumberReady)
 			return false
 		}
 		return true
@@ -103,10 +103,10 @@ func AssertK8sDaemonSet(t *testing.T, clientset *kubernetes.Clientset, namespace
 
 	assert.Eventuallyf(t, check, defaultEventualTimeout, defaultEventualPeriod,
 		"daemonset %q in namespace %q and %d available pods not found",
-		name, namespace, numberAvailable)
+		name, namespace, numberReady)
 }
 
-func AssertK8sDeployment(t *testing.T, clientset *kubernetes.Clientset, namespace, name string, numberAvailable int) {
+func AssertK8sDeployment(t *testing.T, clientset *kubernetes.Clientset, namespace, name string, numberReady int) {
 	check := func() bool {
 		resp, err := clientset.AppsV1().Deployments(namespace).Get(
 			context.Background(), name, metav1.GetOptions{})
@@ -116,20 +116,20 @@ func AssertK8sDeployment(t *testing.T, clientset *kubernetes.Clientset, namespac
 		}
 
 		// Assertions
-		if int(resp.Status.AvailableReplicas) != numberAvailable {
-			t.Logf("expecting number of available replicas to be %d, found %d",
-				numberAvailable, resp.Status.AvailableReplicas)
+		if int(resp.Status.ReadyReplicas) != numberReady {
+			t.Logf("expecting number of ready replicas to be %d, found %d",
+				numberReady, resp.Status.ReadyReplicas)
 			return false
 		}
 		return true
 	}
 
 	assert.Eventuallyf(t, check, defaultEventualTimeout, defaultEventualPeriod,
-		"deployment %q in namespace %q and %d available replicas not found",
-		name, namespace, numberAvailable)
+		"deployment %q in namespace %q and %d ready replicas not found",
+		name, namespace, numberReady)
 }
 
-func AssertK8sDeploymentWithScaling(t *testing.T, clientset *kubernetes.Clientset, namespace, name string, minNumberAvailable int) {
+func AssertK8sDeploymentWithScaling(t *testing.T, clientset *kubernetes.Clientset, namespace, name string, minNumberReady int) {
 	check := func() bool {
 		resp, err := clientset.AppsV1().Deployments(namespace).Get(
 			context.Background(), name, metav1.GetOptions{})
@@ -139,20 +139,20 @@ func AssertK8sDeploymentWithScaling(t *testing.T, clientset *kubernetes.Clientse
 		}
 
 		// Assertions
-		if int(resp.Status.AvailableReplicas) < minNumberAvailable {
-			t.Logf("expecting number of available replicas to be greater than or equal %d, found %d",
-				minNumberAvailable, resp.Status.AvailableReplicas)
+		if int(resp.Status.ReadyReplicas) < minNumberReady {
+			t.Logf("expecting number of ready replicas to be greater than or equal %d, found %d",
+				minNumberReady, resp.Status.ReadyReplicas)
 			return false
 		}
 		return true
 	}
 
 	assert.Eventuallyf(t, check, defaultEventualTimeout, defaultEventualPeriod,
-		"deployment %q in namespace %q and %d minimum available replicas not found",
-		name, namespace, minNumberAvailable)
+		"deployment %q in namespace %q and %d minimum ready replicas not found",
+		name, namespace, minNumberReady)
 }
 
-func AssertK8sStatefulSet(t *testing.T, clientset *kubernetes.Clientset, namespace, name string, numberAvailable int) {
+func AssertK8sStatefulSet(t *testing.T, clientset *kubernetes.Clientset, namespace, name string, numberReady int) {
 	check := func() bool {
 		resp, err := clientset.AppsV1().StatefulSets(namespace).Get(
 			context.Background(), name, metav1.GetOptions{})
@@ -162,17 +162,17 @@ func AssertK8sStatefulSet(t *testing.T, clientset *kubernetes.Clientset, namespa
 		}
 
 		// Assertions
-		if int(resp.Status.AvailableReplicas) != numberAvailable {
-			t.Logf("expecting number of available replicas to be %d, found %d",
-				numberAvailable, resp.Status.AvailableReplicas)
+		if int(resp.Status.ReadyReplicas) != numberReady {
+			t.Logf("expecting number of ready replicas to be %d, found %d",
+				numberReady, resp.Status.ReadyReplicas)
 			return false
 		}
 		return true
 	}
 
 	assert.Eventuallyf(t, check, defaultEventualTimeout, defaultEventualPeriod,
-		"stateful set %q in namespace %q and %d available replicas not found",
-		name, namespace, numberAvailable)
+		"stateful set %q in namespace %q and %d ready replicas not found",
+		name, namespace, numberReady)
 }
 
 func AssertK8sEvent(t *testing.T, clientset *kubernetes.Clientset, namespace,


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
Harden tests with  livenessprobe for nginx-test pod and use Status.NumberReady instead of Status.Available

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
