### PR TITLE
Update deprecated RunKubectlE with RunKubectlContextE

### DIFF
--- a/test/integration/suite/flux_resources_test.go
+++ b/test/integration/suite/flux_resources_test.go
@@ -24,11 +24,11 @@ func TestFluxResourcesReady(t *testing.T) {
 	reconcileAndWait := func(resource string) {
 		namespace := "flux-system"
 		name := "flux-system"
-		err := k8s.RunKubectlE(t, options, "-n", namespace, "annotate", resource, name, fmt.Sprintf("reconcile.fluxcd.io/requestedAt=%s", fmt.Sprintf("%d", time.Now().Unix())), "--overwrite")
+		err := k8s.RunKubectlContextE(t, t.Context(), options, "-n", namespace, "annotate", resource, name, fmt.Sprintf("reconcile.fluxcd.io/requestedAt=%s", fmt.Sprintf("%d", time.Now().Unix())), "--overwrite")
 		if err != nil {
 			t.Fatalf("Failed to trigger flux-system %s reconciliation: %v", resource, err)
 		}
-		err = k8s.RunKubectlE(t, options, "-n", namespace, "wait", resource, name, "--for=condition=Ready", "--timeout=5m")
+		err = k8s.RunKubectlContextE(t, t.Context(), options, "-n", namespace, "wait", resource, name, "--for=condition=Ready", "--timeout=5m")
 		if err != nil {
 			t.Fatalf("Failed flux-system %s reconciliation: %v", resource, err)
 		}
@@ -44,12 +44,12 @@ func TestFluxResourcesReady(t *testing.T) {
 				t.Parallel()
 			}
 			if resource == "helmreleases" {
-				err := k8s.RunKubectlE(t, options, "wait", resource, "--for=condition=Ready", "--all", "-A", "--timeout=10m") // helmreleases can take longer to be ready
+				err := k8s.RunKubectlContextE(t, t.Context(), options, "wait", resource, "--for=condition=Ready", "--all", "-A", "--timeout=10m") // helmreleases can take longer to be ready
 				if err != nil {
 					t.Fatalf("%s not ready: %v", resource, err)
 				}
 			} else {
-				err := k8s.RunKubectlE(t, options, "wait", resource, "--for=condition=Ready", "--all", "-A", "--timeout=5m")
+				err := k8s.RunKubectlContextE(t, t.Context(), options, "wait", resource, "--for=condition=Ready", "--all", "-A", "--timeout=5m")
 				if err != nil {
 					t.Fatalf("%s not ready: %v", resource, err)
 				}


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
Update deprecated RunKubectlE with RunKubectlContextE, since they will be removed in future releases https://github.com/gruntwork-io/terratest/releases/tag/modules%2Fcore%2Fv2.0.0-beta.1.

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [ ] I have rebased the code to master (or merged in the latest from master)

## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
