### PR TITLE
remove unused grafana variables

### DIFF
--- a/_sub/monitoring/grafana/vars.tf
+++ b/_sub/monitoring/grafana/vars.tf
@@ -43,25 +43,6 @@ variable "agent_resource_memory_limit" {
   description = "Set resource memory limits on Grafana Agent container"
 }
 
-variable "tolerations" {
-  type = list(object({
-    key      = string,
-    operator = string,
-    value    = optional(string),
-    effect   = string,
-  }))
-  default = []
-}
-
-variable "affinity" {
-  type = list(object({
-    key      = string,
-    operator = string,
-    values   = list(string)
-  }))
-  default = []
-}
-
 variable "agent_replicas" {
   type        = number
   description = "How many replicas to run Grafana Agent with"

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -613,8 +613,6 @@ module "grafana" {
   open_cost_enabled                      = var.grafana_agent_open_cost_enabled
   agent_resource_memory_limit            = var.grafana_agent_resource_memory_limit
   agent_resource_memory_request          = var.grafana_agent_resource_memory_request
-  affinity                               = var.observability_affinity
-  tolerations                            = var.observability_tolerations
   agent_replicas                         = var.grafana_agent_replicas
   storage_size                           = var.grafana_agent_storage_size
   grafana_stack                          = local.grafana_stack

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -479,26 +479,6 @@ variable "grafana_agent_storage_size" {
   default     = "5Gi"
 }
 
-variable "observability_tolerations" {
-  type = list(object({
-    key      = string,
-    operator = string,
-    value    = optional(string),
-    effect   = string,
-  }))
-  description = "Tolerations to apply to the cluster-wide observability workloads."
-  default     = []
-}
-
-variable "observability_affinity" {
-  type = list(object({
-    key      = string,
-    operator = string,
-    values   = list(string)
-  }))
-  description = "Affinities to apply to the cluster-wide observability workloads."
-  default     = []
-}
 
 # --------------------------------------------------
 # External Secrets with SSM

--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -106,21 +106,6 @@ inputs = {
   grafana_agent_resource_memory_limit   = "4Gi"
   grafana_agent_storage_size = "10Gi"
 
-  observability_tolerations = [
-    {
-      key      = "observability.dfds",
-      operator = "Exists",
-      effect   = "NoSchedule",
-    }
-  ]
-  observability_affinity = [
-    {
-      key      = "dedicated",
-      operator = "In",
-      values   = ["observability"],
-    }
-  ]
-
   # --------------------------------------------------
   # External Secrets
   # --------------------------------------------------


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
This pull request removes the `affinity` and `tolerations` configuration because they are now part of platform-apps

Configuration cleanup:

* Removed the `tolerations` and `affinity` variables from `_sub/monitoring/grafana/vars.tf`, so these options are no longer configurable for the Grafana Agent module.
* Removed the `observability_tolerations` and `observability_affinity` variables from `compute/k8s-services/vars.tf`, eliminating these cluster-wide observability workload settings.
* Stopped passing `affinity` and `tolerations` to the `grafana` module in `compute/k8s-services/main.tf`, as these variables have been removed.
## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
