### PR TITLE
Don't run QA pipeline on PR drafts

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -44,6 +44,7 @@ env:
 
 jobs:
   build_test_master:
+    if: github.event.pull_request.draft == false
     name: Build test binary from master branch
     runs-on: ubuntu-latest
     steps:
@@ -98,6 +99,7 @@ jobs:
           path: /tmp/test-feature.bin
 
   apply_test_master:
+    if: github.event.pull_request.draft == false
     name: Provision from master branch
     runs-on: ubuntu-latest
     needs: build_test_master


### PR DESCRIPTION
## Describe your changes

This pull request updates the `.github/workflows/qa.yml` workflow to improve how it handles pull requests that are in draft mode. The main goal is to ensure that CI jobs only run for pull requests that are ready for review, preventing unnecessary builds and tests for drafts.

Key workflow improvements:

**Trigger conditions:**

* The workflow now also triggers when a pull request is marked as "ready for review," in addition to being opened, reopened, or synchronized.

**Job execution safeguards:**

* Both the `build_test_feature` and `apply_test_feature` jobs now include a condition to ensure they only run if the pull request is not a draft (`github.event.pull_request.draft == false`). This prevents CI resources from being used on draft pull requests. [[1]](diffhunk://#diff-4d515b7cca4aa254976e10e863f94e4527f5edd15f4315279f578385fc0f68b8L77-R77) [[2]](diffhunk://#diff-4d515b7cca4aa254976e10e863f94e4527f5edd15f4315279f578385fc0f68b8L181-R181)

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
