### PR TITLE
use built-in GITHUB_TOKEN for tool install, least privil

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -76,7 +76,7 @@ jobs:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 60s
         uses: gruntwork-io/terragrunt-action@v3
         with:
-          github_token: ${{ secrets.SHARED_WORKFLOW_HOUSEKEEPING }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -157,7 +157,7 @@ jobs:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 60s
         uses: gruntwork-io/terragrunt-action@v3
         with:
-          github_token: ${{ secrets.SHARED_WORKFLOW_HOUSEKEEPING }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6


### PR DESCRIPTION
## Describe your changes
This pull request updates the GitHub Actions workflow configuration to use the default `GITHUB_TOKEN` instead of a custom secret for authentication with the `gruntwork-io/terragrunt-action`. This change improves maintainability and security by relying on the built-in GitHub token.

Workflow authentication update:

* Updated the `github_token` input for `gruntwork-io/terragrunt-action` from `secrets.SHARED_WORKFLOW_HOUSEKEEPING` to `secrets.GITHUB_TOKEN` in two places within `.github/workflows/qa.yml`. [[1]](diffhunk://#diff-4d515b7cca4aa254976e10e863f94e4527f5edd15f4315279f578385fc0f68b8L79-R79) [[2]](diffhunk://#diff-4d515b7cca4aa254976e10e863f94e4527f5edd15f4315279f578385fc0f68b8L160-R160)

## Issue ticket number and link
Chore

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
