### PR TITLE
run on self-hosted dfds-runners

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -13,7 +13,6 @@ on:
       - "renovate.json"
       - "test/**"
       - "src/**"
-      - "mise.toml"
 
 jobs:
   auto-release:

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -50,6 +50,8 @@ jobs:
       repository: dfds/infrastructure-modules
       ref: master
       artifact-name: test-master
+      runner: dfds-runners
+      container: 579478677147.dkr.ecr.eu-central-1.amazonaws.com/docker-hub/dfdsdk/prime-pipeline:2.2.3
 
   build_test_feature:
     if: github.ref != 'refs/heads/master' && github.event.pull_request.draft == false
@@ -58,11 +60,15 @@ jobs:
     with:
       test-source-path: test/integration/suite
       artifact-name: test-feature
+      runner: dfds-runners
+      container: 579478677147.dkr.ecr.eu-central-1.amazonaws.com/docker-hub/dfdsdk/prime-pipeline:2.2.3
 
   apply_test_master:
     if: github.event.pull_request.draft == false
     name: Provision from master branch
-    runs-on: ubuntu-latest
+    runs-on: dfds-runners
+    container:
+      image: 579478677147.dkr.ecr.eu-central-1.amazonaws.com/docker-hub/dfdsdk/prime-pipeline:2.2.3
     needs: build_test_master
     steps:
       - name: Checkout code
@@ -70,13 +76,6 @@ jobs:
         with:
           repository: dfds/infrastructure-modules
           ref: master
-
-      - name: Install Terragrunt and OpenTofu
-        env:
-          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 60s
-        uses: gruntwork-io/terragrunt-action@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -145,19 +144,14 @@ jobs:
 
   apply_test_feature:
     name: Apply from feature branch
-    runs-on: ubuntu-latest
+    runs-on: dfds-runners
+    container:
+      image: 579478677147.dkr.ecr.eu-central-1.amazonaws.com/docker-hub/dfdsdk/prime-pipeline:2.2.3
     needs: [apply_test_master, build_test_feature]
     if: github.ref != 'refs/heads/master' && github.event.pull_request.draft == false
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-
-      - name: Install Terragrunt and OpenTofu
-        env:
-          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 60s
-        uses: gruntwork-io/terragrunt-action@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,0 @@
-[tools]
-terragrunt = "1.0.1"
-opentofu = "1.11.6"

--- a/renovate.json
+++ b/renovate.json
@@ -92,8 +92,7 @@
       "description": "Group dependencies affecting the QA environment and it's test resources.",
       "matchFileNames": [
         "test/integration/**",
-        ".github/**",
-        "mise.toml"
+        ".github/**"
       ],
       "addLabels": [
         "norelease"


### PR DESCRIPTION
## Describe your changes
This pull request updates the GitHub Actions workflow in `.github/workflows/qa.yml` to standardize the execution environment by using custom runners and a specific container image, and it removes the installation step for Terragrunt and OpenTofu. These changes help ensure consistency across jobs and streamline the workflow.

**Environment standardization:**

* All jobs now run on the custom `dfds-runners` instead of the default `ubuntu-latest` runner, and use the `579478677147.dkr.ecr.eu-central-1.amazonaws.com/docker-hub/dfdsdk/prime-pipeline:2.2.3` container image for execution. This applies to `build_test_master`, `build_test_feature`, `apply_test_master`, and `apply_test_feature` jobs. [[1]](diffhunk://#diff-4d515b7cca4aa254976e10e863f94e4527f5edd15f4315279f578385fc0f68b8R53-R54) [[2]](diffhunk://#diff-4d515b7cca4aa254976e10e863f94e4527f5edd15f4315279f578385fc0f68b8R63-R71) [[3]](diffhunk://#diff-4d515b7cca4aa254976e10e863f94e4527f5edd15f4315279f578385fc0f68b8L148-L161)

**Workflow simplification:**

* The steps to install Terragrunt and OpenTofu using `gruntwork-io/terragrunt-action@v3` have been removed from both the `apply_test_master` and `apply_test_feature` jobs, simplifying the workflow and potentially relying on the container image to provide these dependencies. [[1]](diffhunk://#diff-4d515b7cca4aa254976e10e863f94e4527f5edd15f4315279f578385fc0f68b8L74-L80) [[2]](diffhunk://#diff-4d515b7cca4aa254976e10e863f94e4527f5edd15f4315279f578385fc0f68b8L148-L161)

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
