### PR TITLE
Add EBS CSI snapshotter memory configuration and remove csi-gp2 storage class

### DIFF
--- a/_sub/compute/eks-addons/main.tf
+++ b/_sub/compute/eks-addons/main.tf
@@ -45,6 +45,19 @@ resource "aws_eks_addon" "aws-ebs-csi-driver" {
     node = {
       metadataSources = "kubernetes" # IMDS is no longer available for AL2023, because of hop limit of 1
     }
+    sidecars = {
+      snapshotter = {
+        resources = {
+          requests = {
+            cpu    = "10m"
+            memory = var.ebs_csi_snapshotter_memory
+          }
+          limits = {
+            memory = var.ebs_csi_snapshotter_memory
+          }
+        }
+      }
+    }
   })
 
   depends_on = [
@@ -191,26 +204,6 @@ resource "aws_iam_role_policy_attachment" "managed-efs-csi-driver-policy" {
 
 # Storage classes
 
-resource "kubernetes_storage_class" "csi-gp2" {
-  metadata {
-    name = "csi-gp2"
-    annotations = {
-      "storageclass.kubernetes.io/is-default-class" = "false"
-    }
-  }
-  storage_provisioner    = "ebs.csi.aws.com"
-  reclaim_policy         = "Delete"
-  volume_binding_mode    = "WaitForFirstConsumer"
-  allow_volume_expansion = "true"
-  parameters = {
-    type = "gp2"
-  }
-
-  depends_on = [
-    aws_eks_addon.aws-ebs-csi-driver
-  ]
-}
-
 resource "kubernetes_storage_class" "csi-gp3" {
   metadata {
     name = "csi-gp3"
@@ -231,6 +224,9 @@ resource "kubernetes_storage_class" "csi-gp3" {
   ]
 }
 
+# This storage class is coming from the EKS addon,
+# but we need to patch it to not be the default storage class,
+# since it uses gp2 which we don't want to use.
 resource "kubernetes_annotations" "gp2-not-default" {
   api_version = "storage.k8s.io/v1"
   kind        = "StorageClass"

--- a/_sub/compute/eks-addons/vars.tf
+++ b/_sub/compute/eks-addons/vars.tf
@@ -66,6 +66,5 @@ variable "podidentity_version_override" {
 
 variable "ebs_csi_snapshotter_memory" {
   type        = string
-  description = "Memory request for the EBS CSI snapshotter container. Default is 512Mi."
-  default     = "512Mi"
+  description = "Memory request for the EBS CSI snapshotter container."
 }

--- a/_sub/compute/eks-addons/vars.tf
+++ b/_sub/compute/eks-addons/vars.tf
@@ -63,3 +63,9 @@ variable "podidentity_version_override" {
   description = "Option to override the version of the eks-pod-identity-agent add-on"
   default     = ""
 }
+
+variable "ebs_csi_snapshotter_memory" {
+  type        = string
+  description = "Memory request for the EBS CSI snapshotter container. Default is 512Mi."
+  default     = "512Mi"
+}

--- a/_sub/compute/eks-nodegroup-managed/main.tf
+++ b/_sub/compute/eks-nodegroup-managed/main.tf
@@ -31,8 +31,8 @@ resource "aws_launch_template" "eks" {
   }
 
   metadata_options {
-    http_endpoint                = "enabled"
-    http_tokens                  = "required"
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
     http_put_response_hop_limit = 1
   }
 
@@ -40,7 +40,7 @@ resource "aws_launch_template" "eks" {
     device_name = "/dev/xvda"
     ebs {
       volume_size           = var.disk_size
-      volume_type           = var.disk_type
+      volume_type           = "gp3"
       delete_on_termination = true
     }
   }

--- a/_sub/compute/eks-nodegroup-managed/vars.tf
+++ b/_sub/compute/eks-nodegroup-managed/vars.tf
@@ -51,15 +51,6 @@ variable "disk_size" {
   type = number
 }
 
-variable "disk_type" {
-  type = string
-
-  validation {
-    condition     = contains(["gp2", "gp3"], var.disk_type)
-    error_message = "Allowed types for the disk are gp2 or gp3."
-  }
-}
-
 variable "instance_types" {
   type    = list(string)
   default = []

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -332,6 +332,7 @@ module "eks_addons" {
   eks_openid_connect_provider_url  = module.eks_cluster.eks_openid_connect_provider_url
   efs_fs_id                        = module.efs_fs.id
   ebs_csi_kms_arn                  = var.eks_addon_awsebscsidriver_kms_arn
+  ebs_csi_snapshotter_memory       = var.eks_addon_ebs_csi_snapshotter_memory
 }
 
 module "k8s_priority_class" {

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -263,7 +263,6 @@ module "eks_managed_workers_node_group" {
   instance_types             = each.value.instance_types
   use_spot_instances         = each.value.use_spot_instances
   disk_size                  = each.value.disk_size
-  disk_type                  = each.value.disk_type
   desired_size_per_subnet    = each.value.desired_size_per_subnet
   taints                     = each.value.taints
   labels                     = each.value.labels

--- a/compute/eks-ec2/vars.tf
+++ b/compute/eks-ec2/vars.tf
@@ -169,6 +169,12 @@ variable "eks_k8s_auth_api_version" {
   default     = "client.authentication.k8s.io/v1beta1"
 }
 
+variable "eks_addon_ebs_csi_snapshotter_memory" {
+  type        = string
+  description = "Memory request for the EBS CSI snapshotter container. Default is 512Mi."
+  default     = "512Mi"
+}
+
 # --------------------------------------------------
 # EKS managed node group
 # --------------------------------------------------

--- a/compute/eks-ec2/vars.tf
+++ b/compute/eks-ec2/vars.tf
@@ -178,7 +178,6 @@ variable "eks_managed_nodegroups" {
     instance_types             = optional(list(string), ["t3.small"])
     use_spot_instances         = optional(bool, false)
     disk_size                  = optional(number, 128)
-    disk_type                  = optional(string, "gp3")
     desired_size_per_subnet    = optional(number, 0)
     availability_zones         = optional(list(string), [])
     max_unavailable            = optional(number, null)

--- a/compute/eks-ec2/versions.tf
+++ b/compute/eks-ec2/versions.tf
@@ -13,11 +13,6 @@ terraform {
       version = ">= 2.38.0"
     }
 
-    tls = {
-      source  = "hashicorp/tls"
-      version = ">= 4.1.0"
-    }
-
   }
 
 }


### PR DESCRIPTION
- **Update EBS volume type to only allow gp3 and remove disk_type variable**
- **Add EBS CSI snapshotter memory configuration and update related modules**

## Describe your changes

This pull request makes several improvements to the EKS (Elastic Kubernetes Service) Terraform modules, focusing on simplifying disk configuration, enhancing the EBS CSI driver setup, and cleaning up unused resources and variables. The most important changes are summarized below:

**EBS CSI Driver and Storage Class Improvements:**
* Added configuration for the EBS CSI snapshotter sidecar, allowing customization of its memory requests and limits via the new variable `ebs_csi_snapshotter_memory`. This enhances flexibility and resource management for the EBS CSI driver (`_sub/compute/eks-addons/main.tf`, `compute/eks-ec2/main.tf`, `compute/eks-ec2/vars.tf`, `_sub/compute/eks-addons/vars.tf`). [[1]](diffhunk://#diff-a043032adae754329a445c95c2ae927fcdc02359c6d7a3eb82cdbce97297b48bR48-R60) [[2]](diffhunk://#diff-377519e7ca2d872af5e1381cb6c57e93942c12625344ff8fc8a970e19a400742R335) [[3]](diffhunk://#diff-b18f8354ea8f3932f1be0681155c6e70c457a10798e9be3a07994adfea3d16b3R172-R177) [[4]](diffhunk://#diff-8b141c11237d6b83a4411f3389c188d22e4adda50b1f2b8a78ac2cc121c6491eR66-R71)
* Removed the legacy `csi-gp2` storage class resource, and ensured that the default storage class is not set to `gp2`, aligning with best practices and current AWS recommendations (`_sub/compute/eks-addons/main.tf`). [[1]](diffhunk://#diff-a043032adae754329a445c95c2ae927fcdc02359c6d7a3eb82cdbce97297b48bL194-L213) [[2]](diffhunk://#diff-a043032adae754329a445c95c2ae927fcdc02359c6d7a3eb82cdbce97297b48bR227-R229)

**Disk Configuration Simplification:**
* Standardized EKS node group disk types to `gp3` by default, removing the `disk_type` variable from node group modules and variables. This reduces configuration complexity and enforces the use of the preferred disk type (`_sub/compute/eks-nodegroup-managed/main.tf`, `compute/eks-ec2/main.tf`, `compute/eks-ec2/vars.tf`, `_sub/compute/eks-nodegroup-managed/vars.tf`). [[1]](diffhunk://#diff-433c151dbb675a65e04574da2d95430b1cf8c9806eb62ed2adef18b8b6ecd8c2L43-R43) [[2]](diffhunk://#diff-377519e7ca2d872af5e1381cb6c57e93942c12625344ff8fc8a970e19a400742L266) [[3]](diffhunk://#diff-b18f8354ea8f3932f1be0681155c6e70c457a10798e9be3a07994adfea3d16b3L181) [[4]](diffhunk://#diff-02c4dec2654cbdd6b9ee622b405117081a32a236919b3b6693162357784ce3daL54-L62)

**Terraform Provider Cleanup:**
* Removed the unused `tls` provider block from the Terraform configuration, reducing unnecessary dependencies (`compute/eks-ec2/versions.tf`).

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
