### PR TITLE
Revert platform-apps back to main

### DIFF
--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -66,7 +66,7 @@ inputs = {
   # Flux CD
   # --------------------------------------------------
 
-  fluxcd_apps_repo_branch           = "add/alb/targetgroupsbindings"
+  fluxcd_apps_repo_branch           = "main"
   fluxcd_bootstrap_repo_name        = "platform-manifests-qa"
   fluxcd_bootstrap_repo_branch      = "main"
   fluxcd_version                    = "v2.7.5"


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
We need to revert qa back on main for platform-apps.

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
