### PR TITLE
Added liveness and readiness probes to traefik and karpenter

### DIFF
--- a/.github/workflows/vendor-go.yml
+++ b/.github/workflows/vendor-go.yml
@@ -75,5 +75,4 @@ jobs:
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git add test/integration/suite/
-          git commit -m "Vendoring Go packages again"
-          git push
+          git diff --cached --quiet && echo "No vendor changes to commit" || (git commit -m "Vendoring Go packages again" && git push)

--- a/test/integration/suite/k8s/karpenter/deployment.yaml
+++ b/test/integration/suite/k8s/karpenter/deployment.yaml
@@ -17,6 +17,18 @@ spec:
       containers:
         - image: nginx:latest
           name: nginx
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 3
+            periodSeconds: 3
       tolerations:
         - key: "dfds.com/karpenter"
           operator: "Exists"

--- a/test/integration/suite/traefik_test.go
+++ b/test/integration/suite/traefik_test.go
@@ -106,6 +106,16 @@ func DeployTestcase(t *testing.T, clientset *kubernetes.Clientset, testName stri
 								InitialDelaySeconds: 3,
 								PeriodSeconds:       3,
 							},
+							ReadinessProbe: &apiv1.Probe{
+								ProbeHandler: apiv1.ProbeHandler{
+									HTTPGet: &apiv1.HTTPGetAction{
+										Port: intstr.IntOrString{IntVal: 80},
+										Path: "/",
+									},
+								},
+								InitialDelaySeconds: 3,
+								PeriodSeconds:       3,
+							},
 						},
 					},
 				},


### PR DESCRIPTION
## Describe your changes
This pull request enhances the reliability of Kubernetes deployments used in integration tests by adding health checks to the `nginx` containers. The main changes are the introduction of both liveness and readiness probes to ensure that the containers are running and ready to serve traffic before being considered healthy by Kubernetes.

**Kubernetes deployment improvements:**

* Added `livenessProbe` and `readinessProbe` to the `nginx` container in the `karpenter` deployment manifest to enable automatic health checks.
* Updated the integration test setup in `traefik_test.go` to include a `ReadinessProbe` for the test deployment, ensuring the test waits for the container to be ready before proceeding.

## Issue ticket number and link
[Investigate QA policy violations](https://dev.azure.com/dfds/Cloud%20Engineering%20Team/_workitems/edit/603482)

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
