### PR TITLE
refactor: update kustomization patches to use new format for HelmRelease targets

### DIFF
--- a/_sub/compute/druid-operator/values/kustomization.yaml
+++ b/_sub/compute/druid-operator/values/kustomization.yaml
@@ -2,5 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ${gitops_apps_repo_url}/apps/${deploy_name}?ref=${gitops_apps_repo_branch}
-patchesStrategicMerge:
-  - patch.yaml
+patches:
+  - path: patch.yaml
+    target:
+      kind: HelmRelease
+      name: druid-operator
+      namespace: druid-system

--- a/_sub/compute/github-arc-runners/dependencies.tf
+++ b/_sub/compute/github-arc-runners/dependencies.tf
@@ -52,8 +52,12 @@ resources:
   - "serviceaccount.yaml"
   - "role.yaml"
   - "rolebinding.yaml"
-patchesStrategicMerge:
-  - "patch.yaml"
+patches:
+  - path: patch.yaml
+    target:
+      kind: HelmRelease
+      name: ${var.deploy_name}
+      namespace: ${var.namespace}
 YAML
 
   helm_patch = <<YAML

--- a/_sub/compute/github-arc-ss-controller/dependencies.tf
+++ b/_sub/compute/github-arc-ss-controller/dependencies.tf
@@ -48,8 +48,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - "${var.gitops_apps_repo_url}/apps/github-arc-ss-controller?ref=${var.gitops_apps_repo_branch}"
-patchesStrategicMerge:
-  - "patch.yaml"
+patches:
+  - path: patch.yaml
+    target:
+      kind: HelmRelease
+      name: ${var.deploy_name}
+      namespace: ${var.namespace}
 YAML
 
   helm_patch = <<YAML

--- a/_sub/compute/k8s-traefik-flux/main.tf
+++ b/_sub/compute/k8s-traefik-flux/main.tf
@@ -23,6 +23,7 @@ resource "github_repository_file" "traefik_helm_install" {
     gitops_apps_repo_url    = var.gitops_apps_repo_url
     deploy_name             = var.deploy_name
     gitops_apps_repo_branch = var.gitops_apps_repo_branch
+    namespace               = var.namespace
   })
   overwrite_on_create = var.overwrite_on_create
 }

--- a/_sub/compute/k8s-traefik-flux/values/helm-install.yaml
+++ b/_sub/compute/k8s-traefik-flux/values/helm-install.yaml
@@ -2,5 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ${gitops_apps_repo_url}/apps/${deploy_name}?ref=${gitops_apps_repo_branch}
-patchesStrategicMerge:
-  - patch.yaml
+patches:
+  - path: patch.yaml
+    target:
+      kind: HelmRelease
+      name: ${deploy_name}
+      namespace: ${namespace}

--- a/_sub/compute/keda/values/kustomization.yaml
+++ b/_sub/compute/keda/values/kustomization.yaml
@@ -2,5 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ${gitops_apps_repo_url}/apps/${deploy_name}?ref=${gitops_apps_repo_branch}
-patchesStrategicMerge:
-  - patch.yaml
+patches:
+  - path: patch.yaml
+    target:
+      kind: HelmRelease
+      name: keda
+      namespace: keda

--- a/_sub/compute/nvidia-device-plugin/values/kustomization.yaml
+++ b/_sub/compute/nvidia-device-plugin/values/kustomization.yaml
@@ -2,5 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ${gitops_apps_repo_url}/apps/${deploy_name}?ref=${gitops_apps_repo_branch}
-patchesStrategicMerge:
-  - patch.yaml
+patches:
+  - path: patch.yaml
+    target:
+      kind: HelmRelease
+      name: nvidia-device-plugin
+      namespace: nvidia-device-plugin

--- a/_sub/compute/trivy-operator/values/kustomization.yaml
+++ b/_sub/compute/trivy-operator/values/kustomization.yaml
@@ -2,5 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ${gitops_apps_repo_url}/apps/${deploy_name}?ref=${gitops_apps_repo_branch}
-patchesStrategicMerge:
-  - patch.yaml
+patches:
+  - path: patch.yaml
+    target:
+      kind: HelmRelease
+      name: trivy-operator
+      namespace: trivy-system

--- a/_sub/monitoring/blackbox-exporter/values/kustomization.yaml
+++ b/_sub/monitoring/blackbox-exporter/values/kustomization.yaml
@@ -2,5 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ${gitops_apps_repo_url}/apps/${deploy_name}?ref=${gitops_apps_repo_branch}
-patchesStrategicMerge:
-  - patch.yaml
+patches:
+  - path: patch.yaml
+    target:
+      kind: HelmRelease
+      name: prometheus-blackbox-exporter
+      namespace: monitoring

--- a/_sub/monitoring/goldpinger/main.tf
+++ b/_sub/monitoring/goldpinger/main.tf
@@ -23,6 +23,7 @@ resource "github_repository_file" "goldpinger_helm_install" {
     gitops_apps_repo_url    = var.gitops_apps_repo_url
     deploy_name             = var.deploy_name
     gitops_apps_repo_branch = var.gitops_apps_repo_branch
+    chart_version           = var.chart_version
   })
   overwrite_on_create = var.overwrite_on_create
 }
@@ -32,9 +33,9 @@ resource "github_repository_file" "goldpinger_helm_patch" {
   branch     = local.repo_branch
   file       = "${local.helm_repo_path}/patch.yaml"
   content = templatefile("${path.module}/values/patch.yaml", {
-    namespace      = var.namespace
-    chart_version  = var.chart_version
-    deploy_name    = var.deploy_name
+    namespace     = var.namespace
+    chart_version = var.chart_version
+    deploy_name   = var.deploy_name
   })
   overwrite_on_create = var.overwrite_on_create
 }

--- a/_sub/monitoring/goldpinger/values/kustomization.yaml
+++ b/_sub/monitoring/goldpinger/values/kustomization.yaml
@@ -2,5 +2,17 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ${gitops_apps_repo_url}/apps/${deploy_name}?ref=${gitops_apps_repo_branch}
-patchesStrategicMerge:
-  - patch.yaml
+patches:
+  - target:
+      kind: HelmRelease
+      name: goldpinger
+    patch: |-
+      - op: add
+        path: /spec/serviceAccountName
+        value: helm-controller
+      - op: replace
+        path: /spec/chart/spec/version
+        value: "${chart_version}"
+      - op: replace
+        path: /spec/values/serviceMonitor/enabled
+        value: false

--- a/_sub/monitoring/grafana/values/kustomization.yaml
+++ b/_sub/monitoring/grafana/values/kustomization.yaml
@@ -2,5 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ${gitops_apps_repo_url}/apps/${deploy_name}?ref=${gitops_apps_repo_branch}
-patchesStrategicMerge:
-  - patch.yaml
+patches:
+  - path: patch.yaml
+    target:
+      kind: HelmRelease
+      name: grafana-k8s-monitoring
+      namespace: grafana

--- a/_sub/monitoring/metrics-server/dependencies.tf
+++ b/_sub/monitoring/metrics-server/dependencies.tf
@@ -46,8 +46,17 @@ YAML
     kind: Kustomization
     resources:
       - ${var.gitops_apps_repo_url}/apps/${var.deploy_name}?ref=${var.gitops_apps_repo_branch}
-    patchesStrategicMerge:
-      - patch.yaml
+    patches:
+      - target:
+          kind: HelmRelease
+          name: metrics-server
+        patch: |-
+          - op: add
+            path: /spec/serviceAccountName
+            value: helm-controller
+          - op: replace
+            path: /spec/chart/spec/version
+            value: "${var.chart_version}"
     YAML
 
   helm_patch = <<YAML

--- a/_sub/network/external-dns/values/helm-install.yaml
+++ b/_sub/network/external-dns/values/helm-install.yaml
@@ -2,5 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ${gitops_apps_repo_url}/apps/${deploy_name}?ref=${gitops_apps_repo_branch}
-patchesStrategicMerge:
-  - patch.yaml
+patches:
+  - path: patch.yaml
+    target:
+      kind: HelmRelease
+      name: external-dns
+      namespace: external-dns

--- a/_sub/security/external-secrets/dependencies.tf
+++ b/_sub/security/external-secrets/dependencies.tf
@@ -48,8 +48,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - "${var.gitops_apps_repo_url}/apps/${var.deploy_name}?ref=${var.gitops_apps_repo_branch}"
-patchesStrategicMerge:
-  - "patch.yaml"
+patches:
+  - path: patch.yaml
+    target:
+      kind: HelmRelease
+      name: ${var.deploy_name}
+      namespace: ${var.namespace}
 YAML
 
   helm_patch = <<YAML

--- a/_sub/security/falco/values/kustomization.yaml
+++ b/_sub/security/falco/values/kustomization.yaml
@@ -2,5 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ${gitops_apps_repo_url}/apps/${deploy_name}?ref=${gitops_apps_repo_branch}
-patchesStrategicMerge:
-  - patch.yaml
+patches:
+  - path: patch.yaml
+    target:
+      kind: HelmRelease
+      name: falco
+      namespace: falco

--- a/_sub/storage/velero/values/kustomization.yaml
+++ b/_sub/storage/velero/values/kustomization.yaml
@@ -2,5 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ${gitops_apps_repo_url}/apps/${deploy_name}?ref=${gitops_apps_repo_branch}
-patchesStrategicMerge:
-  - patch.yaml
+patches:
+  - path: patch.yaml
+    target:
+      kind: HelmRelease
+      name: velero
+      namespace: velero


### PR DESCRIPTION
## Describe your changes

This pull request updates the way Kustomize patches are applied across multiple Kubernetes-related modules, standardizing the patch format and improving HelmRelease targeting. Additionally, it introduces more granular patch definitions for some resources and adds variable support for specific values. These changes help ensure more reliable and maintainable deployments.

**Kustomize patching improvements:**

* Replaces the deprecated `patchesStrategicMerge` directive with the newer `patches` format in all relevant `kustomization.yaml` and Terraform files, allowing for more precise targeting of `HelmRelease` resources by kind, name, and namespace. [[1]](diffhunk://#diff-6f828eec98cf12049703e649bd418bb8e1c531c8dd720146172a433a355a83ffL5-R10) [[2]](diffhunk://#diff-4b65fcb74935fee52655eb40ea9e6f3cef982408178906d20a81b0262327dfc8L55-R60) [[3]](diffhunk://#diff-f024b18e3e95f23657f8f78ff3d7bc898aa372d62e61afeeb2c8758add00da94L51-R56) [[4]](diffhunk://#diff-84c1a78ef3baaabf14a46f8994636b211f6552e1535236e1c216313066f79b45L5-R10) [[5]](diffhunk://#diff-2966b20159eaf3aa4a9b5dfe1f98d5cd5853b9f6e61a658152f297de255bf260L5-R10) [[6]](diffhunk://#diff-d09d387a2754ad6404db79466f9ca8812e8e03ceb1ad3388cfa55948f0d54147L5-R10) [[7]](diffhunk://#diff-55106c7640096617906e84626128f55fb597610d89fd5e2a60342ec9f8d71b94L5-R10) [[8]](diffhunk://#diff-9e087ede4d9811058143829a8f2831bfb206319451688a2ae42c5865992ac456L5-R10) [[9]](diffhunk://#diff-a3445fbcf7a1e1045b31b2b3f6b72a22a9d4336cc1feed7547a6091630f093adL5-R10) [[10]](diffhunk://#diff-d84594ebc51163e447685f309dd898c0646e9c23b31af2c0390966b08cc3dcbbL5-R10) [[11]](diffhunk://#diff-16c5342b210a2d7bf6997fa66c41c6fb864c0f27c88f390af0667a356ad848d0L51-R56) [[12]](diffhunk://#diff-b42f65ab3ae7a4b45f65b1d393c379b4a928272aece89149c0fe32aa3486da27L5-R10) [[13]](diffhunk://#diff-3f249ff304bdd95caa25337286e8c60eacdb4912b2dbc774e948290e26529e63L5-R10)

**Resource-specific patch enhancements:**

* Introduces inline patch definitions for `goldpinger` and `metrics-server`, allowing direct specification of patch operations such as setting `serviceAccountName`, chart version, and disabling `serviceMonitor` where needed. [[1]](diffhunk://#diff-6949b5e283e21e8a8fffe48e8904be23fde6a5faa0642aef8b9f105cf0ba6b5dL5-R18) [[2]](diffhunk://#diff-712f5119b5811ddf40b122ae6bac7cff1f973dd91230a6d8b412931e76c480c1L49-R59)

**Variable support improvements:**

* Adds support for passing the `namespace` and `chart_version` variables in the Terraform modules for `traefik` and `goldpinger`, enabling more flexible and dynamic deployments. [[1]](diffhunk://#diff-a6e237b7137ac709047526e9f784f666adb77961459eccf840189ab2add4db58R26) [[2]](diffhunk://#diff-47e2ef46426d4b52d8805da00a988c4d56f831a51148964d4d4d22875cd7bcc1R26)

These updates collectively modernize patch handling, improve configurability, and help reduce deployment errors by making patch targeting explicit and maintainable.

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
