### PR TITLE
feat: add natgw support for vpc peerings

### DIFF
--- a/_sub/network/vpc-peering-requester/main.tf
+++ b/_sub/network/vpc-peering-requester/main.tf
@@ -20,8 +20,10 @@ resource "aws_vpc_ipam_preview_next_cidr" "this" {
 }
 
 locals {
-  subnets            = var.ipam_cidr_enable ? cidrsubnets(aws_vpc_ipam_preview_next_cidr.this[0].cidr, var.ipam_subnet_bits...) : []
+  subnets            = var.ipam_cidr_enable ? slice(cidrsubnets(aws_vpc_ipam_preview_next_cidr.this[0].cidr, concat(var.ipam_subnet_bits, var.ipam_subnet_bits_natgw)...), 0, (length(var.ipam_subnet_bits) + length(var.ipam_subnet_bits_natgw)) - length(var.ipam_subnet_bits_natgw)) : []
   availability_zones = slice(data.aws_availability_zones.available.names, 0, length(var.ipam_subnet_bits))
+  subnets_natgw = var.ipam_cidr_enable && var.nat_gw_enable ? slice(cidrsubnets(aws_vpc_ipam_preview_next_cidr.this[0].cidr, concat(var.ipam_subnet_bits, var.ipam_subnet_bits_natgw)...), length(var.ipam_subnet_bits), ((length(var.ipam_subnet_bits) + length(var.ipam_subnet_bits_natgw)))) : []
+  availability_zones_natgw = slice(data.aws_availability_zones.available.names, 0, length(var.ipam_subnet_bits_natgw))
 }
 
 resource "aws_vpc" "peering" {
@@ -68,6 +70,34 @@ resource "aws_subnet" "this" {
 
   tags = merge(var.tags, {
     Name = "peering-${element(local.availability_zones, count.index)}"
+  })
+}
+
+resource "aws_subnet" "this_natgw" {
+  count                   = var.ipam_cidr_enable && var.nat_gw_enable ? length(var.ipam_subnet_bits_natgw) : 0
+  vpc_id                  = aws_vpc.peering.id
+  map_public_ip_on_launch = var.map_public_ip_on_launch
+  cidr_block              = element(local.subnets_natgw, count.index)
+  availability_zone       = element(local.availability_zones_natgw, count.index)
+
+  tags = merge(var.tags, {
+    Name = "peering-natgw-${element(local.availability_zones_natgw, count.index)}"
+  })
+}
+
+resource "aws_nat_gateway" "natgw" {
+  count                   = var.ipam_cidr_enable && var.nat_gw_enable ? length(var.ipam_subnet_bits_natgw) : 0
+  allocation_id = aws_eip.natgw[count.index].id
+  subnet_id = aws_subnet.this_natgw[count.index].id
+}
+
+resource "aws_eip" "natgw" {
+  count = var.ipam_cidr_enable && var.nat_gw_enable ? length(var.ipam_subnet_bits_natgw) : 0
+
+  domain = "vpc"
+
+  tags = merge(var.tags, {
+    Name = "peering-natgw-${element(local.availability_zones_natgw, count.index)}"
   })
 }
 
@@ -360,7 +390,15 @@ resource "aws_vpc_peering_connection" "capability" {
 }
 
 resource "aws_route" "capability_to_shared" {
+  count = var.nat_gw_enable ? 0 : 1
   route_table_id            = aws_vpc.peering.main_route_table_id
+  destination_cidr_block    = var.peer_cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.capability.id
+}
+
+resource "aws_route" "capability_to_shared_natgw" {
+  count = var.nat_gw_enable && var.ipam_cidr_enable ? length(var.ipam_subnet_bits) : 0
+  route_table_id            = aws_route_table.standard[count.index].id
   destination_cidr_block    = var.peer_cidr_block
   vpc_peering_connection_id = aws_vpc_peering_connection.capability.id
 }
@@ -374,7 +412,54 @@ resource "aws_internet_gateway" "gw" {
 }
 
 resource "aws_route" "default" {
+  count = var.nat_gw_enable ? 0 : 1
   route_table_id         = aws_vpc.peering.main_route_table_id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.gw.id
+}
+
+# Route tables when using NAT Gateway
+resource "aws_route_table" "standard" {
+  count  = var.nat_gw_enable && var.ipam_cidr_enable ? length(var.ipam_subnet_bits) : 0
+  vpc_id = aws_vpc.peering.id
+
+  tags = merge(var.tags, {
+    Name = "peering-${element(local.availability_zones, count.index)}"
+  })
+}
+
+resource "aws_route_table_association" "standard" {
+  count  = var.nat_gw_enable && var.ipam_cidr_enable ? length(var.ipam_subnet_bits) : 0
+  subnet_id = aws_subnet.this[count.index].id
+  route_table_id = aws_route_table.standard[count.index].id
+}
+
+resource "aws_route_table" "natgw" {
+  count  = var.nat_gw_enable && var.ipam_cidr_enable ? length(var.ipam_subnet_bits_natgw) : 0
+  vpc_id = aws_vpc.peering.id
+
+  tags = merge(var.tags, {
+    Name = "natgw-${element(local.availability_zones_natgw, count.index)}"
+  })
+}
+
+resource "aws_route_table_association" "natgw" {
+  count  = var.nat_gw_enable && var.ipam_cidr_enable ? length(var.ipam_subnet_bits_natgw) : 0
+  subnet_id = aws_subnet.this_natgw[count.index].id
+  route_table_id = aws_route_table.natgw[count.index].id
+}
+
+# Default route for standard subnets when using NAT Gateway
+resource "aws_route" "standard" {
+  count = var.nat_gw_enable && var.ipam_cidr_enable ? length(var.ipam_subnet_bits) : 0
+  route_table_id         = aws_route_table.standard[count.index].id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id             = aws_nat_gateway.natgw[count.index].id
+}
+
+resource "aws_route" "natgw" {
+  count = var.nat_gw_enable && var.ipam_cidr_enable ? length(var.ipam_subnet_bits_natgw) : 0
+  route_table_id         = aws_route_table.natgw[count.index].id
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = aws_internet_gateway.gw.id
 }

--- a/_sub/network/vpc-peering-requester/vars.tf
+++ b/_sub/network/vpc-peering-requester/vars.tf
@@ -67,6 +67,11 @@ variable "ipam_pool" {
   description = "The ID of the IPAM pool when using AWS IPAM assignment."
 }
 
+variable "ipam_pool_natgw" {
+  type        = string
+  description = "The ID of the IPAM pool when using AWS IPAM assignment for NAT Gateway. Should not be set the same as ipam_pool."
+}
+
 variable "ipam_cidr_enable" {
   description = "Use IPAM for VPC peering connections"
   type        = bool
@@ -83,4 +88,16 @@ variable "ipam_subnet_bits" {
   description = "The number of bits to use for subnet calculations"
   type        = list(number)
   default     = [1, 1]
+}
+
+variable "ipam_subnet_bits_natgw" {
+  description = "The number of bits to use for subnet calculations with NAT Gateway"
+  type        = list(number)
+  default     = [1, 1]
+}
+
+variable "nat_gw_enable" {
+  description = "Enable NAT Gateway creation"
+  type        = bool
+  default     = false
 }

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -446,9 +446,12 @@ module "vpc_peering_capability_eu_west_1" {
   for_each                     = { for k, v in var.vpc_peering_settings_eu_west_1 : k => v if var.deploy_vpc_peering_eu_west_1 }
   regional_postfix             = var.deploy_vpc_peering_eu_west_1 && var.deploy_vpc_peering_eu_central_1 ? true : false
   ipam_pool                    = lookup(var.ipam_pools, "eu-west-1", "")
+  ipam_pool_natgw              = lookup(var.ipam_pools_natgw, "eu-west-1", "")
   ipam_cidr_enable             = each.value.ipam_cidr_enable
   ipam_cidr_prefix             = each.value.ipam_cidr_prefix
   ipam_subnet_bits             = each.value.ipam_subnet_bits
+  ipam_subnet_bits_natgw       = each.value.ipam_subnet_bits
+  nat_gw_enable                = each.value.nat_gw_enable
   cidr_block_vpc               = each.value.assigned_cidr_block_vpc
   cidr_block_subnet_a          = each.value.assigned_cidr_block_subnet_a
   cidr_block_subnet_b          = each.value.assigned_cidr_block_subnet_b
@@ -487,9 +490,12 @@ module "vpc_peering_capability_eu_central_1" {
   for_each                     = { for k, v in var.vpc_peering_settings_eu_central_1 : k => v if var.deploy_vpc_peering_eu_central_1 }
   regional_postfix             = var.deploy_vpc_peering_eu_west_1 && var.deploy_vpc_peering_eu_central_1 ? true : false
   ipam_pool                    = lookup(var.ipam_pools, "eu-central-1", "")
+  ipam_pool_natgw              = lookup(var.ipam_pools_natgw, "eu-central-1", "")
   ipam_cidr_enable             = each.value.ipam_cidr_enable
   ipam_cidr_prefix             = each.value.ipam_cidr_prefix
   ipam_subnet_bits             = each.value.ipam_subnet_bits
+  ipam_subnet_bits_natgw       = each.value.ipam_subnet_bits
+  nat_gw_enable                = each.value.nat_gw_enable
   cidr_block_vpc               = each.value.assigned_cidr_block_vpc
   cidr_block_subnet_a          = each.value.assigned_cidr_block_subnet_a
   cidr_block_subnet_b          = each.value.assigned_cidr_block_subnet_b

--- a/security/org-account-context/vars.tf
+++ b/security/org-account-context/vars.tf
@@ -333,6 +333,15 @@ variable "ipam_pools" {
   description = "The ID of the IPAM pool when using AWS IPAM assignment."
 }
 
+variable "ipam_pools_natgw" {
+  type = map(string)
+  default = {
+    "eu-west-1"    = ""
+    "eu-central-1" = ""
+  }
+  description = "The ID of the IPAM pool when using AWS IPAM assignment for NAT Gateway."
+}
+
 variable "vpc_peering_settings_eu_west_1" {
   type = map(object({
     peer_vpc_id                  = string
@@ -346,6 +355,8 @@ variable "vpc_peering_settings_eu_west_1" {
     ipam_cidr_enable             = optional(bool, false)
     ipam_cidr_prefix             = optional(string, "26")
     ipam_subnet_bits             = optional(list(number), [1, 1])
+    ipam_subnet_bits_natgw      = optional(list(number), [1, 1])
+    nat_gw_enable                = optional(bool, false)
   }))
   description = <<EOF
     Map containing two sets of values for VPC peering settings.
@@ -373,6 +384,8 @@ EOF
       ipam_cidr_enable             = false
       ipam_cidr_prefix             = "26"
       ipam_subnet_bits             = [1, 1]
+      ipam_subnet_bits_natgw      = [1, 1]
+      nat_gw_enable                = false
     }
   }
 }
@@ -390,6 +403,8 @@ variable "vpc_peering_settings_eu_central_1" {
     ipam_cidr_enable             = optional(bool, false)
     ipam_cidr_prefix             = optional(string, "26")
     ipam_subnet_bits             = optional(list(number), [1, 1])
+    ipam_subnet_bits_natgw      = optional(list(number), [1, 1])
+    nat_gw_enable                = optional(bool, false)
   }))
   description = <<EOF
   Map containing two sets of values for VPC peering settings.
@@ -417,6 +432,8 @@ EOF
       ipam_cidr_enable             = false
       ipam_cidr_prefix             = "26"
       ipam_subnet_bits             = [1, 1]
+      ipam_subnet_bits_natgw      = [1, 1]
+      nat_gw_enable                = false
     }
   }
 }


### PR DESCRIPTION
## Describe your changes
This PR will allow the addition of natgw in vpc peerings to allow outbound internet access. AWS VPC restrictions mean this cannot be achieved by simple routing

The change is not backwards compatible with existing VPC peerings due to the VPC cidr's and number of subnets used, so can only be applied to new peerings. 

Note that it is important that new peerings should be created with room to double the amount of subnets in the VPC so that the natgw feature can be toggled on if required on any peering. It is not recommended to be switched on by default to save cost.

To test this PR with NAT gateway, please use something along the lines of:

```
ipam_cidr_enable        = true
      ipam_cidr_prefix        = "24"
      ipam_subnet_bits        = [3, 3, 3]
      nat_gw_enable = true
      ipam_subnet_bits_nat_gw = [3, 3, 3]
```

`nat_gw_enable` can then be toggled on and off as desired

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
