### PR TITLE
Fix a bunch of depends on

### DIFF
--- a/_sub/compute/eks-cluster/outputs.tf
+++ b/_sub/compute/eks-cluster/outputs.tf
@@ -33,3 +33,7 @@ output "eks_openid_connect_provider_url" {
 output "eks_service_cidr" {
   value = aws_eks_cluster.eks.kubernetes_network_config[0].service_ipv4_cidr
 }
+
+output "name" {
+  value = aws_eks_cluster.eks.name
+}

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -262,8 +262,6 @@ module "eks_managed_workers_node_group" {
 
   # Docker Hub credentials
   docker_hub_creds_ssm_path = aws_ssm_parameter.dockerhub.name
-
-  depends_on = [module.eks_cluster]
 }
 
 # --------------------------------------------------

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -367,7 +367,7 @@ module "cloudwatch_agent_config_bucket" {
 }
 
 # --------------------------------------------------
-# Cluster access½
+# Cluster access
 # --------------------------------------------------
 
 module "k8s_cloudengineer_clusterrole_and_binding" {

--- a/compute/eks-ec2/main.tf
+++ b/compute/eks-ec2/main.tf
@@ -301,7 +301,6 @@ module "efs_fs" {
 
 module "eks_addons" {
   source                           = "../../_sub/compute/eks-addons"
-  depends_on                       = [module.eks_cluster, module.efs_fs]
   cluster_name                     = var.eks_cluster_name
   kubeproxy_version_override       = var.eks_addon_kubeproxy_version_override
   coredns_version_override         = var.eks_addon_coredns_version_override
@@ -370,7 +369,7 @@ module "cloudwatch_agent_config_bucket" {
 }
 
 # --------------------------------------------------
-# Cluster access
+# Cluster access½
 # --------------------------------------------------
 
 module "k8s_cloudengineer_clusterrole_and_binding" {
@@ -467,10 +466,10 @@ module "karpenter" {
   source                        = "terraform-aws-modules/eks/aws//modules/karpenter"
   version                       = "21.24.2"
   create                        = true
-  cluster_name                  = var.eks_cluster_name
+  cluster_name                  = module.eks_cluster.name
   create_access_entry           = true
   node_iam_role_use_name_prefix = false
-  node_iam_role_name            = "karpenter-${var.eks_cluster_name}"
+  node_iam_role_name            = "karpenter-${module.eks_cluster.name}"
   create_iam_role               = true
   namespace                     = "karpenter"
   # Attach additional IAM policies to the Karpenter node IAM role
@@ -478,7 +477,6 @@ module "karpenter" {
     AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore" # Enable SSM core functionality
   }
   enable_inline_policy = true
-  depends_on           = [module.eks_cluster]
 }
 
 # Controller KMS access policy required for EBS encryption support (see https://karpenter.sh/docs/troubleshooting/#node-terminates-before-ready-on-failed-encrypted-ebs-volume)


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
Karpenter module was making a lot of noise on cluster version upgrades. This can be removed by outputting name from our own cluster module, so that the tooling can correctly resolve the DAG, without us interfering.

I also removed the depends_on used in addons, since we already have an explicit depends_on from the modules.

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
