### PR TITLE
feat: add flux_cluster_name variable to Helm postBuild substitutions so it can be picked up in platform-apps

### DIFF
--- a/_sub/compute/github-arc-runners/dependencies.tf
+++ b/_sub/compute/github-arc-runners/dependencies.tf
@@ -48,6 +48,7 @@ spec:
       flux_github_arc_runners_resource_memory: "${var.runner_resource_memory}"
       flux_github_arc_runners_scale_set_name: "${var.runner_scale_set_name}"
       flux_workload_account_id: "${data.aws_caller_identity.this.id}"
+      flux_cluster_name: "${var.cluster_name}"
 YAML
 
   helm_install = <<YAML

--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -121,6 +121,7 @@ inputs = {
   # Github ARC SS Runners
   # --------------------------------------------------
 
+  github_arc_runners_deploy                = true
   github_arc_runners_runner_scale_set_name = "dfds-runners-qa"
   github_arc_runners_resource_memory       = "1Gi"
 


### PR DESCRIPTION
## Describe your changes

This pull request makes a minor update to the GitHub ARC runners Terraform configuration by adding a new variable to the `spec` section. This change improves the configuration by passing the cluster name to downstream resources.

This is needed for Flux post build substitution so that platform-apps can be configured to pick up the correct roles to be used for IRSA integration to SSM for ARC runners.

- Configuration update:
  * Added `flux_cluster_name` to the `spec` section in `_sub/compute/github-arc-runners/dependencies.tf` to include the cluster name in the resource specification.

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
