### PR TITLE
feat: refactor OIDC provider configuration for multiple clusters and add standby IAM role

### DIFF
--- a/_sub/security/ssm-parameter-store/main.tf
+++ b/_sub/security/ssm-parameter-store/main.tf
@@ -5,12 +5,8 @@ resource "aws_ssm_parameter" "putSecureString" {
   description = var.key_description
   type        = "SecureString"
   value       = var.key_value
-  tags = merge(
-    var.tags,
-    {
-      createdBy = var.tag_createdby != null ? var.tag_createdby : "ssm-parameter-store"
-    }
-  )
+  tags        = var.tags
+
   lifecycle {
     ignore_changes = [
       overwrite,

--- a/_sub/security/ssm-parameter-store/vars.tf
+++ b/_sub/security/ssm-parameter-store/vars.tf
@@ -8,12 +8,6 @@ variable "key_description" {
   type = string
 }
 
-# Parameter was created by what or whom; used to populate the createdBy tag
-variable "tag_createdby" {
-  type    = string
-  default = "not-specified"
-}
-
 # Parameter value or "content"
 variable "key_value" {
   type = string

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -233,9 +233,9 @@ module "eks_managed_workers_route_table_assoc_nat_gateway" {
 # --------------------------------------------------
 
 resource "aws_ssm_parameter" "dockerhub" {
-  name = "/eks/${var.eks_cluster_name}/dockerhub"
-  type = "SecureString"
-  value = jsonencode({username = var.docker_hub_username, password = var.docker_hub_password})
+  name  = "/eks/${var.eks_cluster_name}/dockerhub"
+  type  = "SecureString"
+  value = jsonencode({ username = var.docker_hub_username, password = var.docker_hub_password })
 }
 
 module "eks_managed_workers_node_group" {
@@ -342,7 +342,7 @@ module "param_kubeconfig_admin" {
   key_name        = "/eks/${var.eks_cluster_name}/kubeconfig-admin"
   key_description = "Kube config file for initial admin"
   key_value       = module.eks_heptio.kubeconfig_admin
-  tag_createdby   = var.ssm_param_createdby != null ? var.ssm_param_createdby : "eks-ec2"
+  tags            = var.tags
 }
 
 module "param_kubeconfig_saml" {
@@ -350,7 +350,7 @@ module "param_kubeconfig_saml" {
   key_name        = "/eks/${var.eks_cluster_name}/kubeconfig-saml"
   key_description = "Kube config file for SAML"
   key_value       = module.eks_heptio.kubeconfig_saml
-  tag_createdby   = var.ssm_param_createdby != null ? var.ssm_param_createdby : "eks-ec2"
+  tags            = var.tags
 }
 
 module "eks_s3_public_kubeconfig" {
@@ -376,7 +376,7 @@ module "k8s_service_account_store_secret" {
   key_name        = "/eks/${var.eks_cluster_name}/kubeconfig-deploy-user"
   key_description = "Kube config file for general deployment user"
   key_value       = module.k8s_service_account.deploy_user_kubeconfig
-  tag_createdby   = var.ssm_param_createdby != null ? var.ssm_param_createdby : "eks-ec2"
+  tags            = var.tags
 }
 
 module "cloudwatch_agent_config_bucket" {

--- a/compute/eks-ec2/vars.tf
+++ b/compute/eks-ec2/vars.tf
@@ -16,16 +16,6 @@ variable "tags" {
   default     = {}
 }
 
-# Optional
-# --------------------------------------------------
-
-variable "ssm_param_createdby" {
-  type        = string
-  description = "The value that will be used for the createdBy key when tagging any SSM parameters"
-  default     = null
-}
-
-
 # --------------------------------------------------
 # EKS
 # --------------------------------------------------

--- a/security/org-account-context/dependencies.tf
+++ b/security/org-account-context/dependencies.tf
@@ -67,7 +67,7 @@ data "aws_iam_policy_document" "shared_role_cap_acc" {
         type = "Federated"
 
         identifiers = [
-          "arn:aws:iam::${var.shared_account_id}:oidc-provider/${trim(statement.value["cluster_oidc_url"], "https://")}",
+          "arn:aws:iam::${statement.value["account_id"]}:oidc-provider/${trim(statement.value["cluster_oidc_url"], "https://")}",
         ]
       }
 

--- a/security/org-account-context/dependencies.tf
+++ b/security/org-account-context/dependencies.tf
@@ -46,11 +46,6 @@ data "aws_iam_policy_document" "assume_role_policy_selfservice_api" {
   }
 }
 
-// Gives access to role through the individual Capability account
-locals {
-  oidc_issuer = trim(var.oidc_provider_url, "https://")
-}
-
 data "aws_iam_policy_document" "shared_role_cap_acc" {
   statement {
     actions = ["sts:AssumeRole"]
@@ -61,24 +56,26 @@ data "aws_iam_policy_document" "shared_role_cap_acc" {
     }
   }
 
-  #dynamic "statement" {
-  statement {
-    sid     = "AssumeRoleWithWebIdentity"
-    actions = ["sts:AssumeRoleWithWebIdentity"]
-    effect  = "Allow"
+  dynamic "statement" {
+    for_each = var.oidc_provider
+    content {
+      sid     = "AssumeRoleWithWebIdentity4${statement.key}"
+      actions = ["sts:AssumeRoleWithWebIdentity"]
+      effect  = "Allow"
 
-    principals {
-      type = "Federated"
+      principals {
+        type = "Federated"
 
-      identifiers = [
-        "arn:aws:iam::${var.shared_account_id}:oidc-provider/${local.oidc_issuer}",
-      ]
-    }
+        identifiers = [
+          "arn:aws:iam::${var.shared_account_id}:oidc-provider/${trim(statement.value["cluster_oidc_url"], "https://")}",
+        ]
+      }
 
-    condition {
-      test     = "StringEquals"
-      values   = ["system:serviceaccount:${var.capability_root_id}:ssm-shared-platform-secrets"]
-      variable = "${local.oidc_issuer}:sub"
+      condition {
+        test     = "StringEquals"
+        values   = ["system:serviceaccount:${var.capability_root_id}:ssm-shared-platform-secrets"]
+        variable = "${trim(statement.value["cluster_oidc_url"], "https://")}:sub"
+      }
     }
   }
 }

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -229,7 +229,7 @@ module "aws_iam_oidc_provider_ssm" { # Add SSM parameter for OIDC provider in eu
   key_name        = "/managed/cluster/oidc-provider"
   key_description = "OIDC Provider URL for EKS cluster"
   key_value       = var.oidc_provider["production"].cluster_oidc_url
-  tag_createdby   = var.ssm_param_createdby
+  tags            = var.tags
 }
 
 # Kept for backward compatibility - single OIDC provider
@@ -241,7 +241,7 @@ module "aws_iam_oidc_provider_ssm_eu_west_1" { # Add SSM parameter for OIDC prov
   key_name        = "/managed/cluster/oidc-provider"
   key_description = "OIDC Provider URL for EKS cluster"
   key_value       = var.oidc_provider["production"].cluster_oidc_url
-  tag_createdby   = var.ssm_param_createdby
+  tags            = var.tags
 }
 
 module "aws_iam_oidc_provider_ssm_multiple" { # Add SSM parameter for OIDC provider in eu-central-1
@@ -253,7 +253,7 @@ module "aws_iam_oidc_provider_ssm_multiple" { # Add SSM parameter for OIDC provi
   key_name        = "/managed/cluster/${each.value.cluster_name}/oidc-provider"
   key_description = "OIDC Provider URL for ${each.value.cluster_name} cluster"
   key_value       = each.value.cluster_oidc_url
-  tag_createdby   = var.ssm_param_createdby
+  tags            = var.tags
 }
 
 module "aws_iam_oidc_provider_ssm_multiple_eu_west_1" { # Add SSM parameter for OIDC provider in eu-west-1
@@ -265,7 +265,7 @@ module "aws_iam_oidc_provider_ssm_multiple_eu_west_1" { # Add SSM parameter for 
   key_name        = "/managed/cluster/${each.value.cluster_name}/oidc-provider"
   key_description = "OIDC Provider URL for ${each.value.cluster_name} cluster"
   key_value       = each.value.cluster_oidc_url
-  tag_createdby   = var.ssm_param_createdby
+  tags            = var.tags
 }
 
 # --------------------------------------------------

--- a/security/org-account-context/vars.tf
+++ b/security/org-account-context/vars.tf
@@ -301,12 +301,6 @@ variable "tags" {
   default     = {}
 }
 
-
-variable "ssm_param_createdby" {
-  type        = string
-  description = "The value that will be used for the createdBy key when tagging any SSM parameters"
-}
-
 # VPC Peering
 
 variable "ipam_pools" {

--- a/security/org-account-context/vars.tf
+++ b/security/org-account-context/vars.tf
@@ -117,15 +117,12 @@ variable "parent_id" {
   description = "The ID of the parent AWS Organization OU."
 }
 
-variable "oidc_provider_url" {
-  type        = string
-  description = "The IAM OpenID Connect Provider url from the EKS production account"
-}
-
-variable "oidc_provider_tag" {
-  type        = string
-  description = "Used for tagging the IAM OpenID Connect Provider for the capability account"
-  default     = ""
+variable "oidc_provider" {
+  type = map(object({
+    cluster_oidc_url = string
+    cluster_name     = string
+  }))
+  description = "IAM OIDC Providers for the capability account to trust EKS clusters service accounts"
 }
 
 variable "harden" {

--- a/security/org-account-context/vars.tf
+++ b/security/org-account-context/vars.tf
@@ -121,6 +121,7 @@ variable "oidc_provider" {
   type = map(object({
     cluster_oidc_url = string
     cluster_name     = string
+    account_id       = string
   }))
   description = "IAM OIDC Providers for the capability account to trust EKS clusters service accounts"
 }


### PR DESCRIPTION
BREAKING CHANGE:

- This release is backward compatible with existing logic.
- Our account pipeline need a new variable set before this release can be used: 

```
variable "oidc_provider" {
  type = map(object({
    cluster_oidc_url = string
    cluster_name     = string
  }))
  description = "IAM OIDC Providers for the capability account to trust EKS clusters service accounts"
}
```

## Describe your changes

This pull request refactors how OIDC providers are managed in the organization account context, transitioning from single OIDC provider variables to a map-based structure that supports multiple providers. The changes improve scalability and flexibility for environments with multiple EKS clusters. Additionally, the PR introduces a new IAM role for standby accounts and updates SSM parameter modules for backward compatibility and multi-provider support.

**OIDC Provider Refactor:**
* Replaced single `oidc_provider_url` and `oidc_provider_tag` variables with a new `oidc_provider` map variable, allowing configuration of multiple OIDC providers per capability account. (`security/org-account-context/vars.tf`)
* Updated all usages of OIDC provider variables to iterate over the new map structure, including OIDC provider modules and SSM parameter store modules for both single and multiple providers. (`security/org-account-context/main.tf`)

**IAM Policy and Role Updates:**
* Refactored IAM policy document logic to dynamically generate AssumeRoleWithWebIdentity statements for each OIDC provider using the new map structure. (`security/org-account-context/dependencies.tf`) [[1]](diffhunk://#diff-8819bf6618b724a1d32e7e9cbfcf39a620d199f4a4030ef9ea536c15475ee34fL49-L53) [[2]](diffhunk://#diff-8819bf6618b724a1d32e7e9cbfcf39a620d199f4a4030ef9ea536c15475ee34fL64-R78)
* Added a new IAM role module for standby accounts, granting namespaced access to resources in the standby account. (`security/org-account-context/main.tf`)

**Backward Compatibility:**
* Retained and updated SSM parameter modules for single OIDC provider usage to ensure backward compatibility while introducing new modules for multiple providers. (`security/org-account-context/main.tf`)

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [x] I have tested changes in my account
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
