### PR TITLE
Prepare for Karpenter usage: Remove inactivity cleanup functionality for sandboxes.

### DIFF
--- a/compute/eks-ec2/dependencies.tf
+++ b/compute/eks-ec2/dependencies.tf
@@ -9,13 +9,10 @@ locals {
 }
 
 # ------------------------------------------------------
-# Inactivity based clean up and scale down for sandboxes
+# Scale down for sandboxes
 # ------------------------------------------------------
 
 locals {
-  enable_inactivity_cleanup = (
-    var.enable_inactivity_cleanup && var.eks_is_sandbox ? true : false
-  )
   enable_scale_to_zero_after_business_hours = (
     var.enable_scale_to_zero_after_business_hours && var.eks_is_sandbox ? true : false
   )

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -465,14 +465,6 @@ resource "aws_cloudwatch_metric_alarm" "inactivity" {
   }
 }
 
-module "eks_inactivity_cleanup" {
-  count                = local.enable_inactivity_cleanup ? 1 : 0
-  source               = "../../_sub/compute/eks-inactivity-cleanup"
-  eks_cluster_name     = var.eks_cluster_name
-  eks_cluster_arn      = module.eks_cluster.eks_cluster_arn
-  inactivity_alarm_arn = aws_cloudwatch_metric_alarm.inactivity[0].arn
-}
-
 # --------------------------------------------------
 # GPU workloads
 # --------------------------------------------------
@@ -501,8 +493,8 @@ module "karpenter" {
   node_iam_role_additional_policies = {
     AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore" # Enable SSM core functionality
   }
-  enable_inline_policy          = true
-  depends_on = [module.eks_cluster]
+  enable_inline_policy = true
+  depends_on           = [module.eks_cluster]
 }
 
 # Controller KMS access policy required for EBS encryption support (see https://karpenter.sh/docs/troubleshooting/#node-terminates-before-ready-on-failed-encrypted-ebs-volume)

--- a/compute/eks-ec2/vars.tf
+++ b/compute/eks-ec2/vars.tf
@@ -241,14 +241,8 @@ variable "eks_worker_cur_bucket_arn" {
 }
 
 # ------------------------------------------------------
-# Inactivity based clean up and scale down for sandboxes
+# Scale down for sandboxes
 # ------------------------------------------------------
-
-variable "enable_inactivity_cleanup" {
-  type        = bool
-  default     = true
-  description = "Enables automated clean up of EKS resources based on inactivity. Only applicable to sandboxes."
-}
 
 variable "enable_scale_to_zero_after_business_hours" {
   type        = bool

--- a/compute/k8s-services/dependencies.tf
+++ b/compute/k8s-services/dependencies.tf
@@ -148,16 +148,6 @@ locals {
   gitops_apps_repo_ref = var.fluxcd_apps_repo_tag != "" ? var.fluxcd_apps_repo_tag : var.fluxcd_apps_repo_branch
 }
 
-# --------------------------------------------------
-# Inactivity based clean up for sandboxes
-# --------------------------------------------------
-
-locals {
-  enable_inactivity_cleanup = (
-    var.enable_inactivity_cleanup && data.terraform_remote_state.cluster.outputs.eks_is_sandbox ? true : false
-  )
-}
-
 
 # --------------------------------------------------
 # IAM role for Route53 zone delegation
@@ -278,5 +268,5 @@ locals {
 # Grafana Agent
 locals {
   grafana_deploy = var.grafana_deploy && var.onepassword_token_for_grafana != "" ? true : false
-  grafana_stack = data.terraform_remote_state.cluster.outputs.eks_is_sandbox ? "sandbox" : "platform"
+  grafana_stack  = data.terraform_remote_state.cluster.outputs.eks_is_sandbox ? "sandbox" : "platform"
 }

--- a/compute/k8s-services/main.tf
+++ b/compute/k8s-services/main.tf
@@ -35,16 +35,16 @@ module "traefik_crds" {
 # --------------------------------------------------
 
 module "traefik_blue_variant_flux_manifests" {
-  source               = "../../_sub/compute/k8s-traefik-flux"
-  cluster_name         = var.eks_cluster_name
-  deploy_name          = "traefik-blue-variant"
-  github_owner         = var.fluxcd_bootstrap_repo_owner
-  repo_name            = var.fluxcd_bootstrap_repo_name
-  repo_branch          = var.fluxcd_bootstrap_repo_branch
-  eks_fqdn             = local.eks_fqdn
-  gitops_apps_repo_url = local.fluxcd_apps_repo_url
-  gitops_apps_repo_ref = local.gitops_apps_repo_ref
-  alb_target_group_arn = module.traefik_alb_anon.alb_target_group_arn_blue
+  source                    = "../../_sub/compute/k8s-traefik-flux"
+  cluster_name              = var.eks_cluster_name
+  deploy_name               = "traefik-blue-variant"
+  github_owner              = var.fluxcd_bootstrap_repo_owner
+  repo_name                 = var.fluxcd_bootstrap_repo_name
+  repo_branch               = var.fluxcd_bootstrap_repo_branch
+  eks_fqdn                  = local.eks_fqdn
+  gitops_apps_repo_url      = local.fluxcd_apps_repo_url
+  gitops_apps_repo_ref      = local.gitops_apps_repo_ref
+  alb_target_group_arn      = module.traefik_alb_anon.alb_target_group_arn_blue
   alb_auth_target_group_arn = module.traefik_alb_auth.alb_target_group_arn_blue
 
   providers = {
@@ -53,16 +53,16 @@ module "traefik_blue_variant_flux_manifests" {
 }
 
 module "traefik_green_variant_manifests" {
-  source               = "../../_sub/compute/k8s-traefik-flux"
-  cluster_name         = var.eks_cluster_name
-  deploy_name          = "traefik-green-variant"
-  github_owner         = var.fluxcd_bootstrap_repo_owner
-  repo_name            = var.fluxcd_bootstrap_repo_name
-  repo_branch          = var.fluxcd_bootstrap_repo_branch
-  eks_fqdn             = local.eks_fqdn
-  gitops_apps_repo_url = local.fluxcd_apps_repo_url
-  gitops_apps_repo_ref = local.gitops_apps_repo_ref
-  alb_target_group_arn = module.traefik_alb_anon.alb_target_group_arn_green
+  source                    = "../../_sub/compute/k8s-traefik-flux"
+  cluster_name              = var.eks_cluster_name
+  deploy_name               = "traefik-green-variant"
+  github_owner              = var.fluxcd_bootstrap_repo_owner
+  repo_name                 = var.fluxcd_bootstrap_repo_name
+  repo_branch               = var.fluxcd_bootstrap_repo_branch
+  eks_fqdn                  = local.eks_fqdn
+  gitops_apps_repo_url      = local.fluxcd_apps_repo_url
+  gitops_apps_repo_ref      = local.gitops_apps_repo_ref
+  alb_target_group_arn      = module.traefik_alb_anon.alb_target_group_arn_green
   alb_auth_target_group_arn = module.traefik_alb_auth.alb_target_group_arn_green
 
   providers = {
@@ -545,27 +545,6 @@ module "velero" {
     aws    = aws
   }
 }
-
-# --------------------------------------------------
-# Inactivity based clean up for sandboxes
-# --------------------------------------------------
-
-module "elb_inactivity_cleanup_anon" {
-  count                = data.terraform_remote_state.cluster.outputs.eks_is_sandbox && local.enable_inactivity_cleanup ? 1 : 0
-  source               = "../../_sub/compute/elb-inactivity-cleanup"
-  inactivity_alarm_arn = data.terraform_remote_state.cluster.outputs.eks_inactivity_alarm_arn
-  elb_name             = module.traefik_alb_anon.alb_name
-  elb_arn              = module.traefik_alb_anon.alb_arn
-}
-
-module "elb_inactivity_cleanup_auth" {
-  count                = data.terraform_remote_state.cluster.outputs.eks_is_sandbox && local.enable_inactivity_cleanup ? 1 : 0
-  source               = "../../_sub/compute/elb-inactivity-cleanup"
-  inactivity_alarm_arn = data.terraform_remote_state.cluster.outputs.eks_inactivity_alarm_arn
-  elb_name             = module.traefik_alb_auth.alb_name
-  elb_arn               = module.traefik_alb_auth.alb_arn
-}
-
 
 # --------------------------------------------------
 # Grafana Agent for Kubernetes monitoring

--- a/compute/k8s-services/vars.tf
+++ b/compute/k8s-services/vars.tf
@@ -370,17 +370,6 @@ variable "velero_node_agent_pod_memory" {
   description = "Memory resources request and limit size for Velero node agent pods"
 }
 
-
-# --------------------------------------------------
-# Inactivity based clean up for sandboxes
-# --------------------------------------------------
-
-variable "enable_inactivity_cleanup" {
-  type        = bool
-  default     = true
-  description = "Enables automated clean up of ELB resources based on inactivity. Only applicable to sandboxes."
-}
-
 # --------------------------------------------------
 # Grafana Agent for Kubernetes monitoring
 # --------------------------------------------------

--- a/test/integration/eu-west-1/k8s-qa/cluster/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/cluster/terragrunt.hcl
@@ -46,10 +46,6 @@ inputs = {
   eks_k8s_auth_api_version    = "client.authentication.k8s.io/v1beta1"
 
   eks_is_sandbox = true
-  # Since rebooting the cluster after inactivity at the moment requires first
-  # running `terragrunt apply -target=module.eks_cluster` the QA cluster is
-  # excluded from the inactivity clean up on this step.
-  enable_inactivity_cleanup = false
 
   # --------------------------------------------------
   # Managed nodes

--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -31,7 +31,6 @@ inputs = {
 
   eks_is_sandbox            = true
   eks_cluster_name          = "qa"
-  enable_inactivity_cleanup = false
   use_worker_nat_gateway    = true
 
   # --------------------------------------------------


### PR DESCRIPTION
Also run terraform format on changed files.

## Describe your changes

This pull request removes the "inactivity-based cleanup" feature for EKS and ELB resources in sandbox environments. The related variables, local values, and module instantiations for inactivity cleanup have been deleted from both the `eks-ec2` and `k8s-services` modules, as well as from the corresponding test configurations. The only remaining scale-down mechanism is "scale to zero after business hours."

**Removal of inactivity-based cleanup:**

* Deleted the `enable_inactivity_cleanup` variable and all related local values from `eks-ec2` and `k8s-services` modules, removing support for inactivity-triggered resource cleanup. [[1]](diffhunk://#diff-b18f8354ea8f3932f1be0681155c6e70c457a10798e9be3a07994adfea3d16b3L244-L252) [[2]](diffhunk://#diff-83380a112934c41699d826a5e1a07c6ee2d0729366db765c2d9c40fd2967c45bL373-L383) [[3]](diffhunk://#diff-73215c5737e0c7ae7f5fd46edf0f79c6108f8876a7b0b530c936d56a83230084L12-L18) [[4]](diffhunk://#diff-2e7c8e5dd2f4a76d76adb2da41988c1905571c7b2d401b1c58fc0f113241e49bL151-L160)
* Removed the instantiation of the `eks_inactivity_cleanup` and `elb_inactivity_cleanup` modules, which handled cleanup of EKS and ELB resources based on inactivity alarms. [[1]](diffhunk://#diff-377519e7ca2d872af5e1381cb6c57e93942c12625344ff8fc8a970e19a400742L468-L475) [[2]](diffhunk://#diff-9dcb2b34c331c83c7b15b8785fc38080f22e765d3119f854acc7848e7f669485L549-L569)

**Test and configuration cleanup:**

* Removed the `enable_inactivity_cleanup` input from Terragrunt test configuration files, reflecting the removal of this feature. [[1]](diffhunk://#diff-7f7aa824ffca7a437c5189aec8a5adb01c34e18ca80309a31f4c11d09b90617fL49-L52) [[2]](diffhunk://#diff-23bdbeb0d3e57bc3139b318801dda0b1c266354c34072dffc2a1932f1df0cc11L34)

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
