### PR TITLE
feat(iam): add capability role for ec2-inventory-api

### DIFF
--- a/_sub/security/iam-policies/main.tf
+++ b/_sub/security/iam-policies/main.tf
@@ -239,6 +239,22 @@ data "aws_iam_policy_document" "ssu_ecr_pull_compliance_exporter" {
   }
 }
 
+# ssu ec2-inventory-api
+data "aws_iam_policy_document" "ssu_ec2_inventory_api" {
+  statement {
+    sid    = "SsoReaderTf"
+    effect = "Allow"
+    actions = [
+      "iam:ListAccountAliases",
+      "ec2:DescribeRegions",
+      "ec2:DescribeInstances",
+      "ec2:DescribeImages"
+    ]
+    resources = [
+      "*"
+    ]
+  }
+}
 
 # VPCReader
 data "aws_iam_policy_document" "vpcreader" {

--- a/_sub/security/iam-policies/outputs.tf
+++ b/_sub/security/iam-policies/outputs.tf
@@ -18,6 +18,10 @@ output "ssuecrpullcomplianceexporter" {
   value = data.aws_iam_policy_document.ssu_ecr_pull_compliance_exporter.json
 }
 
+output "ssuec2inventoryapi" {
+  value = data.aws_iam_policy_document.ssu_ec2_inventory_api.json
+}
+
 output "vpcreader" {
   value = data.aws_iam_policy_document.vpcreader.json
 }

--- a/security/org-account-context/dependencies.tf
+++ b/security/org-account-context/dependencies.tf
@@ -53,6 +53,17 @@ data "aws_iam_policy_document" "assume_role_policy_ecr_pull_compliance_exporter"
   }
 }
 
+data "aws_iam_policy_document" "assume_role_policy_ec2_inventory_api" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.ssu_account_id}:role/ssu-ec2-inventory-api"]
+    }
+  }
+}
+
 data "aws_iam_policy_document" "assume_role_policy_selfservice_api" {
   statement {
     actions = ["sts:AssumeRole"]

--- a/security/org-account-context/main.tf
+++ b/security/org-account-context/main.tf
@@ -172,6 +172,21 @@ module "iam_role_ssu_ecr_pull_compliance_exporter" {
   }
 }
 
+module "iam_role_ssu_ec2_inventory_api" {
+  source               = "../../_sub/security/iam-role"
+  role_name            = "ssu-ec2-inventory-api"
+  role_description     = "Allows ec2-inventory-api to make inventory of EC2 instances"
+  max_session_duration = 28800 # 8 hours
+  assume_role_policy   = data.aws_iam_policy_document.assume_role_policy_ec2_inventory_api.json
+  role_policy_name     = "ssuEc2InventoryApi"
+  role_policy_document = module.iam_policies.ssuec2inventoryapi
+
+  providers = {
+    aws = aws.workload
+  }
+}
+
+
 module "iam_role_vpc_reader" {
   source               = "../../_sub/security/iam-role"
   role_name            = "vpc-reader"


### PR DESCRIPTION
For use in a service that shows people their vulnerable EC2 instances