### PR TITLE
We now only expect 2 Keda controller

### DIFF
--- a/test/integration/suite/keda_test.go
+++ b/test/integration/suite/keda_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestKedaDeployment(t *testing.T) {
 	t.Parallel()
 	clientset := NewK8sClientSet(t)
-	AssertK8sDeployment(t, clientset, "keda", "keda-operator", 3)
+	AssertK8sDeployment(t, clientset, "keda", "keda-operator", 2)
 	AssertK8sDeployment(t, clientset, "keda", "keda-operator-metrics-apiserver", 3)
 	AssertK8sDeployment(t, clientset, "keda", "keda-admission-webhooks", 3)
 }


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
We need to stop expecting N replicas unless it is really important and just look in status to see if we are getting the expected amount of ready pods.

We reduced the number of Keda controller from 3 -> 2 see https://github.com/dfds/platform-apps/pull/594, but in this test we expect 3, so it fails. There isn't any good reason to expect 3.

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
