### PR TITLE
Make wait for HelmRelease longer 5m->10m

### DIFF
--- a/test/integration/suite/flux_resources_test.go
+++ b/test/integration/suite/flux_resources_test.go
@@ -43,9 +43,16 @@ func TestFluxResourcesReady(t *testing.T) {
 			if resource != "gitrepository" && resource != "kustomizations" {
 				t.Parallel()
 			}
-			err := k8s.RunKubectlE(t, options, "wait", resource, "--for=condition=Ready", "--all", "-A", "--timeout=5m")
-			if err != nil {
-				t.Fatalf("%s not ready: %v", resource, err)
+			if resource == "helmreleases" {
+				err := k8s.RunKubectlE(t, options, "wait", resource, "--for=condition=Ready", "--all", "-A", "--timeout=10m") // helmreleases can take longer to be ready
+				if err != nil {
+					t.Fatalf("%s not ready: %v", resource, err)
+				}
+			} else {
+				err := k8s.RunKubectlE(t, options, "wait", resource, "--for=condition=Ready", "--all", "-A", "--timeout=5m")
+				if err != nil {
+					t.Fatalf("%s not ready: %v", resource, err)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->

Make wait for HelmRelease longer 5m->10m because default HelmRelease timeout is 5m30s, but for HelmReleases we overwrite this with 10m. Traefik is good example due to preStop hook of 300 seconds.

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code