### PR TITLE
feat: only use one subnet for ssm vpc endpoints

### DIFF
--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -150,7 +150,7 @@ module "eks_workers" {
 module "ssm" {
   source  = "../../_sub/network/vpc-ssm"
   vpc_id  = module.eks_cluster.vpc_id
-  subnets = [for sn in module.eks_managed_workers_subnet.subnets : sn.id]
+  subnets = [for sn in module.eks_managed_workers_subnet.subnets : sn.id if endswith(sn.availability_zone, "a")]
 }
 
 # --------------------------------------------------


### PR DESCRIPTION
## Describe your changes
This PR limits the ssm vpc endpoint to 1 subnet. It selects the "a" availability zone.

This is done to reduce the considerable cost of the SSM VPC endpoints by 1/3 and we accept the risk of availability zone loss.

I was between marking this as major or patch. I have added the patch label, there is no breaking change to the consumption of the module.

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
