### PR TITLE
feat: add arc-runners to external secrets SSM allowed namespaces

### DIFF
--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -109,7 +109,7 @@ inputs = {
   # External Secrets
   # --------------------------------------------------
 
-  external_secrets_ssm_allowed_namespaces = ["atlantis", "flux-system", "velero"]
+  external_secrets_ssm_allowed_namespaces = ["atlantis", "flux-system", "velero", "arc-runners"]
 
   # --------------------------------------------------
   # Github ARC SS Controller


### PR DESCRIPTION
## Describe your changes

This pull request makes a small update to the list of namespaces allowed to access SSM secrets via External Secrets. The `arc-runners` namespace is now included in the `external_secrets_ssm_allowed_namespaces` array.

* Added `arc-runners` to the `external_secrets_ssm_allowed_namespaces` list in `terragrunt.hcl`, allowing this namespace to use External Secrets with SSM.

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
