### PR TITLE
EKS nodes version <= 1.34, uses containerd v2 with different syntax

### DIFF
--- a/_sub/compute/eks-nodegroup-managed/dependencies.tf
+++ b/_sub/compute/eks-nodegroup-managed/dependencies.tf
@@ -39,3 +39,7 @@ locals {
 data "aws_eks_cluster" "this" {
   name = var.cluster_name
 }
+
+locals {
+  ami_using_containerd_v2 = (tonumber(split(".", var.cluster_version)[0]) == 1 && tonumber(split(".", var.cluster_version)[1]) >= 34) || tonumber(split(".", var.cluster_version)[0]) >= 2 # versions above 1.33 uses containerd v2, which uses different syntaxt for image registry auth
+}

--- a/_sub/compute/eks-nodegroup-managed/main.tf
+++ b/_sub/compute/eks-nodegroup-managed/main.tf
@@ -20,6 +20,7 @@ resource "aws_launch_template" "eks" {
     sys_cpu : var.system_reserved_cpu,
     sys_memory : var.system_reserved_memory,
     docker_hub_creds : var.docker_hub_creds_ssm_path,
+    ami_using_containerd_v2 : local.ami_using_containerd_v2
   }))
   key_name               = var.ec2_ssh_key
   update_default_version = true

--- a/_sub/compute/eks-nodegroup-managed/user-data.sh.tftpl
+++ b/_sub/compute/eks-nodegroup-managed/user-data.sh.tftpl
@@ -13,9 +13,15 @@ sudo sysctl -p
 DOCKER_HUB_CREDS=$(aws ssm get-parameter --name ${docker_hub_creds} --with-decrypt --query 'Parameter.Value' --output text)
 DOCKER_HUB_USER=$(echo "$${DOCKER_HUB_CREDS}" | jq -r .username)
 DOCKER_HUB_PASSWD=$(echo "$${DOCKER_HUB_CREDS}" | jq -r .password)
+
 cat << EOF >> /etc/containerd/config.toml
+%{ if ami_using_containerd_v2 }
+  [plugins."io.containerd.cri.v1.images".registry.configs]
+    [plugins."io.containerd.cri.v1.images".registry.configs."registry-1.docker.io".auth]
+%{ else }
   [plugins."io.containerd.grpc.v1.cri".registry.configs]
     [plugins."io.containerd.grpc.v1.cri".registry.configs."registry-1.docker.io".auth]
+%{ endif ~}
       username = "$${DOCKER_HUB_USER}"
       password = "$${DOCKER_HUB_PASSWD}"
 EOF


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
Prepare for EKS AMI version 1.34 with containerd v2, that uses different syntax see https://github.com/containerd/containerd/blob/main/docs/cri/registry.md.

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
