### PR TITLE
fix grafana_deploy toggle type

### DIFF
--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -386,7 +386,7 @@ variable "enable_inactivity_cleanup" {
 # --------------------------------------------------
 
 variable "grafana_deploy" {
-  type        = string
+  type        = bool
   default     = false
   description = <<-EOT
       Feature toggle for Grafana module.


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
This pull request makes a minor improvement to the `grafana_deploy` variable in the Kubernetes services Terraform configuration. The type of the variable was changed from `string` to `bool` to better reflect its intended use as a feature toggle.

- Changed the type of the `grafana_deploy` variable from `string` to `bool` in `vars.tf` to improve type safety and clarity.
## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
