### PR TITLE
Refactor: Update QA pipeline to skip execution for pull requests labeled 'on-hold'

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -42,7 +42,7 @@ env:
 
 jobs:
   build_test_master:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'on-hold')
     name: Build test binary from master branch
     uses: dfds/shared-workflows/.github/workflows/automation-integration-test-build.yml@2.0.4
     with:
@@ -52,7 +52,7 @@ jobs:
       artifact-name: test-master
 
   build_test_feature:
-    if: github.ref != 'refs/heads/master' && github.event.pull_request.draft == false
+    if: github.ref != 'refs/heads/master' && github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'on-hold')
     name: Build test binary from feature branch
     uses: dfds/shared-workflows/.github/workflows/automation-integration-test-build.yml@2.0.4
     with:
@@ -60,7 +60,7 @@ jobs:
       artifact-name: test-feature
 
   apply_test_master:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'on-hold')
     name: Provision from master branch
     runs-on: ubuntu-latest
     needs: build_test_master
@@ -141,7 +141,7 @@ jobs:
     name: Apply from feature branch
     runs-on: ubuntu-latest
     needs: [apply_test_master, build_test_feature]
-    if: github.ref != 'refs/heads/master' && github.event.pull_request.draft == false
+    if: github.ref != 'refs/heads/master' && github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'on-hold')
     steps:
       - name: Checkout code
         uses: actions/checkout@v7


### PR DESCRIPTION
## Describe your changes

This pull request updates the GitHub Actions workflow to prevent jobs from running when a pull request has the `on-hold` label. This ensures that CI/CD jobs are skipped for PRs that are not ready for testing or deployment.

Workflow condition improvements:

* Updated the `if` conditions for the `build_test_master`, `build_test_feature`, `apply_test_master`, and `apply_test_feature` jobs in `.github/workflows/qa.yml` to skip execution if the pull request is labeled with `on-hold`. [[1]](diffhunk://#diff-4d515b7cca4aa254976e10e863f94e4527f5edd15f4315279f578385fc0f68b8L45-R45) [[2]](diffhunk://#diff-4d515b7cca4aa254976e10e863f94e4527f5edd15f4315279f578385fc0f68b8L55-R63) [[3]](diffhunk://#diff-4d515b7cca4aa254976e10e863f94e4527f5edd15f4315279f578385fc0f68b8L144-R144)

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
