### PR TITLE
Setting fluxcd_tenants to empty, since it is failing and cant consume the referenced repo

### DIFF
--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -71,17 +71,7 @@ inputs = {
   fluxcd_bootstrap_repo_name        = "platform-manifests-qa"
   fluxcd_version                    = "v2.7.5"
 
-  fluxcd_tenants = [
-    {
-      namespace = "flux-tenant-test"
-      repositories = [
-        {
-          url = "https://github.com/dfds/flux-tenant-test"
-          branch = "main"
-        }
-      ]
-    }
-  ]
+  fluxcd_tenants = []
 
   # --------------------------------------------------
   # Atlantis


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->

Setting fluxcd_tenants to empty, since it is failing and cant consume the referenced repo with error below.

`failed to get secret 'flux-tenant-test/flux-tenant-test': failed to get secret 'flux-tenant-test/flux-tenant-test': secrets "flux-tenant-test" not found`

This is a perfect example of flux tenant setup not working due to manual applied PAT tokens, since we delete QA from time to time.

So in my mind the only thing we are testing here is that we can write files to Github and then turning the blind eye to it failing when flux is consuming it.

An argument could be made to write a test, but it would fail again on cluster recreation due to above mentioned bug with manual applied PAT tokens.

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
