### PR TITLE
Remove/eks nodegroup managed/containerd v2 logic

### DIFF
--- a/_sub/compute/eks-cluster/vars.tf
+++ b/_sub/compute/eks-cluster/vars.tf
@@ -3,7 +3,12 @@ variable "cluster_name" {
 }
 
 variable "cluster_version" {
-  type = string
+  type        = string
+  description = "The Kubernetes version for the EKS cluster. Must be >= 1.34."
+  validation {
+    condition     = tonumber(split(".", var.cluster_version)[0]) > 1 || (tonumber(split(".", var.cluster_version)[0]) == 1 && tonumber(split(".", var.cluster_version)[1]) >= 34)
+    error_message = "cluster_version must be >= 1.34."
+  }
 }
 
 variable "cluster_zones" {

--- a/_sub/compute/eks-nodegroup-managed/dependencies.tf
+++ b/_sub/compute/eks-nodegroup-managed/dependencies.tf
@@ -19,29 +19,3 @@ locals {
   # Pins AMI to 'ami_id' if it is set, otherwise, sets to the latest AMI.
   node_ami = var.ami_id != "" ? var.ami_id : data.aws_ami.eks-node.id
 }
-
-# AMI is using containerd v2 logic
-data "aws_ami" "this" {
-  filter {
-    name   = "image-id"
-    values = [local.node_ami]
-  }
-  most_recent = true
-  owners      = ["602401143452"] # Amazon Account ID
-}
-
-locals {
-  ami_defined_cluster_version = reverse(split("-", data.aws_ami.this.name))[1]                                                                                                                                                           # cluster version from AMI name, e.g. "amazon-eks-node-al2023-x86_64-standard-1.33-v20251016" -> 1.33
-  cluster_version_gt_133      = (tonumber(split(".", local.ami_defined_cluster_version)[0]) == 1 && tonumber(split(".", local.ami_defined_cluster_version)[1]) >= 34) || tonumber(split(".", local.ami_defined_cluster_version)[0]) >= 2 # versions above 1.33 uses containerd v2, which uses different syntaxt for image registry auth
-
-  ami_date = tonumber(trim(reverse(split("-", data.aws_ami.this.name))[0], "v")) # extracts the date from the AMI name, e.g. "amazon-eks-node-al2023-x86_64-standard-1.33-v20251016" -> 20251016
-
-  cluster_version_containerdv2_cuttoff_date = {
-    "1.33" = 20251016
-    "1.32" = 20251023
-    "1.31" = 20251030
-    "1.30" = 20251106
-  } # dates containerd v2 will be backported to EKS Optimized AL2023 AMIs (https://github.com/awslabs/amazon-eks-ami/issues/2470#issue-3514989135)
-
-  ami_using_containerd_v2 = local.cluster_version_gt_133 || local.ami_date >= lookup(local.cluster_version_containerdv2_cuttoff_date, local.ami_defined_cluster_version, 99999999) # first portion checks if cluster version is > 1.33, second portion checks if AMI date is >= cuttoff date for the cluster version
-}

--- a/_sub/compute/eks-nodegroup-managed/main.tf
+++ b/_sub/compute/eks-nodegroup-managed/main.tf
@@ -20,7 +20,6 @@ resource "aws_launch_template" "eks" {
     sys_cpu : var.system_reserved_cpu,
     sys_memory : var.system_reserved_memory,
     docker_hub_creds : var.docker_hub_creds_ssm_path,
-    ami_using_containerd_v2 : local.ami_using_containerd_v2
   }))
   key_name               = var.ec2_ssh_key
   update_default_version = true

--- a/_sub/compute/eks-nodegroup-managed/user-data.sh.tftpl
+++ b/_sub/compute/eks-nodegroup-managed/user-data.sh.tftpl
@@ -14,13 +14,8 @@ DOCKER_HUB_CREDS=$(aws ssm get-parameter --name ${docker_hub_creds} --with-decry
 DOCKER_HUB_USER=$(echo "$${DOCKER_HUB_CREDS}" | jq -r .username)
 DOCKER_HUB_PASSWD=$(echo "$${DOCKER_HUB_CREDS}" | jq -r .password)
 cat << EOF >> /etc/containerd/config.toml
-%{ if ami_using_containerd_v2 ~}
   [plugins."io.containerd.cri.v1.images".registry.configs]
     [plugins."io.containerd.cri.v1.images".registry.configs."registry-1.docker.io".auth]
-%{ else ~}
-  [plugins."io.containerd.grpc.v1.cri".registry.configs]
-    [plugins."io.containerd.grpc.v1.cri".registry.configs."registry-1.docker.io".auth]
-%{ endif ~}
       username = "$${DOCKER_HUB_USER}"
       password = "$${DOCKER_HUB_PASSWD}"
 EOF

--- a/compute/eks-ec2/vars.tf
+++ b/compute/eks-ec2/vars.tf
@@ -25,7 +25,12 @@ variable "eks_cluster_name" {
 }
 
 variable "eks_cluster_version" {
-  type = string
+  type        = string
+  description = "The Kubernetes version for the EKS cluster. Must be >= 1.34."
+  validation {
+    condition     = tonumber(split(".", var.eks_cluster_version)[0]) > 1 || (tonumber(split(".", var.eks_cluster_version)[0]) == 1 && tonumber(split(".", var.eks_cluster_version)[1]) >= 34)
+    error_message = "eks_cluster_version must be >= 1.34."
+  }
 }
 
 variable "eks_cluster_cidr_block" {


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
With EKS version on all shared clusters being >= 1.34 we can remove containerd v1 logic, since it is no longer supported on newer AMI's.

It feels super redundant to do validation two places and I still cannot decide where to put it so I did it in both places. Let's discuss that.

* Cluster version requirement >= 1.34
* Containerd v1 logic removed

An additional argument for the version requirement is that 1.33 will go into extended support soon'ish.

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
