### PR TITLE
Refactor: Remove scale to zero functionality and related variables for

### DIFF
--- a/_sub/compute/eks-nodegroup-managed/dependencies.tf
+++ b/_sub/compute/eks-nodegroup-managed/dependencies.tf
@@ -1,7 +1,7 @@
 locals {
   asg_desired_size = length(var.subnet_ids) * var.desired_size_per_subnet
   # A sandbox should be able to be put scaled down to 0 at the end of the workday.
-  asg_min_size = var.enable_scale_to_zero_after_business_hours ? 0 : local.asg_desired_size
+  asg_min_size = local.asg_desired_size
   asg_max_size = 2 * local.asg_desired_size
 }
 

--- a/_sub/compute/eks-nodegroup-managed/main.tf
+++ b/_sub/compute/eks-nodegroup-managed/main.tf
@@ -91,13 +91,3 @@ resource "aws_eks_node_group" "group" {
     min_size     = local.asg_min_size
   }
 }
-
-resource "aws_autoscaling_schedule" "eks" {
-  count                  = var.enable_scale_to_zero_after_business_hours ? signum(var.desired_size_per_subnet) : 0
-  autoscaling_group_name = aws_eks_node_group.group[0].resources[0].autoscaling_groups[0].name
-  scheduled_action_name  = "Scale to zero"
-  recurrence             = var.scale_to_zero_cron
-  min_size               = local.asg_min_size
-  max_size               = local.asg_max_size
-  desired_capacity       = 0
-}

--- a/_sub/compute/eks-nodegroup-managed/vars.tf
+++ b/_sub/compute/eks-nodegroup-managed/vars.tf
@@ -92,17 +92,6 @@ variable "docker_hub_creds_ssm_path" {
 # Inactivity based scale down for sandboxes
 # ------------------------------------------------------
 
-variable "enable_scale_to_zero_after_business_hours" {
-  type        = bool
-  default     = true
-  description = "Enables automated scale to zero of EC2 instance after business hours. Only applicable to sandboxes."
-}
-
-variable "scale_to_zero_cron" {
-  type        = string
-  description = "The time when the ASG will be scaled to zero, specified in Unix cron syntax"
-}
-
 variable "max_unavailable" {
   type        = number
   description = "Desired max number of unavailable worker nodes during node group update."

--- a/compute/eks-ec2/dependencies.tf
+++ b/compute/eks-ec2/dependencies.tf
@@ -7,13 +7,3 @@ locals {
     "vpc.peering.actor" = "accepter"
   })
 }
-
-# ------------------------------------------------------
-# Scale down for sandboxes
-# ------------------------------------------------------
-
-locals {
-  enable_scale_to_zero_after_business_hours = (
-    var.enable_scale_to_zero_after_business_hours && var.eks_is_sandbox ? true : false
-  )
-}

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -244,17 +244,16 @@ module "eks_managed_workers_node_group" {
 
   for_each = var.eks_managed_nodegroups
 
-  cluster_name                              = var.eks_cluster_name
-  cluster_version                           = var.eks_cluster_version
-  enable_scale_to_zero_after_business_hours = local.enable_scale_to_zero_after_business_hours
-  node_role_arn                             = module.eks_workers.worker_role_arn
-  security_groups                           = [module.eks_workers_security_group.id]
-  scale_to_zero_cron                        = var.eks_worker_scale_to_zero_cron
-  ec2_ssh_key                               = module.eks_workers_keypair.key_name
-  eks_endpoint                              = module.eks_cluster.eks_endpoint
-  eks_certificate_authority                 = module.eks_cluster.eks_certificate_authority
-  eks_service_cidr                          = module.eks_cluster.eks_service_cidr
-  worker_inotify_max_user_watches           = var.eks_worker_inotify_max_user_watches
+  cluster_name                    = var.eks_cluster_name
+  cluster_version                 = var.eks_cluster_version
+  node_role_arn                   = module.eks_workers.worker_role_arn
+  security_groups                 = [module.eks_workers_security_group.id]
+  scale_to_zero_cron              = var.eks_worker_scale_to_zero_cron
+  ec2_ssh_key                     = module.eks_workers_keypair.key_name
+  eks_endpoint                    = module.eks_cluster.eks_endpoint
+  eks_certificate_authority       = module.eks_cluster.eks_certificate_authority
+  eks_service_cidr                = module.eks_cluster.eks_service_cidr
+  worker_inotify_max_user_watches = var.eks_worker_inotify_max_user_watches
 
   # Node group variations
   nodegroup_name             = each.key

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -248,7 +248,6 @@ module "eks_managed_workers_node_group" {
   cluster_version                 = var.eks_cluster_version
   node_role_arn                   = module.eks_workers.worker_role_arn
   security_groups                 = [module.eks_workers_security_group.id]
-  scale_to_zero_cron              = var.eks_worker_scale_to_zero_cron
   ec2_ssh_key                     = module.eks_workers_keypair.key_name
   eks_endpoint                    = module.eks_cluster.eks_endpoint
   eks_certificate_authority       = module.eks_cluster.eks_certificate_authority

--- a/compute/eks-ec2/vars.tf
+++ b/compute/eks-ec2/vars.tf
@@ -240,16 +240,6 @@ variable "eks_worker_cur_bucket_arn" {
   description = "S3 ARN for Billing Cost and Usage Report (CUR)"
 }
 
-# ------------------------------------------------------
-# Scale down for sandboxes
-# ------------------------------------------------------
-
-variable "enable_scale_to_zero_after_business_hours" {
-  type        = bool
-  default     = true
-  description = "Enables automated scale to zero of EC2 instance after business hours. Only applicable to sandboxes."
-}
-
 # --------------------------------------------------
 # GPU workloads
 # --------------------------------------------------

--- a/compute/eks-ec2/vars.tf
+++ b/compute/eks-ec2/vars.tf
@@ -113,12 +113,6 @@ variable "eks_managed_worker_subnets" {
   default = []
 }
 
-variable "eks_worker_scale_to_zero_cron" {
-  type        = string
-  description = "The time when the ASG will be scaled to zero, specified in Unix cron syntax"
-  default     = "0 18 * * *"
-}
-
 variable "eks_addon_kubeproxy_version_override" {
   type    = string
   default = ""


### PR DESCRIPTION
sandboxes

## Describe your changes

This pull request removes the "scale to zero after business hours" feature from the EKS managed node group modules. This includes eliminating the related variables, logic, and autoscaling schedule resources that previously allowed node groups (especially sandboxes) to be automatically scaled down to zero outside business hours.

Key changes:

**Removal of scale-to-zero feature and related configuration:**

* Deleted the `enable_scale_to_zero_after_business_hours` and `scale_to_zero_cron` variables from both `compute/eks-ec2/vars.tf` and `_sub/compute/eks-nodegroup-managed/vars.tf`, as well as the associated local variable logic in `compute/eks-ec2/dependencies.tf`. [[1]](diffhunk://#diff-b18f8354ea8f3932f1be0681155c6e70c457a10798e9be3a07994adfea3d16b3L243-L252) [[2]](diffhunk://#diff-02c4dec2654cbdd6b9ee622b405117081a32a236919b3b6693162357784ce3daL95-L105) [[3]](diffhunk://#diff-73215c5737e0c7ae7f5fd46edf0f79c6108f8876a7b0b530c936d56a83230084L10-L19)
* Removed the conditional minimum size logic from `_sub/compute/eks-nodegroup-managed/dependencies.tf`, so the ASG minimum size is now always set to the desired size per subnet.
* Eliminated the `aws_autoscaling_schedule` resource from `_sub/compute/eks-nodegroup-managed/main.tf`, which previously scheduled the scale-to-zero action.
* Updated module usage in `compute/eks-ec2/main.tf` to remove passing the now-deleted `enable_scale_to_zero_after_business_hours` variable.

These changes simplify the EKS node group configuration by removing the business-hours-based scale-down functionality and its supporting infrastructure.

## Checklist before requesting a review
- x ] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
