### PR TITLE
Update AWS provider version constraints across multiple modules to exclude version 6.14.0

### DIFF
--- a/_sub/compute/atlantis/versions.tf
+++ b/_sub/compute/atlantis/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
     github = {
       source  = "integrations/github"

--- a/_sub/compute/ec2-keypair/versions.tf
+++ b/_sub/compute/ec2-keypair/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/compute/ecr-repo/versions.tf
+++ b/_sub/compute/ecr-repo/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/compute/efs-fs/versions.tf
+++ b/_sub/compute/efs-fs/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/compute/eks-addons/versions.tf
+++ b/_sub/compute/eks-addons/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/_sub/compute/eks-alb-auth/versions.tf
+++ b/_sub/compute/eks-alb-auth/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/compute/eks-alb/versions.tf
+++ b/_sub/compute/eks-alb/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/compute/eks-cluster/versions.tf
+++ b/_sub/compute/eks-cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/compute/eks-heptio/versions.tf
+++ b/_sub/compute/eks-heptio/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/_sub/compute/eks-inactivity-cleanup/versions.tf
+++ b/_sub/compute/eks-inactivity-cleanup/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 

--- a/_sub/compute/eks-nlb/versions.tf
+++ b/_sub/compute/eks-nlb/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/compute/eks-nodegroup-managed/versions.tf
+++ b/_sub/compute/eks-nodegroup-managed/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/compute/eks-workers/versions.tf
+++ b/_sub/compute/eks-workers/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/compute/elb-inactivity-cleanup/versions.tf
+++ b/_sub/compute/elb-inactivity-cleanup/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 

--- a/_sub/compute/k8s-blaster-namespace/versions.tf
+++ b/_sub/compute/k8s-blaster-namespace/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
     github = {
       source  = "integrations/github"

--- a/_sub/compute/k8s-subnet-exporter/versions.tf
+++ b/_sub/compute/k8s-subnet-exporter/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/_sub/compute/k8s-traefik-flux/versions.tf
+++ b/_sub/compute/k8s-traefik-flux/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
     github = {
       source  = "integrations/github"

--- a/_sub/compute/lambda/lambda-from-archive/versions.tf
+++ b/_sub/compute/lambda/lambda-from-archive/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/_sub/compute/lambda/run-lambda-permission/versions.tf
+++ b/_sub/compute/lambda/run-lambda-permission/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/database/postgres-restore/versions.tf
+++ b/_sub/database/postgres-restore/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/database/postgres/versions.tf
+++ b/_sub/database/postgres/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/examples/route53-zone/versions.tf
+++ b/_sub/examples/route53-zone/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/misc/budget-monthly/versions.tf
+++ b/_sub/misc/budget-monthly/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/monitoring/alarm-notifier/versions.tf
+++ b/_sub/monitoring/alarm-notifier/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/monitoring/aws-resource-explorer-metrics/versions.tf
+++ b/_sub/monitoring/aws-resource-explorer-metrics/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/monitoring/cloudwatch-alarms/alb-5XX/versions.tf
+++ b/_sub/monitoring/cloudwatch-alarms/alb-5XX/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/monitoring/cloudwatch-alarms/alb-targets-health/versions.tf
+++ b/_sub/monitoring/cloudwatch-alarms/alb-targets-health/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/network/acm-certificate-san/versions.tf
+++ b/_sub/network/acm-certificate-san/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/network/internet-gateway/versions.tf
+++ b/_sub/network/internet-gateway/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/network/ipam-pool-query/versions.tf
+++ b/_sub/network/ipam-pool-query/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/network/ipam-pool/versions.tf
+++ b/_sub/network/ipam-pool/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/network/ipam-scope/versions.tf
+++ b/_sub/network/ipam-scope/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/network/ipam/versions.tf
+++ b/_sub/network/ipam/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/network/nat-gateway/versions.tf
+++ b/_sub/network/nat-gateway/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/network/route-table-assoc/versions.tf
+++ b/_sub/network/route-table-assoc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/network/route-table/versions.tf
+++ b/_sub/network/route-table/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/network/route53-delegate-zone/versions.tf
+++ b/_sub/network/route53-delegate-zone/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/network/route53-record/versions.tf
+++ b/_sub/network/route53-record/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/network/route53-zone/versions.tf
+++ b/_sub/network/route53-zone/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/network/security-group-eks-node/versions.tf
+++ b/_sub/network/security-group-eks-node/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/network/vpc-flow-log/versions.tf
+++ b/_sub/network/vpc-flow-log/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/network/vpc-peering-accepter/versions.tf
+++ b/_sub/network/vpc-peering-accepter/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/network/vpc-peering-requester/versions.tf
+++ b/_sub/network/vpc-peering-requester/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/network/vpc-ssm/versions.tf
+++ b/_sub/network/vpc-ssm/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/network/vpc-subnet-eks/versions.tf
+++ b/_sub/network/vpc-subnet-eks/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/network/vpc-subnet/versions.tf
+++ b/_sub/network/vpc-subnet/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/network/vpc/versions.tf
+++ b/_sub/network/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/security/alternate-contact/versions.tf
+++ b/_sub/security/alternate-contact/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/_sub/security/aws-backup/versions.tf
+++ b/_sub/security/aws-backup/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/security/azure-app-registration/versions.tf
+++ b/_sub/security/azure-app-registration/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/_sub/security/cloudtrail-alarm/versions.tf
+++ b/_sub/security/cloudtrail-alarm/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/security/cloudtrail-config/versions.tf
+++ b/_sub/security/cloudtrail-config/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/security/config-config/versions.tf
+++ b/_sub/security/config-config/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/security/external-secrets-ssm/versions.tf
+++ b/_sub/security/external-secrets-ssm/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/security/grafana-cloud-cloudwatch-integration/versions.tf
+++ b/_sub/security/grafana-cloud-cloudwatch-integration/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/security/hardened-account/versions.tf
+++ b/_sub/security/hardened-account/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = "~> 6.14.0"
+      version               = "~> 6.0, != 6.14.0"
       configuration_aliases = [aws.workload, aws.workload_2, aws.sso]
     }
   }

--- a/_sub/security/helm-1password-connect/versions.tf
+++ b/_sub/security/helm-1password-connect/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/security/iam-account-alias/versions.tf
+++ b/_sub/security/iam-account-alias/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/security/iam-bucket-replication/versions.tf
+++ b/_sub/security/iam-bucket-replication/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/security/iam-identity-center-assignment/versions.tf
+++ b/_sub/security/iam-identity-center-assignment/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/security/iam-identity-center/versions.tf
+++ b/_sub/security/iam-identity-center/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/security/iam-oidc-provider/versions.tf
+++ b/_sub/security/iam-oidc-provider/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/_sub/security/iam-policies/versions.tf
+++ b/_sub/security/iam-policies/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/security/iam-role/versions.tf
+++ b/_sub/security/iam-role/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/security/iam-user/versions.tf
+++ b/_sub/security/iam-user/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/security/kms-key/versions.tf
+++ b/_sub/security/kms-key/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/security/org-account-query/versions.tf
+++ b/_sub/security/org-account-query/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/security/org-account/versions.tf
+++ b/_sub/security/org-account/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/_sub/security/org-delegated-administrator/versions.tf
+++ b/_sub/security/org-delegated-administrator/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/security/org-delegated-ipam-admin/versions.tf
+++ b/_sub/security/org-delegated-ipam-admin/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/security/org-ou/versions.tf
+++ b/_sub/security/org-ou/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/security/org-policy/versions.tf
+++ b/_sub/security/org-policy/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/security/org-service-control-policy/versions.tf
+++ b/_sub/security/org-service-control-policy/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/security/resource-access-manager/versions.tf
+++ b/_sub/security/resource-access-manager/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/security/security-bot/versions.tf
+++ b/_sub/security/security-bot/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/security/ssm-parameter-store/versions.tf
+++ b/_sub/security/ssm-parameter-store/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/security/steampipe-audit/versions.tf
+++ b/_sub/security/steampipe-audit/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/storage/ecr-pull-through-cache/versions.tf
+++ b/_sub/storage/ecr-pull-through-cache/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 

--- a/_sub/storage/s3-bucket-lifecycle/versions.tf
+++ b/_sub/storage/s3-bucket-lifecycle/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/storage/s3-bucket-object/versions.tf
+++ b/_sub/storage/s3-bucket-object/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/storage/s3-bucket/versions.tf
+++ b/_sub/storage/s3-bucket/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/storage/s3-cloudtrail-bucket/versions.tf
+++ b/_sub/storage/s3-cloudtrail-bucket/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/storage/s3-config-bucket/versions.tf
+++ b/_sub/storage/s3-config-bucket/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/_sub/storage/velero/versions.tf
+++ b/_sub/storage/velero/versions.tf
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
     github = {
       source  = "integrations/github"

--- a/compute/ecr-repo/versions.tf
+++ b/compute/ecr-repo/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/compute/eks-ec2/versions.tf
+++ b/compute/eks-ec2/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
 
     kubernetes = {

--- a/compute/k8s-services/versions.tf
+++ b/compute/k8s-services/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
 
     kubernetes = {

--- a/database/postgres-restore/versions.tf
+++ b/database/postgres-restore/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/database/postgres/versions.tf
+++ b/database/postgres/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/network/ipam/versions.tf
+++ b/network/ipam/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/network/route53-sub-zone/versions.tf
+++ b/network/route53-sub-zone/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/security/cloudtrail-master/versions.tf
+++ b/security/cloudtrail-master/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/security/ebs-snapshot-sharing/versions.tf
+++ b/security/ebs-snapshot-sharing/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/security/ebs-tag-shared-snapshots/versions.tf
+++ b/security/ebs-tag-shared-snapshots/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/security/iam-ecr-access/versions.tf
+++ b/security/iam-ecr-access/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/security/iam-identity-center-master/versions.tf
+++ b/security/iam-identity-center-master/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/security/iam-roles-master/versions.tf
+++ b/security/iam-roles-master/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/security/iam-roles-qa/versions.tf
+++ b/security/iam-roles-qa/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/security/iam-users-master/versions.tf
+++ b/security/iam-users-master/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/security/legacy-account-context/versions.tf
+++ b/security/legacy-account-context/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/security/org-account-assume/versions.tf
+++ b/security/org-account-assume/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/security/org-account-context/versions.tf
+++ b/security/org-account-context/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/security/org-account/versions.tf
+++ b/security/org-account/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/security/org-capability-root/versions.tf
+++ b/security/org-capability-root/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/security/org-delegated-administrator-master/versions.tf
+++ b/security/org-delegated-administrator-master/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/security/org-delegated-ipam-admin-master/versions.tf
+++ b/security/org-delegated-ipam-admin-master/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/security/org-policies/versions.tf
+++ b/security/org-policies/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/security/org-unit-manage/versions.tf
+++ b/security/org-unit-manage/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/security/shared-symmetric-key/versions.tf
+++ b/security/shared-symmetric-key/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/security/ssh-keypair/versions.tf
+++ b/security/ssh-keypair/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/storage/ecr-pull-through-cache-docker/versions.tf
+++ b/storage/ecr-pull-through-cache-docker/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 

--- a/storage/s3-eks-public/versions.tf
+++ b/storage/s3-eks-public/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/storage/s3-replication-destination/versions.tf
+++ b/storage/s3-replication-destination/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }

--- a/storage/s3-velero-backup/versions.tf
+++ b/storage/s3-velero-backup/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.14.0"
+      version = "~> 6.0, != 6.14.0"
     }
   }
 }


### PR DESCRIPTION
## Describe your changes

This pull request updates the AWS provider version constraint across multiple Terraform modules to avoid using version 6.14.0, while still allowing other 6.x versions. This change helps prevent issues related to the specific 6.14.0 release and ensures compatibility and stability across all affected modules.

**Provider version constraint update:**

* Changed the AWS provider version from `~> 6.14.0` to `~> 6.0, != 6.14.0` in the following modules to exclude the problematic 6.14.0 version:  
  * `_sub/compute/atlantis/versions.tf`
  * `_sub/compute/ec2-keypair/versions.tf`, `_sub/compute/ecr-repo/versions.tf`
  * `_sub/compute/efs-fs/versions.tf`, `_sub/compute/eks-alb-auth/versions.tf`, `_sub/compute/eks-alb/versions.tf`, `_sub/compute/eks-cluster/versions.tf`, `_sub/compute/eks-nlb/versions.tf`, `_sub/compute/eks-nodegroup-managed/versions.tf`, `_sub/compute/eks-workers/versions.tf`, `_sub/database/postgres-restore/versions.tf`, `_sub/compute/lambda/run-lambda-permission/versions.tf`
  * `_sub/compute/eks-addons/versions.tf`
  * `_sub/compute/eks-heptio/versions.tf`
  * `_sub/compute/eks-inactivity-cleanup/versions.tf`, `_sub/compute/elb-inactivity-cleanup/versions.tf`
  * `_sub/compute/k8s-blaster-namespace/versions.tf`
  * `_sub/compute/k8s-subnet-exporter/versions.tf`
  * `_sub/compute/k8s-traefik-flux/versions.tf`
  * `_sub/compute/lambda/lambda-from-archive/versions.tf`

This change ensures all affected modules will use AWS provider versions in the 6.x range except for 6.14.0, improving reliability and reducing risk of provider-specific bugs.

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
