### PR TITLE
Update OnePassword credentials for QA workflows

### DIFF
--- a/.github/workflows/nuke-qa.yml
+++ b/.github/workflows/nuke-qa.yml
@@ -53,7 +53,7 @@ jobs:
           TF_VAR_docker_hub_username: op://CloudEng-General/Docker Cloud/password # pragma: allowlist-secret
           TF_VAR_eks_addon_awsebscsidriver_kms_arn: op://CloudEng-General/Hardened Account EBS Volume Shared KMS Key/arn # pragma: allowlist-secret
           TF_VAR_fluxcd_bootstrap_repo_owner_token: op://CloudEng-General/Github account devex-sa/Tokens/flux-qa # pragma: allowlist-secret
-          TF_VAR_onepassword_credentials_json: op://CloudEng-General/1Password Connect/nonprod_json # pragma: allowlist-secret
+          TF_VAR_onepassword_credentials_json: op://CloudEng-General/1Password Connect/k8s-hellman-nonprod/hxbc2ougl5gcrgogqlcjyhdabm # pragma: allowlist-secret
           TF_VAR_onepassword_token_for_atlantis: op://CloudEng-General/1Password Connect/nonprod_atlantis_token # pragma: allowlist-secret
           TF_VAR_velero_ebs_csi_kms_arn: op://CloudEng-General/Hardened Account EBS Volume Shared KMS Key/arn # pragma: allowlist-secret
           SLACK_WEBHOOK: op://CloudEng-General/Slack dfds.slack.com webhooks/jdm5vktylqnczrlkkbvsveyp5e # pragma: allowlist-secret

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -100,7 +100,7 @@ jobs:
           TF_VAR_docker_hub_password: op://CloudEng-General/Docker Cloud/password # pragma: allowlist-secret
           TF_VAR_eks_addon_awsebscsidriver_kms_arn: op://CloudEng-General/Hardened Account EBS Volume Shared KMS Key/arn # pragma: allowlist-secret
           TF_VAR_fluxcd_bootstrap_repo_owner_token: op://CloudEng-General/Github account devex-sa/Tokens/flux-qa # pragma: allowlist-secret
-          TF_VAR_onepassword_credentials_json: op://CloudEng-General/1Password Connect/nonprod_json # pragma: allowlist-secret
+          TF_VAR_onepassword_credentials_json: op://CloudEng-General/1Password Connect/k8s-hellman-nonprod/hxbc2ougl5gcrgogqlcjyhdabm # pragma: allowlist-secret
           TF_VAR_onepassword_token_for_atlantis: op://CloudEng-General/1Password Connect/nonprod_atlantis_token # pragma: allowlist-secret
           TF_VAR_onepassword_token_for_grafana: op://CloudEng-General/1Password Connect/nonprod_grafana_token # pragma: allowlist-secret
           TF_VAR_velero_ebs_csi_kms_arn: op://CloudEng-General/Hardened Account EBS Volume Shared KMS Key/arn # pragma: allowlist-secret
@@ -175,7 +175,7 @@ jobs:
           TF_VAR_docker_hub_password: op://CloudEng-General/Docker Cloud/password # pragma: allowlist-secret
           TF_VAR_eks_addon_awsebscsidriver_kms_arn: op://CloudEng-General/Hardened Account EBS Volume Shared KMS Key/arn # pragma: allowlist-secret
           TF_VAR_fluxcd_bootstrap_repo_owner_token: op://CloudEng-General/Github account devex-sa/Tokens/flux-qa # pragma: allowlist-secret
-          TF_VAR_onepassword_credentials_json: op://CloudEng-General/1Password Connect/nonprod_json # pragma: allowlist-secret
+          TF_VAR_onepassword_credentials_json: op://CloudEng-General/1Password Connect/k8s-hellman-nonprod/hxbc2ougl5gcrgogqlcjyhdabm # pragma: allowlist-secret
           TF_VAR_onepassword_token_for_atlantis: op://CloudEng-General/1Password Connect/nonprod_atlantis_token # pragma: allowlist-secret
           TF_VAR_onepassword_token_for_grafana: op://CloudEng-General/1Password Connect/nonprod_grafana_token # pragma: allowlist-secret
           TF_VAR_velero_ebs_csi_kms_arn: op://CloudEng-General/Hardened Account EBS Volume Shared KMS Key/arn # pragma: allowlist-secret


### PR DESCRIPTION
## Describe your changes

This pull request updates the 1Password credentials used in the QA GitHub Actions workflows. The main change is switching the `TF_VAR_onepassword_credentials_json` secret to reference a new path in 1Password, likely reflecting an updated or more specific set of credentials for the `k8s-hellman-nonprod` environment.

**Secrets management updates:**

* Updated the `TF_VAR_onepassword_credentials_json` environment variable in `.github/workflows/qa.yml` and `.github/workflows/nuke-qa.yml` to use the new 1Password path `op://CloudEng-General/1Password Connect/k8s-hellman-nonprod/hxbc2ougl5gcrgogqlcjyhdabm` instead of the previous `nonprod_json` reference. [[1]](diffhunk://#diff-4d515b7cca4aa254976e10e863f94e4527f5edd15f4315279f578385fc0f68b8L103-R103) [[2]](diffhunk://#diff-4d515b7cca4aa254976e10e863f94e4527f5edd15f4315279f578385fc0f68b8L178-R178) [[3]](diffhunk://#diff-8566a9ab9b829705e244e0179c9fdb9e622ed10c4a39b96213b78d91f173d6ecL56-R56)

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
