### PR TITLE
Set Flux test branch back to main

### DIFF
--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -66,7 +66,7 @@ inputs = {
   # Flux CD
   # --------------------------------------------------
 
-  fluxcd_apps_repo_branch           = "feature/falco-reduce-patch" # For PR review process only. Will be revered back to main after merge.
+  fluxcd_apps_repo_branch           = "main"
   fluxcd_bootstrap_repo_branch      = "main"
   fluxcd_bootstrap_repo_name        = "platform-manifests-qa"
   fluxcd_version                    = "v2.7.5"


### PR DESCRIPTION
## Describe your changes

This pull request updates the configuration for the Flux CD deployment in the QA environment. The main change is reverting the `fluxcd_apps_repo_branch` from a feature branch back to `main`, indicating the end of a PR review process.

- Configuration update:
  * Set `fluxcd_apps_repo_branch` in `terragrunt.hcl` back to `"main"` to use the primary branch for Flux CD applications, replacing the temporary feature branch used during PR review.

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
