### PR TITLE
feat(security): add condition to deny actions for specific IAM role

### DIFF
--- a/security/org-policies/preventive.tf
+++ b/security/org-policies/preventive.tf
@@ -83,6 +83,12 @@ data "aws_iam_policy_document" "preventive" {
       "guardduty:UpdateThreatIntelSet",
     ]
     resources = ["*"]
+
+    condition {
+      test     = "StringNotLike"
+      variable = "aws:PrincipalArn"
+      values   = ["arn:aws:iam::*:role/OrgRole"]
+    }
   }
 
   statement {


### PR DESCRIPTION
## Describe your changes

This pull request introduces a security enhancement to the organization-wide preventive IAM policy by adding a condition to restrict certain GuardDuty actions. The change ensures that only roles matching a specific naming pattern are allowed to perform sensitive operations.

Security policy improvements:

* Added a `StringNotLike` condition to the `aws:PrincipalArn` variable in the `preventive` IAM policy document, restricting the listed GuardDuty actions to principals with ARNs matching `arn:aws:iam::*:role/OrgRole`.

## Checklist before requesting a review
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
