### PR TITLE
Add ecr:BatchImportUpstreamImage policy to nodes IAM role

### DIFF
--- a/_sub/compute/eks-workers/iam.tf
+++ b/_sub/compute/eks-workers/iam.tf
@@ -142,3 +142,19 @@ resource "aws_iam_role_policy" "cur" {
 EOF
 
 }
+
+# Allow nodes to pull new images and tag through ECR pull through cache
+data "aws_iam_policy_document" "allow_ecr_pull_through_cache" {
+  statement {
+    sid = "ECRPullThroughCache"
+    effect = "Allow"
+    actions   = ["ecr:BatchImportUpstreamImage"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "allow_ecr_pull_through_cache" {
+  name = "eks-${var.cluster_name}-ecr-pull-through-cache"
+  role = aws_iam_role.eks.id
+  policy = data.aws_iam_policy_document.allow_ecr_pull_through_cache.json
+}


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
Add ecr:BatchImportUpstreamImage policy to allow new images and tags from pull through cache.

I have tested this locally and I can now pull new images that doesn't exist in the pull through cache, but also new tags.

Tested with curlimage/curl:latest and 8.18.0 (not latest) and dfdsdk/prime-pipeline:2.2.6.

I would have loved to do some testing on both the containerd Dockerhub configuration and pulling from the cache, but it would most likely require access to the pull through cache.

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
