### PR TITLE
Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "local>dfds/renovate-config"
   ],
-  "branchPrefix": "feature/renovate/",
+
   "ignorePaths": [
     "test/integration/suite/vendor/**"
   ],
@@ -42,50 +42,18 @@
   ],
   "packageRules": [
     {
-        "matchUpdateTypes": [
-            "lockFileMaintenance"
-        ],
-        "addLabels": [
-            "lockFile"
-        ],
-        "minimumReleaseAge": "0 days",
-        "automerge": true,
-        "ignoreTests": false,
-        "matchCurrentVersion": "!/^0/"
-    },
-    {
       "matchUpdateTypes": [
-        "pin",
-        "digest",
-        "patch"
-      ],
-      "addLabels": [
-        "release:patch"
-      ],
-      "minimumReleaseAge": "0 days",
-      "automerge": true,
-      "ignoreTests": false,
-      "matchCurrentVersion": "!/^0/"
-    },
-    {
-      "matchUpdateTypes": [
+        "patch",
         "minor"
       ],
       "addLabels": [
         "release:patch"
-      ],
-      "minimumReleaseAge": "1 days",
-      "automerge": false,
-      "ignoreTests": false,
-      "matchCurrentVersion": "!/^0/"
+      ]
     },
     {
       "matchUpdateTypes": [
         "major"
       ],
-      "minimumReleaseAge": "7 days",
-      "automerge": false,
-      "ignoreTests": false,
       "matchCurrentVersion": "!/^0/"
     },
     {


### PR DESCRIPTION
This pull request updates the `renovate.json` configuration to use a shared Renovate config and simplifies the package update rules. The main changes are switching to a centralized config and consolidating and removing several custom rules for dependency updates.

Configuration changes:

* Switched the `extends` property to use the shared `local>dfds/renovate-config` instead of the default recommended config, centralizing Renovate settings.

Package update rule simplification:

* Removed custom rules for `lockFileMaintenance`, `pin`, and `digest` updates, as well as automerge and minimum release age settings for patches and majors, consolidating to a single rule for `patch` and `minor` updates with the `release:patch` label.