### PR TITLE
fix: update references from aws_region.current.name to aws_region.current.region because the former is deprecated

### DIFF
--- a/_sub/compute/eks-heptio/dependencies.tf
+++ b/_sub/compute/eks-heptio/dependencies.tf
@@ -23,7 +23,7 @@ locals {
       endpoint         = var.eks_endpoint
       ca               = var.eks_certificate_authority
       role_arn         = var.aws_assume_role_arn
-      aws_region       = data.aws_region.current.name
+      aws_region       = data.aws_region.current.region
       auth_api_version = var.eks_k8s_auth_api_version
     }
   )

--- a/_sub/compute/eks-heptio/main.tf
+++ b/_sub/compute/eks-heptio/main.tf
@@ -51,7 +51,7 @@ resource "null_resource" "enable-workers-from-s3" {
   }
 
   provisioner "local-exec" {
-    command = "bash ${path.module}/apply_blaster_configmap.sh ${data.aws_region.current.name} ${var.kubeconfig_path} ${var.blaster_configmap_s3_bucket} ${var.blaster_configmap_key} ${local.path_default_configmap} ${var.aws_assume_role_arn}"
+    command = "bash ${path.module}/apply_blaster_configmap.sh ${data.aws_region.current.region} ${var.kubeconfig_path} ${var.blaster_configmap_s3_bucket} ${var.blaster_configmap_key} ${local.path_default_configmap} ${var.aws_assume_role_arn}"
     quiet   = true
   }
 

--- a/_sub/network/ipam/main.tf
+++ b/_sub/network/ipam/main.tf
@@ -1,7 +1,7 @@
 data "aws_region" "current" {}
 
 locals {
-  all_ipam_regions = distinct(concat([data.aws_region.current.name], var.ipam_regions))
+  all_ipam_regions = distinct(concat([data.aws_region.current.region], var.ipam_regions))
   all_tags         = merge(var.tags, { "Name" = var.ipam_name })
 }
 

--- a/_sub/network/vpc-peering-accepter/main.tf
+++ b/_sub/network/vpc-peering-accepter/main.tf
@@ -47,6 +47,6 @@ resource "aws_vpc_peering_connection_accepter" "shared" {
   auto_accept               = true
 
   tags = merge(var.tags, {
-    Name = "${var.capability_id}_${data.aws_region.current.name}"
+    Name = "${var.capability_id}_${data.aws_region.current.region}"
   })
 }

--- a/_sub/network/vpc-peering-requester/main.tf
+++ b/_sub/network/vpc-peering-requester/main.tf
@@ -10,7 +10,7 @@ data "aws_availability_zones" "available" {
 }
 
 locals {
-  regional_postfix = var.regional_postfix ? "-${data.aws_region.current.name}" : ""
+  regional_postfix = var.regional_postfix ? "-${data.aws_region.current.region}" : ""
 }
 
 resource "aws_vpc_ipam_preview_next_cidr" "this" {
@@ -106,7 +106,7 @@ resource "aws_subnet" "a" {
   vpc_id                  = aws_vpc.peering.id
   map_public_ip_on_launch = var.map_public_ip_on_launch
   cidr_block              = var.cidr_block_subnet_a
-  availability_zone       = "${data.aws_region.current.name}a"
+  availability_zone       = "${data.aws_region.current.region}a"
 
   tags = merge(var.tags, {
     Name = "peering-a"
@@ -119,7 +119,7 @@ resource "aws_subnet" "b" {
   vpc_id                  = aws_vpc.peering.id
   map_public_ip_on_launch = var.map_public_ip_on_launch
   cidr_block              = var.cidr_block_subnet_b
-  availability_zone       = "${data.aws_region.current.name}b"
+  availability_zone       = "${data.aws_region.current.region}b"
 
   tags = merge(var.tags, {
     Name = "peering-b"
@@ -198,7 +198,7 @@ resource "aws_vpc_security_group_ingress_rule" "sec_sec" {
 resource "aws_vpc_endpoint" "ssm" {
   count             = var.deploy_vpc_peering_endpoints ? 1 : 0
   vpc_id            = aws_vpc.peering.id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.ssm"
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.ssm"
   vpc_endpoint_type = "Interface"
 
   private_dns_enabled = true
@@ -217,14 +217,14 @@ resource "aws_vpc_endpoint" "ssm" {
   ]
 
   tags = merge(var.tags, {
-    Name = "peering-com.amazonaws.${data.aws_region.current.name}.ssm"
+    Name = "peering-com.amazonaws.${data.aws_region.current.region}.ssm"
   })
 }
 
 resource "aws_vpc_endpoint" "ssmmessages" {
   count             = var.deploy_vpc_peering_endpoints ? 1 : 0
   vpc_id            = aws_vpc.peering.id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.ssmmessages"
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.ssmmessages"
   vpc_endpoint_type = "Interface"
 
   private_dns_enabled = true
@@ -243,14 +243,14 @@ resource "aws_vpc_endpoint" "ssmmessages" {
   ]
 
   tags = merge(var.tags, {
-    Name = "peering-com.amazonaws.${data.aws_region.current.name}.ssmmessages"
+    Name = "peering-com.amazonaws.${data.aws_region.current.region}.ssmmessages"
   })
 }
 
 resource "aws_vpc_endpoint" "ec2" {
   count             = var.deploy_vpc_peering_endpoints ? 1 : 0
   vpc_id            = aws_vpc.peering.id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.ec2"
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.ec2"
   vpc_endpoint_type = "Interface"
 
   private_dns_enabled = true
@@ -269,14 +269,14 @@ resource "aws_vpc_endpoint" "ec2" {
   ]
 
   tags = merge(var.tags, {
-    Name = "peering-com.amazonaws.${data.aws_region.current.name}.ec2"
+    Name = "peering-com.amazonaws.${data.aws_region.current.region}.ec2"
   })
 }
 
 resource "aws_vpc_endpoint" "ec2messages" {
   count             = var.deploy_vpc_peering_endpoints ? 1 : 0
   vpc_id            = aws_vpc.peering.id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.ec2messages"
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.ec2messages"
   vpc_endpoint_type = "Interface"
 
   private_dns_enabled = true
@@ -295,7 +295,7 @@ resource "aws_vpc_endpoint" "ec2messages" {
   ]
 
   tags = merge(var.tags, {
-    Name = "peering-com.amazonaws.${data.aws_region.current.name}.ec2messages"
+    Name = "peering-com.amazonaws.${data.aws_region.current.region}.ec2messages"
   })
 }
 

--- a/_sub/network/vpc-ssm/main.tf
+++ b/_sub/network/vpc-ssm/main.tf
@@ -27,7 +27,7 @@ resource "aws_vpc_security_group_ingress_rule" "ssm_https" {
 
 resource "aws_vpc_endpoint" "ssm" {
   vpc_id            = var.vpc_id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.ssm"
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.ssm"
   vpc_endpoint_type = "Interface"
 
   private_dns_enabled = true
@@ -39,13 +39,13 @@ resource "aws_vpc_endpoint" "ssm" {
   ]
 
   tags = merge(var.tags, {
-    Name = "peering-com.amazonaws.${data.aws_region.current.name}.ssm"
+    Name = "peering-com.amazonaws.${data.aws_region.current.region}.ssm"
   })
 }
 
 resource "aws_vpc_endpoint" "ssmmessages" {
   vpc_id            = var.vpc_id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.ssmmessages"
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.ssmmessages"
   vpc_endpoint_type = "Interface"
 
   private_dns_enabled = true
@@ -57,6 +57,6 @@ resource "aws_vpc_endpoint" "ssmmessages" {
   ]
 
   tags = merge(var.tags, {
-    Name = "peering-com.amazonaws.${data.aws_region.current.name}.ssmmessages"
+    Name = "peering-com.amazonaws.${data.aws_region.current.region}.ssmmessages"
   })
 }

--- a/_sub/network/vpc-ssm/vars.tf
+++ b/_sub/network/vpc-ssm/vars.tf
@@ -3,11 +3,11 @@ variable "vpc_id" {
 }
 
 variable "subnets" {
-    type = list(string)
-    default = []
+  type    = list(string)
+  default = []
 }
 
 variable "tags" {
-    type = map(string)
-    default = {}
+  type    = map(string)
+  default = {}
 }

--- a/_sub/security/cloudtrail-config/main.tf
+++ b/_sub/security/cloudtrail-config/main.tf
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "key_policy" {
     condition {
       test     = "StringEquals"
       variable = "AWS:SourceArn"
-      values   = ["arn:aws:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/${var.trail_name}"]
+      values   = ["arn:aws:cloudtrail:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:trail/${var.trail_name}"]
     }
 
     condition {
@@ -59,7 +59,7 @@ data "aws_iam_policy_document" "key_policy" {
     condition {
       test     = "StringEquals"
       variable = "AWS:SourceArn"
-      values   = ["arn:aws:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/${var.trail_name}"]
+      values   = ["arn:aws:cloudtrail:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:trail/${var.trail_name}"]
     }
   }
 


### PR DESCRIPTION
## Describe your changes

This pull request updates all references to the AWS region in several Terraform modules to use the `region` attribute instead of `name` from the `data.aws_region.current` data source. This change ensures consistent and correct usage of the AWS region identifier, which is important for resource naming, configuration, and interoperability across modules.

**Consistent AWS Region Reference Updates:**

* Updated all region references in resource names, tags, and configuration values to use `data.aws_region.current.region` instead of `data.aws_region.current.name` in the following modules:
  * EKS Heptio dependencies and worker provisioning scripts (`_sub/compute/eks-heptio/dependencies.tf`, `_sub/compute/eks-heptio/main.tf`) [[1]](diffhunk://#diff-fb0883ca106184e7f9335a239e0e3d9f7174e80332153c425577890a2eb464f4L26-R26) [[2]](diffhunk://#diff-59882565692b9e3cdf15615f70bd848cd8669e7e740400d0124bb4bc70e7817fL54-R54)
  * IPAM region list construction (`_sub/network/ipam/main.tf`)
  * VPC peering accepter and requester resource tags, subnet availability zones, and VPC endpoint service names (`_sub/network/vpc-peering-accepter/main.tf`, `_sub/network/vpc-peering-requester/main.tf`) [[1]](diffhunk://#diff-e20c94f5b3d396ae3b54981dea98d7df5621903ae9bb85c63dbbc8b0182d79ceL50-R50) [[2]](diffhunk://#diff-102b9e9826581da57cda6e2b87f7c21b029eaac75b11e5e8414190104e07d554L13-R13) [[3]](diffhunk://#diff-102b9e9826581da57cda6e2b87f7c21b029eaac75b11e5e8414190104e07d554L79-R79) [[4]](diffhunk://#diff-102b9e9826581da57cda6e2b87f7c21b029eaac75b11e5e8414190104e07d554L92-R92) [[5]](diffhunk://#diff-102b9e9826581da57cda6e2b87f7c21b029eaac75b11e5e8414190104e07d554L171-R171) [[6]](diffhunk://#diff-102b9e9826581da57cda6e2b87f7c21b029eaac75b11e5e8414190104e07d554L190-R197) [[7]](diffhunk://#diff-102b9e9826581da57cda6e2b87f7c21b029eaac75b11e5e8414190104e07d554L216-R223) [[8]](diffhunk://#diff-102b9e9826581da57cda6e2b87f7c21b029eaac75b11e5e8414190104e07d554L242-R249) [[9]](diffhunk://#diff-102b9e9826581da57cda6e2b87f7c21b029eaac75b11e5e8414190104e07d554L268-R268)
  * VPC SSM endpoint service names and tags (`_sub/network/vpc-ssm/main.tf`) [[1]](diffhunk://#diff-5ff69497c85f158ae07fc8de00db172bdb39347855f665cd5f76f13fe0c32a86L30-R30) [[2]](diffhunk://#diff-5ff69497c85f158ae07fc8de00db172bdb39347855f665cd5f76f13fe0c32a86L42-R48) [[3]](diffhunk://#diff-5ff69497c85f158ae07fc8de00db172bdb39347855f665cd5f76f13fe0c32a86L60-R60)
  * CloudTrail key policy ARN construction (`_sub/security/cloudtrail-config/main.tf`) [[1]](diffhunk://#diff-3c75b780e7c778ea252f96626f93fb4022c59503ce32182342496f347b0ab5b2L26-R26) [[2]](diffhunk://#diff-3c75b780e7c778ea252f96626f93fb4022c59503ce32182342496f347b0ab5b2L62-R62)

These updates help prevent misconfigurations and potential resource creation errors due to incorrect region identifiers.

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
