### PR TITLE
Remove Falco stream webhook URL references from configuration

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -146,7 +146,6 @@ jobs:
           TF_VAR_velero_azure_resource_group_name: op://CloudEng-General/Azure - Offsite Backup/qa-resource-group-name # pragma: allowlist-secret
           TF_VAR_velero_azure_storage_account_name: op://CloudEng-General/Azure - Offsite Backup/qa-storage-account-name # pragma: allowlist-secret
           TF_VAR_falco_slack_alert_webhook_url: op://CloudEng-General/Slack dfds.slack.com webhooks/hgdm4deysbaryzpqvjg6lbh2xm # pragma: allowlist-secret
-          TF_VAR_falco_stream_webhook_url: op://CloudEng-General/Slack dfds.slack.com webhooks/vhrc25x3njx6h7o3g5aawlhtmm # pragma: allowlist-secret
 
       - name: Provision shared EKS S3 bucket
         run: ./src/qa-test-eks.sh apply-shared _global/eks-public-s3-bucket
@@ -226,7 +225,6 @@ jobs:
           TF_VAR_velero_azure_resource_group_name: op://CloudEng-General/Azure - Offsite Backup/qa-resource-group-name # pragma: allowlist-secret
           TF_VAR_velero_azure_storage_account_name: op://CloudEng-General/Azure - Offsite Backup/qa-storage-account-name # pragma: allowlist-secret
           TF_VAR_falco_slack_alert_webhook_url: op://CloudEng-General/Slack dfds.slack.com webhooks/hgdm4deysbaryzpqvjg6lbh2xm # pragma: allowlist-secret
-          TF_VAR_falco_stream_webhook_url: op://CloudEng-General/Slack dfds.slack.com webhooks/vhrc25x3njx6h7o3g5aawlhtmm # pragma: allowlist-secret
 
       - name: Provision shared EKS S3 bucket
         run: ./src/qa-test-eks.sh apply-shared _global/eks-public-s3-bucket

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -146,6 +146,7 @@ jobs:
           TF_VAR_velero_azure_resource_group_name: op://CloudEng-General/Azure - Offsite Backup/qa-resource-group-name # pragma: allowlist-secret
           TF_VAR_velero_azure_storage_account_name: op://CloudEng-General/Azure - Offsite Backup/qa-storage-account-name # pragma: allowlist-secret
           TF_VAR_falco_slack_alert_webhook_url: op://CloudEng-General/Slack dfds.slack.com webhooks/hgdm4deysbaryzpqvjg6lbh2xm # pragma: allowlist-secret
+          TF_VAR_falco_stream_webhook_url: op://CloudEng-General/Slack dfds.slack.com webhooks/vhrc25x3njx6h7o3g5aawlhtmm # pragma: allowlist-secret
 
       - name: Provision shared EKS S3 bucket
         run: ./src/qa-test-eks.sh apply-shared _global/eks-public-s3-bucket

--- a/_sub/security/falco/main.tf
+++ b/_sub/security/falco/main.tf
@@ -8,7 +8,6 @@ resource "github_repository_file" "helm" {
   content = templatefile("${path.module}/values/app-config.yaml", {
     app_install_name        = local.app_install_name
     helm_repo_path          = local.helm_repo_path
-    stream_webhook_url      = var.stream_webhook_url
     slack_alert_webhook_url = var.slack_alert_webhook_url
     deploy_name             = local.deploy_name
     prune                   = var.prune
@@ -33,8 +32,7 @@ resource "github_repository_file" "helm_patch" {
   branch     = local.repo_branch
   file       = "${local.helm_repo_path}/patch.yaml"
   content = templatefile("${path.module}/values/patch.yaml", {
-    custom_rules       = var.custom_rules
-    stream_webhook_url = var.stream_webhook_url
+    custom_rules = var.custom_rules
   })
   overwrite_on_create = true
 }

--- a/_sub/security/falco/values/patch.yaml
+++ b/_sub/security/falco/values/patch.yaml
@@ -8,7 +8,3 @@ spec:
     customRules:
         falco_custom_rules.yaml: |-
           ${custom_rules}
-    falco:
-      program_output:
-        enabled: true
-        program: "jq '{text: .output}' | curl -d @- -X POST ${stream_webhook_url}"

--- a/_sub/security/falco/vars.tf
+++ b/_sub/security/falco/vars.tf
@@ -38,11 +38,6 @@ variable "slack_alert_webhook_url" {
   description = "Value for slack webhook url to which to send alerts."
 }
 
-variable "stream_webhook_url" {
-  type        = string
-  description = "Value for webhook url to which to send falco events stream."
-}
-
 variable "custom_rules" {
   type        = string
   description = "Custom rules to be added to the falco config"

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -785,7 +785,6 @@ module "falco" {
   gitops_apps_repo_url    = local.fluxcd_apps_repo_url
   gitops_apps_repo_ref    = local.gitops_apps_repo_ref
   slack_alert_webhook_url = var.falco_slack_alert_webhook_url
-  stream_webhook_url      = var.falco_stream_webhook_url
   custom_rules            = var.falco_custom_rules
 
   providers = {

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -650,11 +650,6 @@ variable "falco_slack_alert_webhook_url" {
   description = "Slack webhook for Falco alerts"
 }
 
-variable "falco_stream_webhook_url" {
-  type        = string
-  description = "Slack webhook for Falco events"
-}
-
 variable "falco_custom_rules" {
   type        = string
   default     = ""


### PR DESCRIPTION
## Describe your changes

This pull request removes support for the `stream_webhook_url` configuration in the Falco security monitoring setup. The changes eliminate the use of the stream webhook for Falco event streaming, both in Terraform variables and in the Helm chart configuration. Only the Slack alert webhook remains for Falco notifications.

Key changes:

**Falco stream webhook removal:**

* Deleted the `stream_webhook_url` variable and all related references from Terraform modules and variable definitions, including in `_sub/security/falco/vars.tf`, `compute/k8s-services/vars.tf`, and `compute/k8s-services/main.tf`. [[1]](diffhunk://#diff-5db93aa5076a809aba7fae50c9f1719714cbdfa4d7732d82a7e44fa0ddb51df3L41-L45) [[2]](diffhunk://#diff-83380a112934c41699d826a5e1a07c6ee2d0729366db765c2d9c40fd2967c45bL653-L657) [[3]](diffhunk://#diff-9dcb2b34c331c83c7b15b8785fc38080f22e765d3119f854acc7848e7f669485L788)
* Removed the use of `stream_webhook_url` from Helm chart template files and resource definitions, specifically in `_sub/security/falco/main.tf` and `_sub/security/falco/values/patch.yaml`. [[1]](diffhunk://#diff-aa9c23ffa6b583e6062cbff98a98751e0f26f6c4bbfd2db28bbbe11715f9be05L11) [[2]](diffhunk://#diff-aa9c23ffa6b583e6062cbff98a98751e0f26f6c4bbfd2db28bbbe11715f9be05L37) [[3]](diffhunk://#diff-9b963db6a113863561d9126c302c54facab176a24fd4d8064be36def9cb5dd5dL11-L14)

**CI/CD workflow update:**

* Eliminated the `TF_VAR_falco_stream_webhook_url` secret from the QA GitHub Actions workflow configuration, as it is no longer needed. (`.github/workflows/qa.yml`) [[1]](diffhunk://#diff-4d515b7cca4aa254976e10e863f94e4527f5edd15f4315279f578385fc0f68b8L149) [[2]](diffhunk://#diff-4d515b7cca4aa254976e10e863f94e4527f5edd15f4315279f578385fc0f68b8L229)

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
