### PR TITLE
minor fixes to nlb submodule to make it useful again

### DIFF
--- a/_sub/compute/eks-nlb/main.tf
+++ b/_sub/compute/eks-nlb/main.tf
@@ -4,6 +4,8 @@ resource "aws_lb" "nlb" {
   internal           = false #tfsec:ignore:aws-elbv2-alb-not-public tfsec:ignore:aws-elb-alb-not-public
   load_balancer_type = "network"
   subnets            = var.subnet_ids
+
+  security_groups = var.deploy ? [aws_security_group.traefik[0].id, aws_security_group.traefik_deployment[0].id] : []
 }
 
 resource "aws_autoscaling_attachment" "nlb" {
@@ -15,23 +17,27 @@ resource "aws_autoscaling_attachment" "nlb" {
 resource "aws_lb_target_group" "nlb" {
   count       = var.deploy ? 1 : 0
   name_prefix = substr(var.cluster_name, 0, min(6, length(var.cluster_name)))
-  port        = 30000
+  port        = var.target_http_port
   protocol    = "TCP"
   vpc_id      = var.vpc_id
+
+  health_check {
+    path     = var.health_check_path
+    port     = var.target_admin_port
+    protocol = "HTTP"
+    matcher  = 200
+  }
 
   lifecycle {
     create_before_destroy = true
   }
 }
 
-#
 resource "aws_lb_listener" "nlb" {
   count             = var.deploy ? 1 : 0
   load_balancer_arn = aws_lb.nlb[0].arn
   port              = "443"
-  protocol          = "TLS"
-  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
-  certificate_arn   = var.nlb_certificate_arn
+  protocol          = "TCP"
 
   default_action {
     type             = "forward"
@@ -39,14 +45,91 @@ resource "aws_lb_listener" "nlb" {
   }
 }
 
-resource "aws_security_group_rule" "allow_argo" {
+resource "aws_lb_listener" "nlb_insecure" {
+  count             = var.deploy ? 1 : 0
+  load_balancer_arn = aws_lb.nlb[0].arn
+  port              = "80"
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.nlb[0].arn
+  }
+}
+
+
+resource "aws_security_group_rule" "traefik" { # on the nodes
   count       = var.deploy ? 1 : 0
   type        = "ingress"
   description = "Allow inbound HTTP traffic"
-  from_port   = 30000
-  to_port     = 30001
+  from_port   = var.target_http_port
+  to_port     = var.target_admin_port
   protocol    = "tcp"
 
-  cidr_blocks       = var.cidr_blocks
   security_group_id = var.nodes_sg_id
+
+  source_security_group_id = aws_security_group.traefik[0].id
+}
+
+resource "aws_security_group" "traefik" {
+  count       = var.deploy ? 1 : 0
+  name_prefix = "allow_traefik-${var.cluster_name}-nlb"
+  description = "Allow traefik connection for ${var.cluster_name}"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "Ingress on standard HTTP port"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "TCP"
+    cidr_blocks = ["0.0.0.0/0"] #tfsec:ignore:aws-vpc-no-public-ingress-sg tfsec:ignore:aws-ec2-no-public-ingress-sgr
+  }
+
+  ingress {
+    description = "Ingress on standard HTTPS port"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "TCP"
+    cidr_blocks = ["0.0.0.0/0"] #tfsec:ignore:aws-vpc-no-public-ingress-sg tfsec:ignore:aws-ec2-no-public-ingress-sgr
+  }
+
+  tags = {
+    Name = "${var.cluster_name}-traefik-sg"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+}
+
+resource "aws_security_group" "traefik_deployment" { # on the load balancer
+  count       = var.deploy ? 1 : 0
+  name_prefix = "allow_traefik_deployment-${var.cluster_name}"
+  description = "Allow traefik connection related to the traefik deployment for ${var.cluster_name}"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "Ingress on var.target_admin_port"
+    from_port   = var.target_admin_port
+    to_port     = var.target_admin_port
+    protocol    = "TCP"
+    self        = true
+  }
+
+  egress {
+    description = "Egress from var.target_http_port to var.target_admin_port"
+    from_port   = var.target_http_port
+    to_port     = var.target_admin_port
+    protocol    = "TCP"
+    cidr_blocks = ["0.0.0.0/0"] #tfsec:ignore:aws-vpc-no-public-egress-sg tfsec:ignore:aws-ec2-no-public-egress-sgr
+  }
+
+  tags = {
+    Name = "${var.cluster_name}-traefik-blue-sg"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }

--- a/_sub/compute/eks-nlb/vars.tf
+++ b/_sub/compute/eks-nlb/vars.tf
@@ -11,24 +11,29 @@ variable "vpc_id" {
   type = string
 }
 
-# variable "nlb_certificate_arn" {}
-
 variable "nodes_sg_id" {
   type = string
 }
 
-variable "cidr_blocks" {
-  type = list(string)
-}
 
 variable "subnet_ids" {
   type = list(string)
 }
 
-variable "nlb_certificate_arn" {
-  type = string
-}
 
 variable "autoscaling_group_ids" {
   type = list(string)
+}
+
+
+variable "target_http_port" {
+  type = number
+}
+
+variable "target_admin_port" {
+  type = number
+}
+
+variable "health_check_path" {
+  type = string
 }


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
This pull request updates the configuration for the Network Load Balancer (NLB) and security groups in the EKS NLB Terraform module to improve flexibility, security, and health monitoring. The main changes include parameterizing ports, introducing new security groups for Traefik, updating listener protocols, and adding a configurable health check.

**Security group and access control improvements:**

* Added new security groups `aws_security_group.traefik` and `aws_security_group.traefik_deployment` to better isolate and manage Traefik access, and updated the NLB to use these security groups when `var.deploy` is true. (`_sub/compute/eks-nlb/main.tf`) [[1]](diffhunk://#diff-e66a73116e1bd5caf172de397bfca1d0e48f6801c84d2ea314bc5a55146fe4d0R7-R8) [[2]](diffhunk://#diff-e66a73116e1bd5caf172de397bfca1d0e48f6801c84d2ea314bc5a55146fe4d0L18-R134)
* Replaced the previous security group rule for Argo with rules specifically for Traefik, ensuring only the necessary ports are open and access is restricted between relevant components. (`_sub/compute/eks-nlb/main.tf`)

**Load balancer and listener configuration:**

* Changed the NLB listener protocols from `TLS` to `TCP` for both port 443 (secure) and added a new listener for port 80 (insecure), removing the need for an SSL certificate. (`_sub/compute/eks-nlb/main.tf`)
* Parameterized the target group port using `var.target_http_port` instead of a hardcoded value, increasing flexibility. (`_sub/compute/eks-nlb/main.tf`, `_sub/compute/eks-nlb/vars.tf`) [[1]](diffhunk://#diff-e66a73116e1bd5caf172de397bfca1d0e48f6801c84d2ea314bc5a55146fe4d0L18-R134) [[2]](diffhunk://#diff-9dd95a1007ba517c6cf8bdd25076f5d4f58eab76a3adebb76eb06cb748d06970L14-R39)

**Health check enhancements:**

* Added a configurable health check block to the NLB target group, allowing the path, port, and protocol to be set via variables for improved monitoring and reliability. (`_sub/compute/eks-nlb/main.tf`, `_sub/compute/eks-nlb/vars.tf`) [[1]](diffhunk://#diff-e66a73116e1bd5caf172de397bfca1d0e48f6801c84d2ea314bc5a55146fe4d0L18-R134) [[2]](diffhunk://#diff-9dd95a1007ba517c6cf8bdd25076f5d4f58eab76a3adebb76eb06cb748d06970L14-R39)

**Variable and code cleanup:**

* Removed unused variables (`cidr_blocks`, `nlb_certificate_arn`) and added new variables for ports and health check path to support the above changes. (`_sub/compute/eks-nlb/vars.tf`)
## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
