### PR TITLE
Remove SSH access configuration from EKS node groups and related variables

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.105.0
+    rev: v1.108.1
     hooks:
       - id: terraform_fmt
         exclude: test/integration/suite/vendor/.*

--- a/_sub/compute/ec2-keypair/main.tf
+++ b/_sub/compute/ec2-keypair/main.tf
@@ -1,4 +1,0 @@
-resource "aws_key_pair" "pair" {
-  key_name_prefix = "${var.name}-"
-  public_key      = var.public_key
-}

--- a/_sub/compute/ec2-keypair/outputs.tf
+++ b/_sub/compute/ec2-keypair/outputs.tf
@@ -1,3 +1,0 @@
-output "key_name" {
-  value = aws_key_pair.pair.key_name
-}

--- a/_sub/compute/ec2-keypair/vars.tf
+++ b/_sub/compute/ec2-keypair/vars.tf
@@ -1,7 +1,0 @@
-variable "name" {
-  type = string
-}
-
-variable "public_key" {
-  type = string
-}

--- a/_sub/compute/ec2-keypair/versions.tf
+++ b/_sub/compute/ec2-keypair/versions.tf
@@ -1,9 +1,0 @@
-terraform {
-  required_version = ">= 1.6.0"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = ">= 6.23.0"
-    }
-  }
-}

--- a/_sub/compute/eks-nodegroup-managed/main.tf
+++ b/_sub/compute/eks-nodegroup-managed/main.tf
@@ -20,7 +20,6 @@ resource "aws_launch_template" "eks" {
     sys_memory : var.system_reserved_memory,
     docker_hub_creds : var.docker_hub_creds_ssm_path,
   }))
-  key_name               = var.ec2_ssh_key
   update_default_version = true
 
   network_interfaces {

--- a/_sub/compute/eks-nodegroup-managed/vars.tf
+++ b/_sub/compute/eks-nodegroup-managed/vars.tf
@@ -62,10 +62,6 @@ variable "ami_id" {
   description = "Pins the AMI ID of the nodes to the specified AMI, bypassing AMI updates."
 }
 
-variable "ec2_ssh_key" {
-  type = string
-}
-
 variable "eks_endpoint" {
   type = string
 }

--- a/_sub/network/security-group-eks-node/main.tf
+++ b/_sub/network/security-group-eks-node/main.tf
@@ -49,15 +49,3 @@ resource "aws_security_group_rule" "eks-cluster-ingress-node-https" {
   to_port                  = 443
   type                     = "ingress"
 }
-
-#Enable SSH access to nodes by tfvars set to 1
-resource "aws_security_group_rule" "ssh-access-to-worker-nodes" {
-  #checkov:skip=CKV_AWS_24: Ensure no security groups allow ingress from 0.0.0.0:0 to port 22
-  description       = "Allow SSH access to worker nodes"
-  cidr_blocks       = var.ssh_ip_whitelist
-  from_port         = 22
-  protocol          = "tcp"
-  security_group_id = aws_security_group.eks-node.id
-  to_port           = 22
-  type              = "ingress"
-}

--- a/_sub/network/security-group-eks-node/vars.tf
+++ b/_sub/network/security-group-eks-node/vars.tf
@@ -9,7 +9,3 @@ variable "cluster_name" {
 variable "autoscale_security_group" {
   type = string
 }
-
-variable "ssh_ip_whitelist" {
-  type = list(string)
-}

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -125,18 +125,11 @@ module "eks_managed_workers_subnet" {
   subnets      = local.eks_managed_worker_subnets
 }
 
-module "eks_workers_keypair" {
-  source     = "../../_sub/compute/ec2-keypair"
-  name       = "eks-${var.eks_cluster_name}-workers"
-  public_key = var.eks_worker_ssh_public_key
-}
-
 module "eks_workers_security_group" {
   source                   = "../../_sub/network/security-group-eks-node"
   vpc_id                   = module.eks_cluster.vpc_id
   cluster_name             = var.eks_cluster_name
   autoscale_security_group = module.eks_cluster.autoscale_security_group
-  ssh_ip_whitelist         = var.eks_worker_ssh_ip_whitelist
 }
 
 # Is actually only IAM at this point
@@ -248,7 +241,6 @@ module "eks_managed_workers_node_group" {
   cluster_version                 = var.eks_cluster_version
   node_role_arn                   = module.eks_workers.worker_role_arn
   security_groups                 = [module.eks_workers_security_group.id]
-  ec2_ssh_key                     = module.eks_workers_keypair.key_name
   eks_endpoint                    = module.eks_cluster.eks_endpoint
   eks_certificate_authority       = module.eks_cluster.eks_certificate_authority
   eks_service_cidr                = module.eks_cluster.eks_service_cidr

--- a/compute/eks-ec2/vars.tf
+++ b/compute/eks-ec2/vars.tf
@@ -65,14 +65,6 @@ variable "eks_ipam_prefix_size" {
   }
 }
 
-variable "eks_worker_ssh_public_key" {
-  type = string
-}
-
-variable "eks_worker_ssh_ip_whitelist" {
-  type = list(string)
-}
-
 # Optional
 # --------------------------------------------------
 

--- a/test/integration/eu-west-1/k8s-qa/cluster/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/cluster/terragrunt.hcl
@@ -29,10 +29,7 @@ inputs = {
   eks_is_sandbox            = true
   enable_worker_nat_gateway = true
   use_worker_nat_gateway    = true
-
-  eks_worker_ssh_ip_whitelist = ["193.9.230.0/24"]
-  eks_worker_ssh_public_key   = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC2PlxsmewLiLRCQbuATu4yLRsAOMGqaCa/KL3GPo1Wyr19XVVFWseyaVERN1t/xBPlryOikHbfkuNnm8c3mtOop9daEEi2neWMpHqGp/IqHRw5tJiEg50/zauC2kETuG9pLADzs/tVrLlghKHmzv9s6VPEJM7l6hKWF04AdHK2auICRXnOM+by1+gquoDAvL3tytX55Xrx3P+dMB4tpgt/SABVomE6/XiaaxHdntj6pGGl1CYtzC2Md+4K6pXh2mr/pESqXqGxcW6HBUhwYhDEdm1ZEg3WLaFZ2kTjCvIUCPgA7Zo3cq8NQbjw6rsnrqTrsCG7OIRakrWFlxetKvZluVARaJscnQov98iwS7+owGKf+eJ9Fg6O26ewHKX0zuxU/33l1KqGdfGEVfsA+CzRSKr9yj1BvCzqf4yaESZT/D0uNDCWPTC0pmJ02F1/XUvOnDl7cihHHTXTlwRnXBKz7X8xpwUtb/K+yyvUI4KcRmcmxRUFxl3SVuaaXJ1avfb0FOGB07ZO47OQ1/gCkHmzYpu5YtBeVwOAfxOsCX3k1Svqhvpbwg6KdkdSvouXdMFqQ10rtF65E8yiX0pHnDHC3Vgpa/Nw5hZ0fH1MTRDIDf2ZTciARkzGrUtYPu9Yi68X9bcLgfn6cA6HNp/UGhm6YvpoKrkZgX2yJIkphALqTQ== qa"
-  eks_k8s_auth_api_version    = "client.authentication.k8s.io/v1beta1"
+  eks_k8s_auth_api_version  = "client.authentication.k8s.io/v1beta1"
 
   # --------------------------------------------------
   # Managed nodes


### PR DESCRIPTION
WARNING: DO NOT MERGE UNTIL RIGHT BEFORE DEPLOYMENT. NODES ROLLOVER WILL HAPPEN!

## Describe your changes
- **Update pre-commit-terraform to v1.108.1**
- **Remove SSH access configuration from EKS node groups and related variables**

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
