### PR TITLE
Apparently this can happen to fast that emitted reconciliation timestamp and reconciliation success is equal

### DIFF
--- a/test/integration/suite/util_k8s_test.go
+++ b/test/integration/suite/util_k8s_test.go
@@ -212,6 +212,7 @@ func AssertK8sEvent(t *testing.T, clientset *kubernetes.Clientset, namespace,
 				if event.DeprecatedLastTimestamp.Time.Before(emittedAfter) {
 					// Checking for equal timestamps because the resolution differs.
 					if event.DeprecatedLastTimestamp.Time.Equal(emittedAfter) {
+						t.Logf("Event timestamp at %s and reconciliation triggered timestamp at %s, was equal", event.DeprecatedLastTimestamp.Time, emittedAfter)
 						return true
 					}
 					continue

--- a/test/integration/suite/util_k8s_test.go
+++ b/test/integration/suite/util_k8s_test.go
@@ -209,6 +209,7 @@ func AssertK8sEvent(t *testing.T, clientset *kubernetes.Clientset, namespace,
 				}
 				// Consecutive similar events could be combined into one event so one must
 				// check the last observed time.
+				// Checking for equal timestamps because the resolution can differ.
 				if !event.DeprecatedLastTimestamp.Time.Equal(emittedAfter) || event.DeprecatedLastTimestamp.Time.Before(emittedAfter) {
 					continue
 				}

--- a/test/integration/suite/util_k8s_test.go
+++ b/test/integration/suite/util_k8s_test.go
@@ -209,7 +209,7 @@ func AssertK8sEvent(t *testing.T, clientset *kubernetes.Clientset, namespace,
 				}
 				// Consecutive similar events could be combined into one event so one must
 				// check the last observed time.
-				if event.DeprecatedLastTimestamp.Time.Before(emittedAfter) {
+				if !event.DeprecatedLastTimestamp.Time.Equal(emittedAfter) || event.DeprecatedLastTimestamp.Time.Before(emittedAfter) {
 					continue
 				}
 				return true

--- a/test/integration/suite/util_k8s_test.go
+++ b/test/integration/suite/util_k8s_test.go
@@ -209,8 +209,11 @@ func AssertK8sEvent(t *testing.T, clientset *kubernetes.Clientset, namespace,
 				}
 				// Consecutive similar events could be combined into one event so one must
 				// check the last observed time.
-				// Checking for equal timestamps because the resolution can differ.
-				if !event.DeprecatedLastTimestamp.Time.Equal(emittedAfter) || event.DeprecatedLastTimestamp.Time.Before(emittedAfter) {
+				if event.DeprecatedLastTimestamp.Time.Before(emittedAfter) {
+					// Checking for equal timestamps because the resolution differs.
+					if event.DeprecatedLastTimestamp.Time.Equal(emittedAfter) {
+						return true
+					}
 					continue
 				}
 				return true


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
We seen flaky test in particular with TestTraefikDeployment and the underlying AssertFluxReconciliation where the resolution in timestamps are not high enough to show a difference when calling `Before()` function, so we need to check if `Equal()` too.

This nature of this bug was found by @Mik-Nord :1st_place_medal: 

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
