### PR TITLE
Fix/qa/test/traefik/race condition

### DIFF
--- a/test/integration/suite/traefik_test.go
+++ b/test/integration/suite/traefik_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"testing"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
@@ -25,38 +26,38 @@ import (
 )
 
 func GetTraefikNamespace(clientset *kubernetes.Clientset) *string {
-    ctx := context.TODO()
+	ctx := context.TODO()
 
-    // Get all namespaces
-    namespaces, err := clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
-    if err != nil {
-        log.Printf("Error listing namespaces: %v", err)
-        return nil
-    }
+	// Get all namespaces
+	namespaces, err := clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		log.Printf("Error listing namespaces: %v", err)
+		return nil
+	}
 
-    // Check for Traefik namespace variants
-    traefikVariants := []string{"traefik-blue-variant", "traefik-green-variant"}
+	// Check for Traefik namespace variants
+	traefikVariants := []string{"traefik-blue-variant", "traefik-green-variant"}
 
-    for _, ns := range namespaces.Items {
-        for _, variant := range traefikVariants {
-            if ns.Name == variant {
-                return &variant
-            }
-        }
-    }
+	for _, ns := range namespaces.Items {
+		for _, variant := range traefikVariants {
+			if ns.Name == variant {
+				return &variant
+			}
+		}
+	}
 
-    return nil
+	return nil
 }
 
 func TestTraefikDeployment(t *testing.T) {
 	clientset := NewK8sClientSet(t)
 	AssertFluxReconciliation(t, clientset)
 	traefikNamespace := GetTraefikNamespace(clientset)
-    if traefikNamespace == nil {
-        t.Fatal("Traefik namespace not found")
-    }
+	if traefikNamespace == nil {
+		t.Fatal("Traefik namespace not found")
+	}
 
-    AssertK8sDeployment(t, clientset, *traefikNamespace, *traefikNamespace, 3)
+	AssertK8sDeployment(t, clientset, *traefikNamespace, *traefikNamespace, 3)
 }
 
 func DeployTestcase(t *testing.T, clientset *kubernetes.Clientset, testName string) (*appsv1.Deployment, *apiv1.Service) {
@@ -258,12 +259,24 @@ func TestTraefikIngressRouteAndMiddleware(t *testing.T) {
 
 	AssertK8sDeployment(t, clientset, "default", deployment.Name, 1)
 
-	// Call the test endpoint
-	resp, err := http.Get(fmt.Sprintf("https://nginx-test.%s/test", cfg.DNSZone))
-	if err != nil {
-		t.Log(err)
+	// Call the test endpoint with retry
+	var resp *http.Response
+	for i := range 3 {
+		resp, err = http.Get(fmt.Sprintf("https://nginx-test.%s/test", cfg.DNSZone))
+		if err == nil && resp.StatusCode == 200 {
+			break
+		}
+		if err != nil {
+			t.Logf("attempt %d: HTTP request error: %v", i+1, err)
+		} else {
+			t.Logf("attempt %d: unexpected status code: %d", i+1, resp.StatusCode)
+			resp.Body.Close()
+		}
+		time.Sleep(5 * time.Second)
 	}
-	defer resp.Body.Close()
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	assert.Equal(t, 200, resp.StatusCode)
 
 	// Delete resources
@@ -394,13 +407,24 @@ func TestTraefikGatewayHTTPRoute(t *testing.T) {
 		t.Logf("Error getting Gateway %s/%s: %v", *traefikNamespace, "traefik-gateway", err)
 	}
 
-
-	// Call the test endpoint
-	resp, err := http.Get(fmt.Sprintf("https://nginx-gw-test.%s/", cfg.DNSZone))
-	if err != nil {
-		t.Logf("HTTP request error: %v", err)
+	// Call the test endpoint with retry
+	var resp *http.Response
+	for i := range 3 {
+		resp, err = http.Get(fmt.Sprintf("https://nginx-gw-test.%s/", cfg.DNSZone))
+		if err == nil && resp.StatusCode == 200 {
+			break
+		}
+		if err != nil {
+			t.Logf("attempt %d: HTTP request error: %v", i+1, err)
+		} else {
+			t.Logf("attempt %d: unexpected status code: %d", i+1, resp.StatusCode)
+			resp.Body.Close()
+		}
+		time.Sleep(5 * time.Second)
 	}
-	defer resp.Body.Close()
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	assert.Equal(t, 200, resp.StatusCode)
 
 	// Delete HTTPRoute

--- a/test/integration/suite/traefik_test.go
+++ b/test/integration/suite/traefik_test.go
@@ -272,7 +272,7 @@ func TestTraefikIngressRouteAndMiddleware(t *testing.T) {
 			t.Logf("attempt %d: unexpected status code: %d", i+1, resp.StatusCode)
 			resp.Body.Close()
 		}
-		time.Sleep(5 * time.Second)
+		time.Sleep(3 * time.Second)
 	}
 	if resp != nil {
 		defer resp.Body.Close()
@@ -420,7 +420,7 @@ func TestTraefikGatewayHTTPRoute(t *testing.T) {
 			t.Logf("attempt %d: unexpected status code: %d", i+1, resp.StatusCode)
 			resp.Body.Close()
 		}
-		time.Sleep(5 * time.Second)
+		time.Sleep(3 * time.Second)
 	}
 	if resp != nil {
 		defer resp.Body.Close()


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
Fix race condition errors for Traefik testing with retries. We will retry 3 times and sleep for 3 seconds in between.

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
