### PR TITLE
fix: sort github repositories for atlantis configuration

### DIFF
--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -491,7 +491,7 @@ module "atlantis_github_configuration" {
   source              = "../../_sub/security/atlantis-github-configuration"
   count               = var.atlantis_deploy ? 1 : 0
   dashboard_password  = module.atlantis_deployment[0].dashboard_password
-  github_repositories = var.atlantis_github_repositories
+  github_repositories = sort(var.atlantis_github_repositories)
   ingress_hostname    = var.atlantis_ingress
   webhook_events      = var.atlantis_webhook_events
   webhook_secret      = module.atlantis_deployment[0].webhook_secret

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -933,12 +933,6 @@ variable "external_deletion_policy_override" {
   }
 }
 
-variable "external_dns_domain_filterss" {
-  type        = list(string)
-  description = "List of domain filters for External DNS"
-  default     = []
-}
-
 variable "external_dns_is_debug_mode" {
   type        = bool
   description = "Enable debug logging for External DNS"


### PR DESCRIPTION
## Describe your changes

This pull request introduces a minor improvement to the configuration of Atlantis GitHub repositories and removes an unused variable from the External DNS settings. These changes help ensure consistent behavior and clean up unused code.

Configuration improvements:

* Sorted the `github_repositories` input for the `atlantis_github_configuration` module to ensure a consistent order when passing repository names.

Code cleanup:

* Removed the unused `external_dns_domain_filterss` variable from `vars.tf`, reducing clutter and potential confusion in the configuration.

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
