### PR TITLE
Update version requirement for cluster_version to >= 1.36 so that we notch all clusters towards what we run in production

### DIFF
--- a/_sub/compute/eks-cluster/vars.tf
+++ b/_sub/compute/eks-cluster/vars.tf
@@ -4,10 +4,10 @@ variable "cluster_name" {
 
 variable "cluster_version" {
   type        = string
-  description = "The Kubernetes version for the EKS cluster. Must be >= 1.34."
+  description = "The Kubernetes version for the EKS cluster. Must be >= 1.36."
   validation {
-    condition     = tonumber(split(".", var.cluster_version)[0]) > 1 || (tonumber(split(".", var.cluster_version)[0]) == 1 && tonumber(split(".", var.cluster_version)[1]) >= 34)
-    error_message = "cluster_version must be >= 1.34."
+    condition     = tonumber(split(".", var.cluster_version)[0]) > 1 || (tonumber(split(".", var.cluster_version)[0]) == 1 && tonumber(split(".", var.cluster_version)[1]) >= 36)
+    error_message = "cluster_version must be >= 1.36."
   }
 }
 

--- a/compute/eks-ec2/vars.tf
+++ b/compute/eks-ec2/vars.tf
@@ -26,10 +26,10 @@ variable "eks_cluster_name" {
 
 variable "eks_cluster_version" {
   type        = string
-  description = "The Kubernetes version for the EKS cluster. Must be >= 1.34."
+  description = "The Kubernetes version for the EKS cluster. Must be >= 1.36."
   validation {
-    condition     = tonumber(split(".", var.eks_cluster_version)[0]) > 1 || (tonumber(split(".", var.eks_cluster_version)[0]) == 1 && tonumber(split(".", var.eks_cluster_version)[1]) >= 34)
-    error_message = "eks_cluster_version must be >= 1.34."
+    condition     = tonumber(split(".", var.eks_cluster_version)[0]) > 1 || (tonumber(split(".", var.eks_cluster_version)[0]) == 1 && tonumber(split(".", var.eks_cluster_version)[1]) >= 36)
+    error_message = "eks_cluster_version must be >= 1.36."
   }
 }
 


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
Update version requirement for cluster_version to >= 1.36 so that we notch all clusters towards what we run in production.

We will no longer do any testing on cluster versions lower than 1.36, so we should update our requirement for cluster version too.

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
