### PR TITLE
enable adding custom owners on azure AD besides from default owner

### DIFF
--- a/_sub/security/azure-app-registration/dependencies.tf
+++ b/_sub/security/azure-app-registration/dependencies.tf
@@ -13,4 +13,6 @@ locals {
   roles_ids = var.api_permissions != null ? [
     for role in var.api_permissions.roles : data.azuread_service_principal.msgraph.app_role_ids[role]
   ] : []
+
+  azuread_application_owner_ids = concat([data.azuread_client_config.current.object_id], var.additional_owner_ids)
 }

--- a/_sub/security/azure-app-registration/main.tf
+++ b/_sub/security/azure-app-registration/main.tf
@@ -1,7 +1,7 @@
 resource "azuread_application" "app" {
   display_name    = var.name
   identifier_uris = var.identifier_uris
-  owners          = [data.azuread_client_config.current.object_id]
+  owners          = local.azuread_application_owner_ids
 
   web {
     homepage_url  = var.homepage_url

--- a/_sub/security/azure-app-registration/vars.tf
+++ b/_sub/security/azure-app-registration/vars.tf
@@ -68,3 +68,9 @@ variable "groups_claim" {
     condition     = alltrue([for value in var.groups_claim : contains(["None", "SecurityGroup", "All", "DirectoryRole", "ApplicationGroup"], value)])
   }
 }
+
+variable "additional_owner_ids" {
+  description = "List of additional owner object ID for the Azure AD application"
+  type        = list(string)
+  default     = []
+}

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -81,12 +81,13 @@ module "traefik_alb_cert" {
 }
 
 module "traefik_alb_auth_appreg" {
-  source          = "../../_sub/security/azure-app-registration"
-  count           = var.traefik_alb_auth_deploy ? 1 : 0
-  name            = "Kubernetes EKS ${local.eks_fqdn} cluster"
-  identifier_uris = var.alb_az_app_registration_identifier_urls != null ? var.alb_az_app_registration_identifier_urls : ["https://${local.eks_fqdn}"]
-  homepage_url    = "https://${local.eks_fqdn}"
-  redirect_uris   = local.traefik_alb_auth_appreg_reply_urls
+  source                = "../../_sub/security/azure-app-registration"
+  count                 = var.traefik_alb_auth_deploy ? 1 : 0
+  name                  = "Kubernetes EKS ${local.eks_fqdn} cluster"
+  identifier_uris       = var.alb_az_app_registration_identifier_urls != null ? var.alb_az_app_registration_identifier_urls : ["https://${local.eks_fqdn}"]
+  homepage_url          = "https://${local.eks_fqdn}"
+  redirect_uris         = local.traefik_alb_auth_appreg_reply_urls
+  additional_owner_ids  = var.alb_az_app_registration_additional_owner_ids
 }
 
 module "traefik_alb_auth" {

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -119,6 +119,12 @@ variable "alb_az_app_registration_identifier_urls" {
   nullable = true
 }
 
+variable "alb_az_app_registration_additional_owner_ids" {
+  description = "List of additional owner object ID for the Azure AD application used by the Auth ALB"
+  type        = list(string)
+  default     = []
+}
+
 # --------------------------------------------------
 # Blaster
 # --------------------------------------------------


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
This pull request introduces support for specifying additional Azure AD application owners through a new variable, improving flexibility and maintainability for application registration ownership. The changes allow passing a list of owner object IDs in addition to the default owner, and propagate this option throughout the relevant modules and variables.

This enables managing AD app registration in sandbox environment to be able to for example to get notification on certificates expiration and renewal.

**Azure AD Application Ownership Enhancements:**

* Added a new variable `additional_owner_ids` in `_sub/security/azure-app-registration/vars.tf` to allow specifying extra owner object IDs for Azure AD applications.
* Updated the `locals` block in `_sub/security/azure-app-registration/dependencies.tf` to concatenate the current client object ID with any additional owner IDs, forming the complete list of owners.
* Changed the `owners` property in `_sub/security/azure-app-registration/main.tf` to use the new list of owner IDs from `local.azuread_application_owner_ids` instead of just the current client object ID.

**Module and Variable Propagation:**

* Added a new variable `alb_az_app_registration_additional_owner_ids` in `compute/k8s-services/vars.tf` to support passing additional owner IDs for the Auth ALB application registration.
* Updated the `traefik_alb_auth_appreg` module instantiation in `compute/k8s-services/main.tf` to pass the new `additional_owner_ids` variable to the submodule.
## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
