### PR TITLE
Fix deprecated terraform resources

### DIFF
--- a/_sub/compute/eks-addons/main.tf
+++ b/_sub/compute/eks-addons/main.tf
@@ -204,7 +204,7 @@ resource "aws_iam_role_policy_attachment" "managed-efs-csi-driver-policy" {
 
 # Storage classes
 
-resource "kubernetes_storage_class" "csi-gp3" {
+resource "kubernetes_storage_class_v1" "csi-gp3" {
   metadata {
     name = "csi-gp3"
     annotations = {
@@ -215,6 +215,7 @@ resource "kubernetes_storage_class" "csi-gp3" {
   reclaim_policy         = "Delete"
   volume_binding_mode    = "WaitForFirstConsumer"
   allow_volume_expansion = "true"
+
   parameters = {
     type = "gp3"
   }
@@ -244,7 +245,7 @@ resource "kubernetes_annotations" "gp2-not-default" {
   ]
 }
 
-resource "kubernetes_storage_class" "csi-efs" {
+resource "kubernetes_storage_class_v1" "csi-efs" {
   metadata {
     name = "csi-efs"
     annotations = {

--- a/_sub/compute/k8s-clusterrole/main.tf
+++ b/_sub/compute/k8s-clusterrole/main.tf
@@ -1,4 +1,4 @@
-resource "kubernetes_cluster_role" "role" {
+resource "kubernetes_cluster_role_v1" "role" {
   #checkov:skip=CKV_K8S_49: Minimize wildcard use in Roles and ClusterRoles
   metadata {
     name = var.name
@@ -19,14 +19,14 @@ resource "kubernetes_cluster_role" "role" {
   }
 }
 
-resource "kubernetes_cluster_role_binding" "binding" {
+resource "kubernetes_cluster_role_binding_v1" "binding" {
   metadata {
     name = var.name
   }
   role_ref {
     api_group = "rbac.authorization.k8s.io"
     kind      = "ClusterRole"
-    name      = kubernetes_cluster_role.role.metadata[0].name
+    name      = kubernetes_cluster_role_v1.role.metadata[0].name
   }
   subject {
     api_group = "rbac.authorization.k8s.io"

--- a/_sub/compute/k8s-priority-class/main.tf
+++ b/_sub/compute/k8s-priority-class/main.tf
@@ -38,7 +38,7 @@ locals {
 }
 
 
-resource "kubernetes_priority_class" "class" {
+resource "kubernetes_priority_class_v1" "class" {
   for_each = { for pc in local.priority_classes : pc.name => pc }
   metadata {
     name = each.value.name

--- a/_sub/compute/k8s-service-account/main.tf
+++ b/_sub/compute/k8s-service-account/main.tf
@@ -1,4 +1,4 @@
-resource "kubernetes_service_account" "deploy-user" {
+resource "kubernetes_service_account_v1" "deploy-user" {
   metadata {
     name      = "deploy-user"
     namespace = "kube-system"
@@ -9,7 +9,7 @@ resource "kubernetes_service_account" "deploy-user" {
   provider = kubernetes
 }
 
-resource "kubernetes_cluster_role_binding" "deploy-user" {
+resource "kubernetes_cluster_role_binding_v1" "deploy-user" {
   metadata {
     name = "deploy-user"
   }
@@ -32,10 +32,10 @@ resource "kubernetes_cluster_role_binding" "deploy-user" {
 
 resource "kubernetes_secret_v1" "deploy-token" {
   metadata {
-    generate_name = "${kubernetes_service_account.deploy-user.metadata[0].name}-token-"
-    namespace     = kubernetes_service_account.deploy-user.metadata[0].namespace
+    generate_name = "${kubernetes_service_account_v1.deploy-user.metadata[0].name}-token-"
+    namespace     = kubernetes_service_account_v1.deploy-user.metadata[0].namespace
     annotations = {
-      "kubernetes.io/service-account.name" = kubernetes_service_account.deploy-user.metadata[0].name
+      "kubernetes.io/service-account.name" = kubernetes_service_account_v1.deploy-user.metadata[0].name
     }
   }
 


### PR DESCRIPTION
## Describe your changes

BREAKING CHANGES:

Do this before running any pipeline!!!!

```
cd cluster

# Storage classes
terragrunt state rm module.eks_addons.kubernetes_storage_class.csi-gp3
terragrunt import module.eks_addons.kubernetes_storage_class_v1.csi-gp3 csi-gp3

terragrunt state rm module.eks_addons.kubernetes_storage_class.csi-efs
terragrunt import module.eks_addons.kubernetes_storage_class_v1.csi-efs csi-efs

# Cluster role and binding
terragrunt state rm module.k8s_cloudengineer_clusterrole_and_binding.kubernetes_cluster_role.role
terragrunt import module.k8s_cloudengineer_clusterrole_and_binding.kubernetes_cluster_role_v1.role cloud-engineer

terragrunt state rm module.k8s_cloudengineer_clusterrole_and_binding.kubernetes_cluster_role_binding.binding
terragrunt import module.k8s_cloudengineer_clusterrole_and_binding.kubernetes_cluster_role_binding_v1.binding cloud-engineer

terragrunt state rm module.k8s_service_account.kubernetes_service_account.deploy-user
terragrunt import module.k8s_service_account.kubernetes_service_account_v1.deploy-user kube-system/deploy-user

terragrunt state rm module.k8s_service_account.kubernetes_cluster_role_binding.deploy-user
terragrunt import module.k8s_service_account.kubernetes_cluster_role_binding_v1.deploy-user deploy-user

# Priority classes
terragrunt state rm 'module.k8s_priority_class.kubernetes_priority_class.class["cluster-infrastructure"]'
terragrunt state rm 'module.k8s_priority_class.kubernetes_priority_class.class["cluster-observability"]'
terragrunt state rm 'module.k8s_priority_class.kubernetes_priority_class.class["low"]'
terragrunt state rm 'module.k8s_priority_class.kubernetes_priority_class.class["node-infrastructure"]'
terragrunt state rm 'module.k8s_priority_class.kubernetes_priority_class.class["node-observability"]'
terragrunt state rm 'module.k8s_priority_class.kubernetes_priority_class.class["selfservice"]'

terragrunt import 'module.k8s_priority_class.kubernetes_priority_class_v1.class["cluster-infrastructure"]' cluster-infrastructure
terragrunt import 'module.k8s_priority_class.kubernetes_priority_class_v1.class["cluster-observability"]' cluster-observability
terragrunt import 'module.k8s_priority_class.kubernetes_priority_class_v1.class["low"]' low
terragrunt import 'module.k8s_priority_class.kubernetes_priority_class_v1.class["node-infrastructure"]' node-infrastructure
terragrunt import 'module.k8s_priority_class.kubernetes_priority_class_v1.class["node-observability"]' node-observability
terragrunt import 'module.k8s_priority_class.kubernetes_priority_class_v1.class["selfservice"]' selfservice

```

This pull request updates several Kubernetes Terraform resources to use the versioned (`_v1`) resource types instead of the unversioned ones. This change aligns the codebase with current Terraform provider best practices and ensures compatibility with newer provider versions.

**Kubernetes resource versioning updates:**

* Changed all `kubernetes_*` resources to their versioned equivalents (e.g., `kubernetes_service_account` → `kubernetes_service_account_v1`, `kubernetes_cluster_role` → `kubernetes_cluster_role_v1`, etc.) across multiple modules for improved compatibility and future-proofing. [[1]](diffhunk://#diff-4893099b6ec489bb1daf1d724a32283e138f5126d66155e82ec750474865617cL1-R1) [[2]](diffhunk://#diff-4893099b6ec489bb1daf1d724a32283e138f5126d66155e82ec750474865617cL12-R12) [[3]](diffhunk://#diff-4893099b6ec489bb1daf1d724a32283e138f5126d66155e82ec750474865617cL35-R38) [[4]](diffhunk://#diff-5fb7ef23ae19bb56005ec993478d39f5cce192b0aba2e58188b0a2ec3f395c11L1-R1) [[5]](diffhunk://#diff-5fb7ef23ae19bb56005ec993478d39f5cce192b0aba2e58188b0a2ec3f395c11L22-R29) [[6]](diffhunk://#diff-b8eacdba326d42f6c3cca4724f460bb859b8e80087dfea6135d8c8bc659bdc30L41-R41) [[7]](diffhunk://#diff-a043032adae754329a445c95c2ae927fcdc02359c6d7a3eb82cdbce97297b48bL207-R207) [[8]](diffhunk://#diff-a043032adae754329a445c95c2ae927fcdc02359c6d7a3eb82cdbce97297b48bL247-R248)

**Reference updates for new resource names:**

* Updated references to resource names and attributes to use the new `_v1` resource names, ensuring all dependencies and interpolations remain correct. [[1]](diffhunk://#diff-5fb7ef23ae19bb56005ec993478d39f5cce192b0aba2e58188b0a2ec3f395c11L22-R29) [[2]](diffhunk://#diff-4893099b6ec489bb1daf1d724a32283e138f5126d66155e82ec750474865617cL35-R38)

These changes are primarily mechanical and should not affect the actual infrastructure, but they are important for maintaining compatibility with the latest Terraform Kubernetes provider.

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
