### PR TITLE
workaround implemented and module version updated

### DIFF
--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -491,7 +491,7 @@ module "eks_version_endpoint" {
 # --------------------------------------------------
 module "karpenter" {
   source                        = "terraform-aws-modules/eks/aws//modules/karpenter"
-  version                       = "21.20.0"
+  version                       = "21.22.0"
   create                        = true
   cluster_name                  = var.eks_cluster_name
   create_access_entry           = true
@@ -503,6 +503,7 @@ module "karpenter" {
   node_iam_role_additional_policies = {
     AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore" # Enable SSM core functionality
   }
+  enable_inline_policy          = true
   depends_on = [module.eks_cluster]
 }
 

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -491,7 +491,7 @@ module "eks_version_endpoint" {
 # --------------------------------------------------
 module "karpenter" {
   source                        = "terraform-aws-modules/eks/aws//modules/karpenter"
-  version                       = "21.22.0"
+  version                       = "21.20.0"
   create                        = true
   cluster_name                  = var.eks_cluster_name
   create_access_entry           = true


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
implement workaround https://github.com/terraform-aws-modules/terraform-aws-eks/issues/3692 to fix error in pipeline:

```Error: updating IAM Policy (arn:aws:iam::238947446290:policy/KarpenterController-20251021113841488100000008): operation error IAM: CreatePolicyVersion, https response error StatusCode: 409, RequestID: f5df75d9-2989-472a-a653-de7551ab606a, LimitExceeded: Cannot exceed quota for PolicySize: 6144```

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
