### PR TITLE
fix: update EKS managed nodegroup disk type from gp2 to gp3 as default

### DIFF
--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -330,7 +330,7 @@ module "eks_addons" {
 }
 
 module "k8s_priority_class" {
-  source         = "../../_sub/compute/k8s-priority-class"
+  source = "../../_sub/compute/k8s-priority-class"
 }
 
 module "param_kubeconfig_admin" {

--- a/compute/eks-ec2/vars.tf
+++ b/compute/eks-ec2/vars.tf
@@ -182,7 +182,7 @@ variable "eks_managed_nodegroups" {
     instance_types             = optional(list(string), ["t3.small"])
     use_spot_instances         = optional(bool, false)
     disk_size                  = optional(number, 128)
-    disk_type                  = optional(string, "gp2")
+    disk_type                  = optional(string, "gp3")
     desired_size_per_subnet    = optional(number, 0)
     gpu_ami                    = optional(bool, false)
     availability_zones         = optional(list(string), [])


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
