### PR TITLE
refactor: standardize deployment name usage and remove redundant variables in 1Password Connect configuration. Also use post build substitution

### DIFF
--- a/_sub/security/helm-1password-connect/dependencies.tf
+++ b/_sub/security/helm-1password-connect/dependencies.tf
@@ -3,11 +3,12 @@ data "github_repository" "main" {
 }
 
 locals {
+  deploy_name         = "1password-connect"
   default_repo_branch = data.github_repository.main.default_branch
   cluster_repo_path   = "clusters/${var.cluster_name}"
   repo_branch         = length(var.repo_branch) > 0 ? var.repo_branch : local.default_repo_branch
-  helm_repo_path      = "platform-apps/${var.cluster_name}/${var.deploy_name}/helm"
-  app_install_name    = "platform-apps-${var.deploy_name}"
+  helm_repo_path      = "platform-apps/${var.cluster_name}/${local.deploy_name}/helm"
+  app_install_name    = "platform-apps-${local.deploy_name}"
 }
 
 locals {
@@ -16,7 +17,7 @@ locals {
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: cluster-reconciler-${var.deploy_name}
+  name: cluster-reconciler-${local.deploy_name}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -24,7 +25,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: helm-controller
-  namespace: ${var.namespace}
+  namespace: "1password-connect"
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -41,45 +42,26 @@ spec:
     name: "flux-system"
   path: "./${local.helm_repo_path}"
   prune: ${var.prune}
+  postBuild:
+    substitute:
+      fluxcd_aws_region: ${var.aws_region}
+      fluxcd_aws_workload_account_id: "${var.workload_account_id}"
 YAML
 
   helm_install = <<YAML
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: ${var.namespace}
+namespace: "1password-connect"
 resources:
-  - ${var.gitops_apps_repo_url}/apps/${var.deploy_name}?ref=${var.gitops_apps_repo_branch}
+  - ${var.gitops_apps_repo_url}/apps/${local.deploy_name}?ref=${var.gitops_apps_repo_branch}
 patches:
-  - path: patch.yaml
-YAML
-
-  helm_patch = <<YAML
----
-apiVersion: helm.toolkit.fluxcd.io/v2
-kind: HelmRelease
-metadata:
-  name: ${var.deploy_name}
-  namespace: ${var.namespace}
-spec:
-  serviceAccountName: helm-controller
-  chart:
-    spec:
-      version: ${var.chart_version}
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: 1password-connect
-  annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::${var.workload_account_id}:role/${var.deploy_name}-irsa
----
-apiVersion: external-secrets.io/v1
-kind: SecretStore
-metadata:
-  name: 1password-connect-ssm
-spec:
-  provider:
-    aws:
-      region: ${var.aws_region}
+  - target:
+      kind: HelmRelease
+      name: 1password-connect
+      namespace: 1password-connect
+    patch: |-
+      - op: replace
+        path: /spec/chart/spec/version
+        value: "${var.chart_version}"
 YAML
 }

--- a/_sub/security/helm-1password-connect/iam.tf
+++ b/_sub/security/helm-1password-connect/iam.tf
@@ -3,7 +3,7 @@
 # --------------------------------------------------
 
 locals {
-  iam_role_name = "${var.deploy_name}-irsa"
+  iam_role_name = "${local.deploy_name}-irsa"
 }
 
 # tfsec:ignore:aws-iam-no-policy-wildcards
@@ -37,7 +37,7 @@ data "aws_iam_policy_document" "trust" {
 
     condition {
       test     = "StringEquals"
-      values   = ["system:serviceaccount:${var.namespace}:${var.deploy_name}"]
+      values   = ["system:serviceaccount:1password-connect:${local.deploy_name}"]
       variable = "${var.oidc_issuer}:sub"
     }
   }

--- a/_sub/security/helm-1password-connect/main.tf
+++ b/_sub/security/helm-1password-connect/main.tf
@@ -7,7 +7,7 @@ resource "github_repository_file" "onepassword-connect_helm" {
   branch              = local.repo_branch
   file                = "${local.cluster_repo_path}/${local.app_install_name}-helm.yaml"
   content             = local.app_helm_path
-  overwrite_on_create = var.overwrite_on_create
+  overwrite_on_create = true
 }
 
 resource "github_repository_file" "onepassword-connect_helm_install" {
@@ -15,20 +15,12 @@ resource "github_repository_file" "onepassword-connect_helm_install" {
   branch              = local.repo_branch
   file                = "${local.helm_repo_path}/kustomization.yaml"
   content             = local.helm_install
-  overwrite_on_create = var.overwrite_on_create
-}
-
-resource "github_repository_file" "onepassword-connect_helm_patch" {
-  repository          = var.repo_name
-  branch              = local.repo_branch
-  file                = "${local.helm_repo_path}/patch.yaml"
-  content             = local.helm_patch
-  overwrite_on_create = var.overwrite_on_create
+  overwrite_on_create = true
 }
 
 resource "aws_ssm_parameter" "onepassword_credentials_json" {
   #checkov:skip=CKV_AWS_337: Ensure SSM parameters are using KMS CMK
-  name  = "/${var.deploy_name}/1password-credentials.json"
+  name  = "/${local.deploy_name}/1password-credentials.json"
   type  = "SecureString"
   value = var.credentials_json
 }

--- a/_sub/security/helm-1password-connect/vars.tf
+++ b/_sub/security/helm-1password-connect/vars.tf
@@ -2,22 +2,9 @@ variable "cluster_name" {
   type = string
 }
 
-variable "deploy_name" {
-  type        = string
-  description = "Unique identifier of the deployment, only needs override if deploying multiple instances"
-  default     = "1password-connect"
-}
-
 variable "chart_version" {
   type        = string
   description = "The helm chart version"
-  default     = ""
-}
-
-variable "namespace" {
-  type        = string
-  description = "The namespace in which to deploy Helm resources"
-  default     = "1password-connect"
 }
 
 variable "github_owner" {
@@ -33,24 +20,15 @@ variable "repo_name" {
 variable "repo_branch" {
   type        = string
   description = "Override the default branch of the repo (optional)"
-  default     = null
-}
-
-variable "overwrite_on_create" {
-  type        = bool
-  default     = true
-  description = "Enable overwriting existing files"
 }
 
 variable "gitops_apps_repo_url" {
   type        = string
-  default     = ""
   description = "The https url for your GitOps manifests"
 }
 
 variable "gitops_apps_repo_branch" {
   type        = string
-  default     = "main"
   description = "The default branch for your GitOps manifests"
 }
 

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -779,12 +779,9 @@ module "onepassword_connect" {
   source                  = "../../_sub/security/helm-1password-connect"
   count                   = var.onepassword-connect_deploy ? 1 : 0
   cluster_name            = var.eks_cluster_name
-  deploy_name             = "1password-connect"
-  namespace               = "1password-connect"
   github_owner            = var.fluxcd_bootstrap_repo_owner
   repo_name               = var.fluxcd_bootstrap_repo_name
   repo_branch             = var.fluxcd_bootstrap_repo_branch
-  overwrite_on_create     = var.fluxcd_bootstrap_overwrite_on_create
   gitops_apps_repo_url    = local.fluxcd_apps_repo_url
   gitops_apps_repo_branch = var.fluxcd_apps_repo_branch
   prune                   = var.fluxcd_prune


### PR DESCRIPTION
## Describe your changes

This is a minor change, because deploy_name and namespace was _hardcoded_ in the service module.

This pull request refactors the Helm deployment module for 1Password Connect by standardizing the deployment name and namespace handling, simplifying variable usage, and streamlining file generation and patching. The changes improve maintainability and reduce the number of required input variables, making the module easier to use and less error-prone.

**Refactoring and Standardization**

* The deployment name is now set as a local variable (`local.deploy_name`), removing the need for the `deploy_name` input variable and ensuring consistency across all references. (`_sub/security/helm-1password-connect/dependencies.tf`, [[1]](diffhunk://#diff-09ae9456db86c758d054f434dbbe9976fc109be9626a3f52dac006dc9e984beeR6-R11); `_sub/security/helm-1password-connect/iam.tf`, [[2]](diffhunk://#diff-eb5f1a8bba5cd5fbf0179d9769263b7ee19dae03a45cbb734504e01728ca1cebL6-R6)
* The namespace is hardcoded to `"1password-connect"` in all relevant places, eliminating the `namespace` variable and reducing configuration complexity. (`_sub/security/helm-1password-connect/dependencies.tf`, [[1]](diffhunk://#diff-09ae9456db86c758d054f434dbbe9976fc109be9626a3f52dac006dc9e984beeL19-R28); `_sub/security/helm-1password-connect/iam.tf`, [[2]](diffhunk://#diff-eb5f1a8bba5cd5fbf0179d9769263b7ee19dae03a45cbb734504e01728ca1cebL40-R40)

**Simplification and Cleanup**

* Several unused or redundant variables have been removed, including `deploy_name`, `namespace`, `overwrite_on_create`, and defaults for repo URLs and branches, cleaning up the module interface. (`_sub/security/helm-1password-connect/vars.tf`, [[1]](diffhunk://#diff-6ce25354b98d018d52fc5c85fabe684cfd758d22ce9c60e924c94ce638d2aa19L5-L20) [[2]](diffhunk://#diff-6ce25354b98d018d52fc5c85fabe684cfd758d22ce9c60e924c94ce638d2aa19L36-L53)
* Corresponding references to these variables have been removed from the parent module invocation, further simplifying usage. (`compute/k8s-services/main.tf`, [compute/k8s-services/main.tfL782-L787](diffhunk://#diff-9dcb2b34c331c83c7b15b8785fc38080f22e765d3119f854acc7848e7f669485L782-L787))

**File Generation and Patching**

* The overwrite flag for generated GitHub repository files is now always set to `true`, ensuring files are always updated and removing the need for the `overwrite_on_create` variable. (`_sub/security/helm-1password-connect/main.tf`, [_sub/security/helm-1password-connect/main.tfL10-R23](diffhunk://#diff-7ddbd02e75b84f6c3c7481be027e66cd42904eeb3e3ee6916b92995370bd5751L10-R23))
* Helm patching logic has been refactored: direct patching is now handled inline in the Kustomization manifest, removing the need for a separate patch file resource. (`_sub/security/helm-1password-connect/dependencies.tf`, [[1]](diffhunk://#diff-09ae9456db86c758d054f434dbbe9976fc109be9626a3f52dac006dc9e984beeR45-R65); `_sub/security/helm-1password-connect/main.tf`, [[2]](diffhunk://#diff-7ddbd02e75b84f6c3c7481be027e66cd42904eeb3e3ee6916b92995370bd5751L10-R23)

**Resource Naming Consistency**

* All resource names and paths (e.g., IAM role, SSM parameter) now consistently use `local.deploy_name`, ensuring alignment and reducing risk of misconfiguration. (`_sub/security/helm-1password-connect/iam.tf`, [[1]](diffhunk://#diff-eb5f1a8bba5cd5fbf0179d9769263b7ee19dae03a45cbb734504e01728ca1cebL6-R6); `_sub/security/helm-1password-connect/main.tf`, [[2]](diffhunk://#diff-7ddbd02e75b84f6c3c7481be027e66cd42904eeb3e3ee6916b92995370bd5751L10-R23)

**Kustomize and Helm Improvements**

* The Kustomization manifest now includes a `postBuild` substitution block for AWS region and workload account ID, improving support for dynamic configuration. (`_sub/security/helm-1password-connect/dependencies.tf`, [_sub/security/helm-1password-connect/dependencies.tfR45-R65](diffhunk://#diff-09ae9456db86c758d054f434dbbe9976fc109be9626a3f52dac006dc9e984beeR45-R65))

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
