### PR TITLE
Mark variable as sensitive

### DIFF
--- a/_sub/compute/eks-alb-auth/vars.tf
+++ b/_sub/compute/eks-alb-auth/vars.tf
@@ -32,6 +32,7 @@ variable "azure_client_id" {
 
 variable "azure_client_secret" {
   type = string
+  sensitive = true
 }
 
 variable "access_logs_bucket" {


### PR DESCRIPTION
## Describe your changes

This pull request makes a small but important change to the `azure_client_secret` variable in `_sub/compute/eks-alb-auth/vars.tf`. The variable is now marked as sensitive to ensure that its value is not displayed in logs or output, improving security.

Suggested by a user request from:
Joel Diaz
Founder & Lead Engineer, Gap Hunter Labs

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
