### PR TITLE
Migrate traefik blue to IP aware targetgroup

### DIFF
--- a/_sub/compute/eks-alb-auth/main.tf
+++ b/_sub/compute/eks-alb-auth/main.tf
@@ -24,7 +24,7 @@ resource "aws_lb" "traefik_auth" {
 
 resource "aws_lb_target_group" "traefik_auth_blue_variant" {
   name_prefix          = "b-${substr(var.cluster_name, 0, min(4, length(var.cluster_name)))}"
-  port                 = var.blue_variant_target_http_port
+  port                 = local.traefik_deployment_defaults.ports.web
   protocol             = "HTTP"
   target_type          = "ip"
   vpc_id               = var.vpc_id

--- a/_sub/compute/eks-alb-auth/main.tf
+++ b/_sub/compute/eks-alb-auth/main.tf
@@ -26,12 +26,13 @@ resource "aws_lb_target_group" "traefik_auth_blue_variant" {
   name_prefix          = "b-${substr(var.cluster_name, 0, min(4, length(var.cluster_name)))}"
   port                 = var.blue_variant_target_http_port
   protocol             = "HTTP"
+  target_type          = "ip"
   vpc_id               = var.vpc_id
   deregistration_delay = 300
 
   health_check {
-    path     = var.blue_variant_health_check_path
-    port     = var.blue_variant_target_admin_port
+    path     = local.traefik_deployment_defaults.path
+    port     = local.traefik_deployment_defaults.ports.admin
     protocol = "HTTP"
     matcher  = 200
   }
@@ -39,12 +40,6 @@ resource "aws_lb_target_group" "traefik_auth_blue_variant" {
   lifecycle {
     create_before_destroy = true
   }
-}
-
-resource "aws_autoscaling_attachment" "traefik_auth_blue_variant" {
-  for_each               = var.autoscaling_group_ids
-  autoscaling_group_name = each.key
-  lb_target_group_arn    = aws_lb_target_group.traefik_auth_blue_variant.arn
 }
 
 resource "aws_lb_target_group" "traefik_auth_green_variant" {
@@ -166,19 +161,11 @@ resource "aws_security_group" "traefik_auth" {
     cidr_blocks = ["0.0.0.0/0"] #tfsec:ignore:aws-vpc-no-public-egress-sg tfsec:ignore:aws-ec2-no-public-ingress-sgr tfsec:ignore:aws-ec2-no-public-egress-sgr
   }
 
-  egress {
-    description = "Egress from var.blue_variant_target_http_port to var.blue_variant_target_admin_port"
-    from_port   = var.blue_variant_target_http_port
-    to_port     = var.blue_variant_target_admin_port
-    protocol    = "TCP"
-    cidr_blocks = ["0.0.0.0/0"] #tfsec:ignore:aws-vpc-no-public-egress-sg #tfsec:ignore:aws-ec2-no-public-egress-sgr
-  }
-
   dynamic "egress" {
     for_each = local.traefik_deployment_defaults.ports
 
     content {
-      description = "Egress on ${egress.key} port ${tostring(egress.value)} for the Traefik green variant."
+      description = "Egress on ${egress.key} port ${tostring(egress.value)} for all Traefik variants."
       from_port   = egress.value
       to_port     = egress.value
       protocol    = "TCP"
@@ -196,20 +183,9 @@ resource "aws_security_group" "traefik_auth" {
 
 }
 
-resource "aws_security_group_rule" "allow_traefik_auth_blue" {
-  description              = "Ingress on HTTP port for the Traefik blue variant."
-  type                     = "ingress"
-  from_port                = var.blue_variant_target_http_port
-  to_port                  = var.blue_variant_target_admin_port
-  protocol                 = "tcp"
-  source_security_group_id = aws_security_group.traefik_auth.id
-
-  security_group_id = var.nodes_sg_id
-}
-
-resource "aws_security_group_rule" "allow_traefik_green" {
+resource "aws_security_group_rule" "allow_traefik" {
   for_each = local.traefik_deployment_defaults.ports
-  description              = "Ingress on ${each.key} port ${tostring(each.value)} for the Traefik green variant."
+  description              = "Ingress on ${each.key} port ${tostring(each.value)} for all Traefik variants."
   type                     = "ingress"
   from_port                = each.value
   to_port                  = each.value

--- a/_sub/compute/eks-alb-auth/vars.tf
+++ b/_sub/compute/eks-alb-auth/vars.tf
@@ -47,29 +47,10 @@ variable "access_logs_enabled" {
   default = true
 }
 
-# Blue variant
-
-variable "blue_variant_target_http_port" {
-  type        = number
-  description = "NodePort value for the 'web' entrypoint in Traefik"
-}
-
-variable "blue_variant_target_admin_port" {
-  type        = number
-  description = "NodePort value for the 'traefik' entrypoint in Traefik"
-}
-
-variable "blue_variant_health_check_path" {
-  type        = string
-  description = "The AWS ALB will call this path on Traefik to evaluate node liveness"
-}
-
 variable "blue_variant_weight" {
   type        = number
   description = "The weight of the requests towards the blue variant of Traefik"
 }
-
-# Green variant
 
 variable "green_variant_weight" {
   type        = number

--- a/_sub/compute/eks-alb/main.tf
+++ b/_sub/compute/eks-alb/main.tf
@@ -24,14 +24,15 @@ resource "aws_lb" "traefik" {
 
 resource "aws_lb_target_group" "traefik_blue_variant" {
   name_prefix          = "b-${substr(var.cluster_name, 0, min(4, length(var.cluster_name)))}"
-  port                 = var.blue_variant_target_http_port
+  port                 = local.traefik_deployment_defaults.ports.web
   protocol             = "HTTP"
+  target_type          = "ip"
   vpc_id               = var.vpc_id
   deregistration_delay = 300
 
   health_check {
-    path     = var.blue_variant_health_check_path
-    port     = var.blue_variant_target_admin_port
+    path     = local.traefik_deployment_defaults.path
+    port     = local.traefik_deployment_defaults.ports.admin
     protocol = "HTTP"
     matcher  = 200
   }
@@ -39,12 +40,6 @@ resource "aws_lb_target_group" "traefik_blue_variant" {
   lifecycle {
     create_before_destroy = true
   }
-}
-
-resource "aws_autoscaling_attachment" "traefik_blue_variant" {
-  for_each               = var.autoscaling_group_ids
-  autoscaling_group_name = each.key
-  lb_target_group_arn    = aws_lb_target_group.traefik_blue_variant.arn
 }
 
 resource "aws_lb_target_group" "traefik_green_variant" {
@@ -145,19 +140,11 @@ resource "aws_security_group" "traefik" {
     cidr_blocks = ["0.0.0.0/0"] #tfsec:ignore:aws-vpc-no-public-ingress-sg tfsec:ignore:aws-ec2-no-public-ingress-sgr
   }
 
-  egress {
-    description = "Egress from var.target_http_port to var.target_admin_port"
-    from_port   = var.blue_variant_target_http_port
-    to_port     = var.blue_variant_target_admin_port
-    protocol    = "TCP"
-    cidr_blocks = ["0.0.0.0/0"] #tfsec:ignore:aws-vpc-no-public-egress-sg tfsec:ignore:aws-ec2-no-public-egress-sgr
-  }
-
   dynamic "egress" {
     for_each = local.traefik_deployment_defaults.ports
 
     content {
-      description = "Egress on ${egress.key} port ${tostring(egress.value)} for the Traefik green variant."
+      description = "Egress on ${egress.key} port ${tostring(egress.value)} for the all Traefik variants."
       from_port   = egress.value
       to_port     = egress.value
       protocol    = "TCP"
@@ -174,20 +161,9 @@ resource "aws_security_group" "traefik" {
   }
 }
 
-resource "aws_security_group_rule" "allow_traefik_blue" {
-  description              = "Ingress on HTTP port for the Traefik blue variant."
-  type                     = "ingress"
-  from_port                = var.blue_variant_target_http_port
-  to_port                  = var.blue_variant_target_admin_port
-  protocol                 = "tcp"
-  source_security_group_id = aws_security_group.traefik.id
-
-  security_group_id = var.nodes_sg_id
-}
-
-resource "aws_security_group_rule" "allow_traefik_green" {
+resource "aws_security_group_rule" "allow_traefik" {
   for_each = local.traefik_deployment_defaults.ports
-  description              = "Ingress on ${each.key} port ${tostring(each.value)} for the Traefik green variant."
+  description              = "Ingress on ${each.key} port ${tostring(each.value)} for all Traefik variants."
   type                     = "ingress"
   from_port                = each.value
   to_port                  = each.value

--- a/_sub/compute/eks-alb/vars.tf
+++ b/_sub/compute/eks-alb/vars.tf
@@ -30,22 +30,6 @@ variable "access_logs_bucket" {
   type = string
 }
 
-# Blue variant
-variable "blue_variant_target_http_port" {
-  type        = number
-  description = "NodePort value for the 'web' entrypoint in Traefik"
-}
-
-variable "blue_variant_target_admin_port" {
-  type        = number
-  description = "NodePort value for the 'traefik' entrypoint in Traefik"
-}
-
-variable "blue_variant_health_check_path" {
-  type        = string
-  description = "The AWS ALB will call this path on Traefik to evaluate node liveness"
-}
-
 variable "blue_variant_weight" {
   type        = number
   description = "The weight of the requests towards the blue variant of Traefik"

--- a/_sub/compute/k8s-traefik-flux/main.tf
+++ b/_sub/compute/k8s-traefik-flux/main.tf
@@ -10,8 +10,6 @@ resource "github_repository_file" "traefik_helm" {
     deploy_name       = var.deploy_name
     helm_repo_path    = local.helm_repo_path
     eks_fqdn          = var.eks_fqdn
-    target_http_port  = var.target_http_port
-    target_admin_port = var.target_admin_port
     alb_target_group_arn = var.alb_target_group_arn
     alb_auth_target_group_arn = var.alb_auth_target_group_arn
   })

--- a/_sub/compute/k8s-traefik-flux/values/app-helm.yaml
+++ b/_sub/compute/k8s-traefik-flux/values/app-helm.yaml
@@ -28,9 +28,5 @@ spec:
   postBuild:
     substitute:
       flux_eks_fqdn: "${eks_fqdn}"
-%{ if deploy_name == "traefik-blue-variant" ~}
-      flux_traefik_blue_target_http_port: "${target_http_port}"
-      flux_traefik_blue_target_admin_port: "${target_admin_port}"
-%{ endif ~}
       flux_alb_target_group_arn: "${alb_target_group_arn}"
       flux_alb_auth_target_group_arn: "${alb_auth_target_group_arn}"

--- a/_sub/compute/k8s-traefik-flux/vars.tf
+++ b/_sub/compute/k8s-traefik-flux/vars.tf
@@ -41,16 +41,6 @@ variable "gitops_apps_repo_ref" {
   description = "The default branch or tag for your GitOps manifests"
 }
 
-variable "target_http_port" {
-  type        = number
-  description = "NodePort value for the 'web' entrypoint in Traefik"
-}
-
-variable "target_admin_port" {
-  type        = number
-  description = "NodePort value for the 'traefik' entrypoint in Traefik"
-}
-
 variable "alb_auth_target_group_arn" {
   type        = string
   description = "The ARN of the Traefik auth target group"

--- a/compute/k8s-services/dependencies.tf
+++ b/compute/k8s-services/dependencies.tf
@@ -97,15 +97,8 @@ locals {
 }
 
 # --------------------------------------------------
-#  Traefik node ports for blue/green deployments
+#  OIDC issuer for EKS cluster
 # --------------------------------------------------
-
-locals {
-  traefik_blue_variant_target_http_port   = 31000
-  traefik_blue_variant_target_admin_port  = 31001
-  traefik_green_variant_target_http_port  = 32000
-  traefik_green_variant_target_admin_port = 32001
-}
 
 locals {
   oidc_issuer = trim(data.aws_eks_cluster.eks.identity[0].oidc[0].issuer, "https://")

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -44,8 +44,6 @@ module "traefik_blue_variant_flux_manifests" {
   eks_fqdn             = local.eks_fqdn
   gitops_apps_repo_url = local.fluxcd_apps_repo_url
   gitops_apps_repo_ref = local.gitops_apps_repo_ref
-  target_http_port     = local.traefik_blue_variant_target_http_port
-  target_admin_port    = local.traefik_blue_variant_target_admin_port
   alb_target_group_arn = module.traefik_alb_anon.alb_target_group_arn_blue
   alb_auth_target_group_arn = module.traefik_alb_auth.alb_target_group_arn_blue
 
@@ -64,8 +62,6 @@ module "traefik_green_variant_manifests" {
   eks_fqdn             = local.eks_fqdn
   gitops_apps_repo_url = local.fluxcd_apps_repo_url
   gitops_apps_repo_ref = local.gitops_apps_repo_ref
-  target_http_port     = local.traefik_green_variant_target_http_port
-  target_admin_port    = local.traefik_green_variant_target_admin_port
   alb_target_group_arn = module.traefik_alb_anon.alb_target_group_arn_green
   alb_auth_target_group_arn = module.traefik_alb_auth.alb_target_group_arn_green
 
@@ -140,15 +136,8 @@ module "traefik_alb_auth" {
   azure_client_secret      = try(module.traefik_alb_auth_appreg.application_key, "")
   access_logs_bucket       = module.traefik_alb_s3_access_logs.name
   enable_delete_protection = data.terraform_remote_state.cluster.outputs.eks_is_sandbox ? false : true
-
-  # Blue variant
-  blue_variant_target_http_port  = local.traefik_blue_variant_target_http_port
-  blue_variant_target_admin_port = local.traefik_blue_variant_target_admin_port
-  blue_variant_health_check_path = "/ping"
-  blue_variant_weight            = var.traefik_blue_variant_weight
-
-  # Green variant
-  green_variant_weight            = var.traefik_green_variant_weight
+  blue_variant_weight      = var.traefik_blue_variant_weight
+  green_variant_weight     = var.traefik_green_variant_weight
 }
 
 module "traefik_alb_auth_dns" {
@@ -203,15 +192,8 @@ module "traefik_alb_anon" {
   nodes_sg_id              = data.terraform_remote_state.cluster.outputs.eks_cluster_nodes_sg_id
   access_logs_bucket       = module.traefik_alb_s3_access_logs.name
   enable_delete_protection = data.terraform_remote_state.cluster.outputs.eks_is_sandbox ? false : true
-
-  # Blue variant
-  blue_variant_target_http_port  = local.traefik_blue_variant_target_http_port
-  blue_variant_target_admin_port = local.traefik_blue_variant_target_admin_port
-  blue_variant_health_check_path = "/ping"
-  blue_variant_weight            = var.traefik_blue_variant_weight
-
-  # Green variant
-  green_variant_weight            = var.traefik_green_variant_weight
+  blue_variant_weight      = var.traefik_blue_variant_weight
+  green_variant_weight     = var.traefik_green_variant_weight
 }
 
 module "traefik_alb_anon_dns" {

--- a/compute/k8s-services/moved.tf
+++ b/compute/k8s-services/moved.tf
@@ -102,3 +102,13 @@ moved {
   from = module.falco[0].github_repository_file.helm_patch
   to   = module.falco.github_repository_file.helm_patch
 }
+
+moved {
+  from = module.traefik_alb_anon.aws_security_group_rule.allow_traefik_green
+  to   = module.traefik_alb_anon.aws_security_group_rule.allow_traefik
+}
+
+moved {
+  from = module.traefik_alb_auth.aws_security_group_rule.allow_traefik_green
+  to   = module.traefik_alb_auth.aws_security_group_rule.allow_traefik
+}

--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -44,8 +44,8 @@ inputs = {
   # Traefik v2
   # --------------------------------------------------
 
-  traefik_blue_variant_weight   = 0
-  traefik_green_variant_weight  = 1
+  traefik_blue_variant_weight   = 1
+  traefik_green_variant_weight  = 0
 
   # --------------------------------------------------
   # Blaster
@@ -66,7 +66,7 @@ inputs = {
   # Flux CD
   # --------------------------------------------------
 
-  fluxcd_apps_repo_branch           = "main"
+  fluxcd_apps_repo_branch           = "migrate/traefik/blue/ip-aware-targetgroup"
   fluxcd_bootstrap_repo_name        = "platform-manifests-qa"
   fluxcd_bootstrap_repo_branch      = "main"
   fluxcd_version                    = "v2.7.5"


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
In our current setup all nodes are target for the load balancers in place exposing nodeports. The targetgroup registration is happening through an autoscalinggroup attachment. This makes all nodes go through a registration and deregistration process and adding on top of this all requests are very, very likely to make an extra network jump from the node to a node that actually has Traefik running.

This PR attempt to do a couple of things:
- Remove autoscalinggroup attachment for Traefik blue variant
- Output and use targetgroup arns in TargetgroupBinding via postbuildSubstitution for AWS Loadbalancer Controller to register and deregister targets, in this case Traefik blue variant pods
- Change target group type from instance to IP aware so we do not need nodeports exposed on nodes
- Removed all nodeports variables related to traefik
- Added moved blocks to indicate resource name change
- On platform-apps side of things we implement an namespace label for AWS Loadbalancer Controller to inject a readiness gate into our Traefik blue pods, that will only set a Ready state condition if the pod is registered as a target. This allows for fully graceful deployment rollout of Traefik blue without dropping a single request.

See PR for platform-apps https://github.com/dfds/platform-apps/pull/609.

I have switched the load balancer weight to blue and added the branch for the PR above, to prove that it works in testing.

To clarify this is the PR that merged for Traefik green https://github.com/dfds/infrastructure-modules/pull/2370. We are running 100% ingress traffic on Traefik green in staging, production and standby.

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
