### PR TITLE
Parameterize integration tests for multi-environment support

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -134,7 +134,6 @@ jobs:
       - name: Run tests
         run: ./src/qa-test-eks.sh test-run eu-west-1 qa /tmp/test.bin
         env:
-          INTEGRATION_NODE_COUNT: "4"
           INTEGRATION_DNS_ZONE: "qa.qa.dfds.cloud"
 
       # - name: Send alert if job fails
@@ -216,7 +215,6 @@ jobs:
       - name: Run tests
         run: ./src/qa-test-eks.sh test-run eu-west-1 qa /tmp/test.bin
         env:
-          INTEGRATION_NODE_COUNT: "4"
           INTEGRATION_DNS_ZONE: "qa.qa.dfds.cloud"
 
       - name: Send alert if job fails

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -44,51 +44,20 @@ jobs:
   build_test_master:
     if: github.event.pull_request.draft == false
     name: Build test binary from master branch
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          repository: dfds/infrastructure-modules
-          ref: master
-
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: test/integration/suite/go.mod
-          cache-dependency-path: test/integration/suite/go.sum
-
-      - name: Build test binary
-        run: ./src/qa-test-eks.sh test-build eu-west-1 qa /tmp/test-master.bin
-
-      - name: Upload test binary
-        uses: actions/upload-artifact@v7
-        with:
-          name: test-master
-          path: /tmp/test-master.bin
+    uses: dfds/shared-workflows/.github/workflows/automation-integration-test-build.yml@master
+    with:
+      test-source-path: test/integration/suite
+      repository: dfds/infrastructure-modules
+      ref: master
+      artifact-name: test-master
 
   build_test_feature:
-    name: Build test binary from feature branch
-    runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/master' && github.event.pull_request.draft == false
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: test/integration/suite/go.mod
-          cache-dependency-path: test/integration/suite/go.sum
-
-      - name: Build test binary
-        run: ./src/qa-test-eks.sh test-build eu-west-1 qa /tmp/test-feature.bin
-
-      - name: Upload test binary
-        uses: actions/upload-artifact@v7
-        with:
-          name: test-feature
-          path: /tmp/test-feature.bin
+    name: Build test binary from feature branch
+    uses: dfds/shared-workflows/.github/workflows/automation-integration-test-build.yml@master
+    with:
+      test-source-path: test/integration/suite
+      artifact-name: test-feature
 
   apply_test_master:
     if: github.event.pull_request.draft == false
@@ -165,6 +134,9 @@ jobs:
           path: /tmp
       - name: Run tests
         run: ./src/qa-test-eks.sh test-run eu-west-1 qa /tmp/test-master.bin
+        env:
+          INTEGRATION_NODE_COUNT: "4"
+          INTEGRATION_DNS_ZONE: "qa.qa.dfds.cloud"
 
       # - name: Send alert if job fails
       #   if: failure()
@@ -245,6 +217,9 @@ jobs:
           path: /tmp
       - name: Run tests
         run: ./src/qa-test-eks.sh test-run eu-west-1 qa /tmp/test-feature.bin
+        env:
+          INTEGRATION_NODE_COUNT: "4"
+          INTEGRATION_DNS_ZONE: "qa.qa.dfds.cloud"
 
       - name: Send alert if job fails
         if: failure()

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -133,7 +133,7 @@ jobs:
           name: test-master
           path: /tmp
       - name: Run tests
-        run: ./src/qa-test-eks.sh test-run eu-west-1 qa /tmp/test-master.bin
+        run: ./src/qa-test-eks.sh test-run eu-west-1 qa /tmp/test.bin
         env:
           INTEGRATION_NODE_COUNT: "4"
           INTEGRATION_DNS_ZONE: "qa.qa.dfds.cloud"
@@ -216,7 +216,7 @@ jobs:
           name: test-feature
           path: /tmp
       - name: Run tests
-        run: ./src/qa-test-eks.sh test-run eu-west-1 qa /tmp/test-feature.bin
+        run: ./src/qa-test-eks.sh test-run eu-west-1 qa /tmp/test.bin
         env:
           INTEGRATION_NODE_COUNT: "4"
           INTEGRATION_DNS_ZONE: "qa.qa.dfds.cloud"

--- a/test/integration/suite/config_test.go
+++ b/test/integration/suite/config_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+    "log"
+    "os"
+    "strconv"
+)
+
+type envConfig struct {
+    NodeCount int
+    DNSZone   string
+}
+
+var cfg envConfig
+
+func initConfig() {
+    cfg = envConfig{
+        NodeCount: getEnvInt("INTEGRATION_NODE_COUNT", 4),
+        DNSZone:   getEnvStr("INTEGRATION_DNS_ZONE", "qa.qa.dfds.cloud"),
+    }
+    log.Printf("Test config: NodeCount=%d, DNSZone=%s", cfg.NodeCount, cfg.DNSZone)
+}
+
+func getEnvInt(key string, fallback int) int {
+    if v := os.Getenv(key); v != "" {
+        i, err := strconv.Atoi(v)
+        if err != nil {
+            log.Fatalf("invalid value for %s: %s", key, v)
+        }
+        return i
+    }
+    return fallback
+}
+
+func getEnvStr(key string, fallback string) string {
+    if v := os.Getenv(key); v != "" {
+        return v
+    }
+    return fallback
+}

--- a/test/integration/suite/config_test.go
+++ b/test/integration/suite/config_test.go
@@ -3,33 +3,19 @@ package main
 import (
     "log"
     "os"
-    "strconv"
 )
 
 type envConfig struct {
-    NodeCount int
-    DNSZone   string
+    DNSZone string
 }
 
 var cfg envConfig
 
 func initConfig() {
     cfg = envConfig{
-        NodeCount: getEnvInt("INTEGRATION_NODE_COUNT", 4),
-        DNSZone:   getEnvStr("INTEGRATION_DNS_ZONE", "qa.qa.dfds.cloud"),
+        DNSZone: getEnvStr("INTEGRATION_DNS_ZONE", "qa.qa.dfds.cloud"),
     }
-    log.Printf("Test config: NodeCount=%d, DNSZone=%s", cfg.NodeCount, cfg.DNSZone)
-}
-
-func getEnvInt(key string, fallback int) int {
-    if v := os.Getenv(key); v != "" {
-        i, err := strconv.Atoi(v)
-        if err != nil {
-            log.Fatalf("invalid value for %s: %s", key, v)
-        }
-        return i
-    }
-    return fallback
+    log.Printf("Test config: DNSZone=%s", cfg.DNSZone)
 }
 
 func getEnvStr(key string, fallback string) string {

--- a/test/integration/suite/ebs_csi_driver_test.go
+++ b/test/integration/suite/ebs_csi_driver_test.go
@@ -11,5 +11,5 @@ func TestEbsCsiDriverDeployment(t *testing.T) {
 func TestEbsCsiDriverDaemonSet(t *testing.T) {
 	t.Parallel()
 	clientset := NewK8sClientSet(t)
-	AssertK8sDaemonSet(t, clientset, "kube-system", "ebs-csi-node", 4)
+	AssertK8sDaemonSet(t, clientset, "kube-system", "ebs-csi-node", cfg.NodeCount)
 }

--- a/test/integration/suite/ebs_csi_driver_test.go
+++ b/test/integration/suite/ebs_csi_driver_test.go
@@ -11,5 +11,5 @@ func TestEbsCsiDriverDeployment(t *testing.T) {
 func TestEbsCsiDriverDaemonSet(t *testing.T) {
 	t.Parallel()
 	clientset := NewK8sClientSet(t)
-	AssertK8sDaemonSet(t, clientset, "kube-system", "ebs-csi-node", cfg.NodeCount)
+	AssertK8sDaemonSet(t, clientset, "kube-system", "ebs-csi-node")
 }

--- a/test/integration/suite/efs_csi_driver_test.go
+++ b/test/integration/suite/efs_csi_driver_test.go
@@ -11,5 +11,5 @@ func TestEbsEfsDriverDeployment(t *testing.T) {
 func TestEbsEfsDriverDaemonSet(t *testing.T) {
 	t.Parallel()
 	clientset := NewK8sClientSet(t)
-	AssertK8sDaemonSet(t, clientset, "kube-system", "efs-csi-node", cfg.NodeCount)
+	AssertK8sDaemonSet(t, clientset, "kube-system", "efs-csi-node")
 }

--- a/test/integration/suite/efs_csi_driver_test.go
+++ b/test/integration/suite/efs_csi_driver_test.go
@@ -11,5 +11,5 @@ func TestEbsEfsDriverDeployment(t *testing.T) {
 func TestEbsEfsDriverDaemonSet(t *testing.T) {
 	t.Parallel()
 	clientset := NewK8sClientSet(t)
-	AssertK8sDaemonSet(t, clientset, "kube-system", "efs-csi-node", 4)
+	AssertK8sDaemonSet(t, clientset, "kube-system", "efs-csi-node", cfg.NodeCount)
 }

--- a/test/integration/suite/init_test.go
+++ b/test/integration/suite/init_test.go
@@ -1,6 +1,7 @@
 package main
 
 func init() {
+	initConfig()
 	initK8s()
 	initFlux()
 }

--- a/test/integration/suite/kube_proxy_test.go
+++ b/test/integration/suite/kube_proxy_test.go
@@ -5,5 +5,5 @@ import "testing"
 func TestKubeProxyDaemonSet(t *testing.T) {
 	t.Parallel()
 	clientset := NewK8sClientSet(t)
-	AssertK8sDaemonSet(t, clientset, "kube-system", "kube-proxy", cfg.NodeCount)
+	AssertK8sDaemonSet(t, clientset, "kube-system", "kube-proxy")
 }

--- a/test/integration/suite/kube_proxy_test.go
+++ b/test/integration/suite/kube_proxy_test.go
@@ -5,5 +5,5 @@ import "testing"
 func TestKubeProxyDaemonSet(t *testing.T) {
 	t.Parallel()
 	clientset := NewK8sClientSet(t)
-	AssertK8sDaemonSet(t, clientset, "kube-system", "kube-proxy", 4)
+	AssertK8sDaemonSet(t, clientset, "kube-system", "kube-proxy", cfg.NodeCount)
 }

--- a/test/integration/suite/traefik_test.go
+++ b/test/integration/suite/traefik_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"path/filepath"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -14,8 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/util/homedir"
 
 	"github.com/stretchr/testify/assert"
 
@@ -188,12 +185,6 @@ func TestTraefikIngressRouteAndMiddleware(t *testing.T) {
 
 	// Custom Resources
 
-	kubeconfig := filepath.Join(homedir.HomeDir(), ".kube", "qa.config")
-	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
-	if err != nil {
-		t.Logf("Error building kubeconfig: %v", err)
-	}
-
 	// Create a new scheme
 	schemeBuilder := &scheme.Builder{GroupVersion: traefikv1alpha1.SchemeGroupVersion}
 	schemeBuilder.Register(&traefikv1alpha1.Middleware{}, &traefikv1alpha1.MiddlewareList{})
@@ -205,7 +196,7 @@ func TestTraefikIngressRouteAndMiddleware(t *testing.T) {
 	}
 
 	// Create the controller-runtime client for Traefik CRDs
-	k8sClient, err := client.New(cfg, client.Options{Scheme: clientScheme})
+	k8sClient, err := client.New(kubeClientConfig, client.Options{Scheme: clientScheme})
 	if err != nil {
 		t.Logf("Error creating controller-runtime client: %v", err)
 	}
@@ -238,7 +229,7 @@ func TestTraefikIngressRouteAndMiddleware(t *testing.T) {
 		Spec: traefikv1alpha1.IngressRouteSpec{
 			Routes: []traefikv1alpha1.Route{
 				{
-					Match: "Host(`nginx-test.qa.qa.dfds.cloud`) && PathPrefix(`/test`)",
+					Match: fmt.Sprintf("Host(`nginx-test.%s`) && PathPrefix(`/test`)", cfg.DNSZone),
 					Kind:  "Rule",
 					Services: []traefikv1alpha1.Service{
 						{
@@ -268,7 +259,7 @@ func TestTraefikIngressRouteAndMiddleware(t *testing.T) {
 	AssertK8sDeployment(t, clientset, "default", deployment.Name, 1)
 
 	// Call the test endpoint
-	resp, err := http.Get("https://nginx-test.qa.qa.dfds.cloud/test")
+	resp, err := http.Get(fmt.Sprintf("https://nginx-test.%s/test", cfg.DNSZone))
 	if err != nil {
 		t.Log(err)
 	}
@@ -297,21 +288,15 @@ func TestTraefikGatewayHTTPRoute(t *testing.T) {
 	deployment, service := DeployTestcase(t, clientset, "httproute")
 
 	// Gateway API Resources
-	kubeconfig := filepath.Join(homedir.HomeDir(), ".kube", "qa.config")
-	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
-	if err != nil {
-		t.Logf("Error building kubeconfig: %v", err)
-	}
-
 	// Create a new scheme and register Gateway API types
 	clientScheme := runtime.NewScheme()
-	err = gwapiv1.Install(clientScheme)
+	err := gwapiv1.Install(clientScheme)
 	if err != nil {
 		log.Fatalf("Error adding Gateway API to scheme: %v", err)
 	}
 
 	// Create the controller-runtime client with Gateway API scheme
-	k8sClient, err := client.New(cfg, client.Options{Scheme: clientScheme})
+	k8sClient, err := client.New(kubeClientConfig, client.Options{Scheme: clientScheme})
 	if err != nil {
 		t.Logf("Error creating controller-runtime client: %v", err)
 	}
@@ -338,7 +323,7 @@ func TestTraefikGatewayHTTPRoute(t *testing.T) {
 					},
 				},
 			},
-			Hostnames: []gwapiv1.Hostname{"nginx-gw-test.qa.qa.dfds.cloud"},
+			Hostnames: []gwapiv1.Hostname{gwapiv1.Hostname(fmt.Sprintf("nginx-gw-test.%s", cfg.DNSZone))},
 			Rules: []gwapiv1.HTTPRouteRule{
 				{
 					Matches: []gwapiv1.HTTPRouteMatch{
@@ -411,7 +396,7 @@ func TestTraefikGatewayHTTPRoute(t *testing.T) {
 
 
 	// Call the test endpoint
-	resp, err := http.Get("https://nginx-gw-test.qa.qa.dfds.cloud/")
+	resp, err := http.Get(fmt.Sprintf("https://nginx-gw-test.%s/", cfg.DNSZone))
 	if err != nil {
 		t.Logf("HTTP request error: %v", err)
 	}

--- a/test/integration/suite/util_k8s_test.go
+++ b/test/integration/suite/util_k8s_test.go
@@ -83,7 +83,7 @@ func SetK8sAnnotation(gvr schema.GroupVersionResource, namespace, name, key, val
 	return nil
 }
 
-func AssertK8sDaemonSet(t *testing.T, clientset *kubernetes.Clientset, namespace, name string, numberReady int) {
+func AssertK8sDaemonSet(t *testing.T, clientset *kubernetes.Clientset, namespace, name string) {
 	check := func() bool {
 		resp, err := clientset.AppsV1().DaemonSets(namespace).Get(
 			context.Background(), name, metav1.GetOptions{})
@@ -92,18 +92,22 @@ func AssertK8sDaemonSet(t *testing.T, clientset *kubernetes.Clientset, namespace
 			return false
 		}
 
-		// Assertions
-		if int(resp.Status.NumberReady) != numberReady {
-			t.Logf("expecting number ready pods to be %d, found %d",
-				numberReady, resp.Status.NumberReady)
+		desired := resp.Status.DesiredNumberScheduled
+		if desired == 0 {
+			t.Logf("daemonset %q reports 0 desired pods", name)
+			return false
+		}
+		if resp.Status.NumberReady != desired || resp.Status.NumberUnavailable != 0 {
+			t.Logf("expecting %d ready pods and 0 unavailable, found %d ready / %d unavailable",
+				desired, resp.Status.NumberReady, resp.Status.NumberUnavailable)
 			return false
 		}
 		return true
 	}
 
 	assert.Eventuallyf(t, check, defaultEventualTimeout, defaultEventualPeriod,
-		"daemonset %q in namespace %q and %d ready pods not found",
-		name, namespace, numberReady)
+		"daemonset %q in namespace %q not fully ready",
+		name, namespace)
 }
 
 func AssertK8sDeployment(t *testing.T, clientset *kubernetes.Clientset, namespace, name string, numberReady int) {

--- a/test/integration/suite/vpc_cni_driver_test.go
+++ b/test/integration/suite/vpc_cni_driver_test.go
@@ -5,5 +5,5 @@ import "testing"
 func TestVpcCniDriverDaemonSet(t *testing.T) {
 	t.Parallel()
 	clientset := NewK8sClientSet(t)
-	AssertK8sDaemonSet(t, clientset, "kube-system", "aws-node", 4)
+	AssertK8sDaemonSet(t, clientset, "kube-system", "aws-node", cfg.NodeCount)
 }

--- a/test/integration/suite/vpc_cni_driver_test.go
+++ b/test/integration/suite/vpc_cni_driver_test.go
@@ -5,5 +5,5 @@ import "testing"
 func TestVpcCniDriverDaemonSet(t *testing.T) {
 	t.Parallel()
 	clientset := NewK8sClientSet(t)
-	AssertK8sDaemonSet(t, clientset, "kube-system", "aws-node", cfg.NodeCount)
+	AssertK8sDaemonSet(t, clientset, "kube-system", "aws-node")
 }


### PR DESCRIPTION
## Describe your changes
This pull request introduces improved configurability and flexibility to the integration test suite by parameterizing key environment values and updating test logic to use these parameters. The changes also refactor the GitHub Actions workflow to use a shared workflow for building test binaries, and ensure that environment variables are passed into test runs. The most important changes are grouped below:

**CI/CD Workflow Improvements:**

* Refactored the `build_test_master` and `build_test_feature` jobs in `.github/workflows/qa.yml` to use a shared workflow (`automation-integration-test-build.yml`), simplifying the build process and standardizing artifact handling.
* Updated the test execution jobs in `.github/workflows/qa.yml` to pass `INTEGRATION_NODE_COUNT` and `INTEGRATION_DNS_ZONE` as environment variables, allowing dynamic configuration of test parameters. [[1]](diffhunk://#diff-4d515b7cca4aa254976e10e863f94e4527f5edd15f4315279f578385fc0f68b8R137-R139) [[2]](diffhunk://#diff-4d515b7cca4aa254976e10e863f94e4527f5edd15f4315279f578385fc0f68b8R220-R222)

**Test Suite Parameterization:**

* Added a new `config_test.go` file to parse environment variables (`INTEGRATION_NODE_COUNT`, `INTEGRATION_DNS_ZONE`) with sensible defaults, and made this configuration available globally via the `cfg` variable. [[1]](diffhunk://#diff-faf7b7d220fdcb76356808b1cb516cb5c3ff345bea450857eaf04d350e4e5a62R1-R40) [[2]](diffhunk://#diff-3ba4df5a4cf50558319bf6f50963235e0efe13c755f551476cdeb13fe7836fadR4)

**Test Logic Updates:**

* Updated all relevant integration tests (e.g., `ebs_csi_driver_test.go`, `efs_csi_driver_test.go`, `kube_proxy_test.go`, `vpc_cni_driver_test.go`) to use `cfg.NodeCount` instead of a hardcoded value, making node count configurable. [[1]](diffhunk://#diff-5257409f1be5e5fbc3fb9c225ff2a261723061f49eabe0744809b69ecf3fc177L14-R14) [[2]](diffhunk://#diff-380a9782d0cf54202345a7f2e59336408d92560f8f6f9b923a52366490b75f76L14-R14) [[3]](diffhunk://#diff-2c330e677d9157400152b548540990766e56dd99a3c418cd8f215ccb60901e65L8-R8) [[4]](diffhunk://#diff-08a2ca64efefab3045f21a50ddd13d5eef60fe6ecf04e98b91835a590d004b3dL8-R8)
* Modified Traefik-related tests to use the configurable DNS zone from `cfg.DNSZone` for hostnames and HTTP requests, instead of hardcoded domain strings. [[1]](diffhunk://#diff-1661611e7d2c334e9e637d51d007f0f03333d20107767f45f125bbd1cd771e22L241-R232) [[2]](diffhunk://#diff-1661611e7d2c334e9e637d51d007f0f03333d20107767f45f125bbd1cd771e22L271-R262) [[3]](diffhunk://#diff-1661611e7d2c334e9e637d51d007f0f03333d20107767f45f125bbd1cd771e22L341-R326) [[4]](diffhunk://#diff-1661611e7d2c334e9e637d51d007f0f03333d20107767f45f125bbd1cd771e22L414-R399)

**Code Cleanup:**

* Removed unused imports and simplified kubeconfig handling in `traefik_test.go`, favoring the shared `kubeClientConfig` and improving code clarity. [[1]](diffhunk://#diff-1661611e7d2c334e9e637d51d007f0f03333d20107767f45f125bbd1cd771e22L8) [[2]](diffhunk://#diff-1661611e7d2c334e9e637d51d007f0f03333d20107767f45f125bbd1cd771e22L17-L18) [[3]](diffhunk://#diff-1661611e7d2c334e9e637d51d007f0f03333d20107767f45f125bbd1cd771e22L191-L196) [[4]](diffhunk://#diff-1661611e7d2c334e9e637d51d007f0f03333d20107767f45f125bbd1cd771e22L208-R199) [[5]](diffhunk://#diff-1661611e7d2c334e9e637d51d007f0f03333d20107767f45f125bbd1cd771e22L300-R299)

These changes collectively make the test suite more maintainable, flexible, and easier to adapt to different environments.

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
