### PR TITLE
Upgrade Flux to v2.9.4 in QA

### DIFF
--- a/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
+++ b/test/integration/eu-west-1/k8s-qa/services/terragrunt.hcl
@@ -68,7 +68,7 @@ inputs = {
   fluxcd_apps_repo_branch           = "main"
   fluxcd_bootstrap_repo_name        = "platform-manifests-qa"
   fluxcd_bootstrap_repo_branch      = "main"
-  fluxcd_version                    = "v2.7.5"
+  fluxcd_version                    = "v2.9.4"
 
   fluxcd_tenants = []
 


### PR DESCRIPTION
## Describe your changes

This pull request updates the version of FluxCD used in the QA Kubernetes environment configuration. The only change is an upgrade to a newer FluxCD release.

- Upgraded `fluxcd_version` from `v2.7.5` to `v2.9.4` in `terragrunt.hcl` to ensure the environment uses the latest features and fixes.

**Deprecations:**
"The Flux APIs image.toolkit.fluxcd.io/v1beta2 and notification.toolkit.fluxcd.io/v1beta2
have reached end-of-life and have been removed from the CRDs."

- I have checked that we don't use these. We don't use image.toolkit.fluxcd.io/ at all. We use notification.toolkit.fluxcd.io/v1beta3 for alerts and providers and notification.toolkit.fluxcd.io/v1 for receivers.

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [x] I have added the needed changes in the `test/integration` folder to apply my changes in QA. [Read the guide on adding environment variables in QA](https://wiki.dfds.cloud/en/ce-private/atlantis/adding-env-vars)
- [x] I have rebased the code to master (or merged in the latest from master)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
